### PR TITLE
add: override to destructors

### DIFF
--- a/librawstorio/include/rawstorio/task.hpp
+++ b/librawstorio/include/rawstorio/task.hpp
@@ -64,7 +64,7 @@ class Task {
 class TaskScalar: public Task {
     public:
         TaskScalar(int fd): Task(fd) {}
-        virtual ~TaskScalar() {}
+        virtual ~TaskScalar() override = default;
 
         virtual void* buf() noexcept = 0;
         virtual size_t size() const noexcept = 0;
@@ -74,7 +74,7 @@ class TaskScalar: public Task {
 class TaskVector: public Task {
     public:
         TaskVector(int fd): Task(fd) {}
-        virtual ~TaskVector() {}
+        virtual ~TaskVector() override = default;
 
         virtual iovec* iov() noexcept = 0;
         virtual unsigned int niov() const noexcept = 0;
@@ -85,7 +85,7 @@ class TaskVector: public Task {
 class TaskScalarPositional: public TaskScalar {
     public:
         TaskScalarPositional(int fd): TaskScalar(fd) {}
-        virtual ~TaskScalarPositional() {}
+        virtual ~TaskScalarPositional() override = default;
 
         virtual off_t offset() const noexcept = 0;
 };
@@ -94,7 +94,7 @@ class TaskScalarPositional: public TaskScalar {
 class TaskVectorPositional: public TaskVector {
     public:
         TaskVectorPositional(int fd): TaskVector(fd) {}
-        virtual ~TaskVectorPositional() {}
+        virtual ~TaskVectorPositional() override = default;
 
         virtual off_t offset() const noexcept = 0;
 };

--- a/librawstorio/src/poll_event.hpp
+++ b/librawstorio/src/poll_event.hpp
@@ -76,7 +76,13 @@ class Event {
             _iov_at = _iov.data();
         }
 
-        virtual ~Event() {}
+        Event(const Event &) = delete;
+        Event(Event &&) = delete;
+
+        virtual ~Event() = default;
+
+        Event& operator=(const Event &) = delete;
+        Event& operator=(Event &&) = delete;
 
         inline void set_error(int error) noexcept {
             _error = error;

--- a/src/ost_session.cpp
+++ b/src/ost_session.cpp
@@ -248,8 +248,7 @@ class SessionOp {
 
         SessionOp(const SessionOp &) = delete;
         SessionOp(SessionOp &&) = delete;
-        virtual ~SessionOp() {
-        }
+        virtual ~SessionOp() = default;
 
         SessionOp& operator=(const SessionOp &) = delete;
         SessionOp& operator=(SessionOp &&) = delete;


### PR DESCRIPTION
This pull request refactors several C++ classes by explicitly adding the `override` specifier to their virtual destructors and utilizing `= default` for their implementations. This change improves code robustness and maintainability by allowing the compiler to verify correct overriding behavior and promoting clearer intent. Additionally, it addresses C++ best practices by explicitly defining special member functions for the `Event` class to manage its resource ownership correctly.

* **C++ Destructor Overrides**: Explicitly marked virtual destructors with `override = default` across various classes, enhancing code clarity and enabling compile-time checks for proper inheritance semantics.
* **Modern C++ Practices**: Adopted the `override` and `default` keywords, aligning the codebase with modern C++11 and later standards for virtual function declarations and default implementations.
* **Rule of Five Adherence**: For the `Event` class, copy constructors and assignment operators have been explicitly deleted, and move constructors and assignment operators have also been deleted, to ensure proper resource management and adherence to the Rule of Five.

(cherry picked from commit 47063fc4c41404882ed7dce890bba074c12e99ef)

Conflicts:
	librawstorio/include/rawstorio/task.hpp
	librawstorio/src/poll_event.hpp