### PR TITLE
fix: use at() method to find session by fd (#131)

### DIFF
--- a/librawstorio/src/poll_queue.cpp
+++ b/librawstorio/src/poll_queue.cpp
@@ -178,7 +178,7 @@ void Queue::wait(unsigned int timeout) {
         }
 
         for (const pollfd &fd: fds) {
-            std::shared_ptr<Session> &s = _sessions[fd.fd];
+            std::shared_ptr<Session> &s = _sessions.at(fd.fd);
             if (fd.revents & POLLHUP) {
                 s->process_read(_cqes, true);
                 s->process_write(_cqes, true);


### PR DESCRIPTION
This pull request enhances the robustness and correctness of session management by modifying how sessions are retrieved from a map. By switching from `operator[]` to `at()`, the code now explicitly handles cases where a session might not be found, which helps in identifying and preventing logic errors related to session lifecycle and ensures more predictable behavior.

### Highlights

* **Session Lookup Safety**: Replaced direct array-like access (`operator[]`) with the `at()` method for looking up sessions by file descriptor (`fd`) in the `_sessions` map. This change ensures that an exception is thrown if a session with the given file descriptor does not exist, preventing potential silent insertion of default-constructed sessions and making error conditions explicit.

(cherry picked from commit 6c263580e3a93e7630ab76c65f7741bb0417fb79)