### PR TITLE
fix: license SPDX identifier (#132)

### DIFF
--- a/include/rawstor.h
+++ b/include/rawstor.h
@@ -1,7 +1,7 @@
 /**
  * Copyright (C) 2025, Vasily Stepanov (vasily.stepanov@gmail.com)
  *
- * SPDX-License-Identifier: LGPL-3.0-or-later
+ * SPDX-License-Identifier: LGPL-3.0
  */
 
 #ifndef RAWSTOR_H

--- a/include/rawstor/object.h
+++ b/include/rawstor/object.h
@@ -1,7 +1,7 @@
 /**
  * Copyright (C) 2025, Vasily Stepanov (vasily.stepanov@gmail.com)
  *
- * SPDX-License-Identifier: LGPL-3.0-or-later
+ * SPDX-License-Identifier: LGPL-3.0
  */
 
 #ifndef RAWSTOR_OBJECT_H

--- a/include/rawstor/rawstor.h
+++ b/include/rawstor/rawstor.h
@@ -1,7 +1,7 @@
 /**
  * Copyright (C) 2025, Vasily Stepanov (vasily.stepanov@gmail.com)
  *
- * SPDX-License-Identifier: LGPL-3.0-or-later
+ * SPDX-License-Identifier: LGPL-3.0
  */
 
 #ifndef RAWSTOR_RAWSTOR_H

--- a/include/rawstor/uuid.h
+++ b/include/rawstor/uuid.h
@@ -1,7 +1,7 @@
 /**
  * Copyright (C) 2025, Vasily Stepanov (vasily.stepanov@gmail.com)
  *
- * SPDX-License-Identifier: LGPL-3.0-or-later
+ * SPDX-License-Identifier: LGPL-3.0
  */
 
 #ifndef RAWSTOR_UUID_H


### PR DESCRIPTION
This pull request addresses a minor but important correction to the project's licensing information. It standardizes the SPDX license identifier across multiple core header files, ensuring that the project explicitly uses the LGPL-3.0 license without the 'or-later' clause. This change improves clarity and accuracy regarding the software's distribution terms.

### Highlights

* **License Identifier Update**: The SPDX license identifier has been updated in several header files from "LGPL-3.0-or-later" to "LGPL-3.0".

(cherry picked from commit 760f1e35a72ffefc0506384ac9526286755e4600)