### PR TITLE
fix: rpm release equal 0 in tag ref (#116)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,7 @@ AC_CONFIG_MACRO_DIRS([m4])
 
 
 AC_SUBST([PACKAGE_VERSION_SHORT], [`echo ${PACKAGE_VERSION%%-*}`])
-AC_SUBST([RPM_RELEASE], [`RELEASE=${PACKAGE_VERSION#*-} && echo ${RELEASE//-/^}`])
+AC_SUBST([RPM_RELEASE], [`[[[ ${PACKAGE_VERSION} == *-* ]]] && RELEASE=${PACKAGE_VERSION#*-} && echo ${RELEASE//-/^} || echo "0"`])
 AC_SUBST([LIBRARY_VERSION], [`VERSION=${PACKAGE_VERSION_SHORT%.*} && echo ${VERSION//./:}:0`])
 
 AC_SUBST([GENERIC_CFLAGS], ["-std=gnu99 -Wall -Wextra -Werror"])


### PR DESCRIPTION
This pull request resolves an issue where the RPM release number was incorrectly derived or left empty when the package version string did not contain a specific release identifier. The change ensures that the `RPM_RELEASE` variable is robustly set to "0" in such scenarios, which is crucial for consistent and correct RPM package generation.

### Highlights

* **RPM Release Calculation Fix**: The logic for determining the `RPM_RELEASE` variable in `configure.ac` has been updated to correctly handle cases where the `PACKAGE_VERSION` does not contain a release suffix.
* **Default RPM Release Value**: If the `PACKAGE_VERSION` string does not include a hyphen (indicating a release suffix), the `RPM_RELEASE` will now explicitly be set to "0", preventing potential issues with RPM package metadata.

(cherry picked from commit 08b33955df75995c572acf68df2aa6bcee27035e)