### PR TITLE
add: license to public headers (#129)

### DIFF
--- a/include/rawstor.h
+++ b/include/rawstor.h
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2025, Vasily Stepanov (vasily.stepanov@gmail.com)
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
 #ifndef RAWSTOR_H
 #define RAWSTOR_H
 

--- a/include/rawstor/object.h
+++ b/include/rawstor/object.h
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2025, Vasily Stepanov (vasily.stepanov@gmail.com)
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
 #ifndef RAWSTOR_OBJECT_H
 #define RAWSTOR_OBJECT_H
 

--- a/include/rawstor/rawstor.h
+++ b/include/rawstor/rawstor.h
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2025, Vasily Stepanov (vasily.stepanov@gmail.com)
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
 #ifndef RAWSTOR_RAWSTOR_H
 #define RAWSTOR_RAWSTOR_H
 

--- a/include/rawstor/uuid.h
+++ b/include/rawstor/uuid.h
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2025, Vasily Stepanov (vasily.stepanov@gmail.com)
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
 #ifndef RAWSTOR_UUID_H
 #define RAWSTOR_UUID_H
 


### PR DESCRIPTION
This pull request aims to enhance legal clarity and open-source compliance by embedding license information directly into the public header files. It introduces an "LGPL-3.0-or-later" license identifier and copyright notice to ensure proper attribution and usage terms for the library's public interfaces.

### Highlights

* **License Addition**: A license header specifying "SPDX-License-Identifier: LGPL-3.0-or-later" has been added to all public header files.
* **Copyright Information**: The added license headers include copyright information for Vasily Stepanov, dated 2025.
* **License Inconsistency Noted**: A bot review comment highlighted a potential inconsistency between the license specified in the file headers (LGPL-3.0-or-later) and a 'COPYING' file (which might contain LGPL-3.0), suggesting alignment and providing a full LGPLv3 text.

(cherry picked from commit 295bcaf6e8b16c84d3e0783044cdeb4b717387e7)