### PR TITLE
add: iov routines (#138)

### DIFF
--- a/librawstorio/src/poll_event.cpp
+++ b/librawstorio/src/poll_event.cpp
@@ -47,7 +47,7 @@ size_t Event::shift(size_t shift) {
         _result += _size;
         _niov_at = 0;
     } else {
-        ret = rawstor_iovec_shift(&_iov_at, &_niov_at, shift);
+        ret = shift - rawstor_iovec_discard_front(&_iov_at, &_niov_at, shift);
         _result += shift;
     }
     return ret;

--- a/librawstorstd/include/rawstorstd/iovec.h
+++ b/librawstorstd/include/rawstorstd/iovec.h
@@ -11,8 +11,15 @@ extern "C" {
 #endif
 
 
-size_t rawstor_iovec_shift(
-    struct iovec **iov, unsigned int *niov, size_t shift);
+size_t rawstor_iovec_discard_front(
+    struct iovec **iov, unsigned int *niov, size_t size);
+
+size_t rawstor_iovec_discard_back(
+    struct iovec **iov, unsigned int *niov, size_t size);
+
+size_t rawstor_iovec_to_buf(
+    struct iovec *iov, unsigned int niov, size_t offset,
+    void *buf, size_t size);
 
 
 #ifdef __cplusplus

--- a/librawstorstd/src/iovec.c
+++ b/librawstorstd/src/iovec.c
@@ -3,21 +3,69 @@
 #include <sys/uio.h>
 
 #include <stddef.h>
+#include <string.h>
 
 
-size_t rawstor_iovec_shift(struct iovec **iov, unsigned int *niov, size_t shift) {
-    while (*niov > 0 && shift >= (*iov)[0].iov_len) {
-        shift -= (*iov)[0].iov_len;
+size_t rawstor_iovec_discard_front(
+    struct iovec **iov, unsigned int *niov, size_t size)
+{
+    size_t total = 0;
+
+    while (*niov > 0 && size >= (*iov)[0].iov_len) {
+        size -= (*iov)[0].iov_len;
+        total += (*iov)[0].iov_len;
         --(*niov);
         ++(*iov);
     }
 
-    if (*niov == 0) {
-        return shift;
+    if (*niov != 0) {
+        (*iov)[0].iov_base += size;
+        (*iov)[0].iov_len -= size;
+        total += size;
     }
 
-    (*iov)[0].iov_base += shift;
-    (*iov)[0].iov_len -= shift;
+    return total;
+}
 
-    return 0;
+
+size_t rawstor_iovec_discard_back(
+    struct iovec **iov, unsigned int *niov, size_t size)
+{
+    size_t total = 0;
+
+    while (*niov > 0 && size >= (*iov)[*niov - 1].iov_len) {
+        size -= (*iov)[*niov - 1].iov_len;
+        total += (*iov)[*niov - 1].iov_len;
+        --(*niov);
+    }
+
+    if (*niov != 0) {
+        (*iov)[*niov - 1].iov_len -= size;
+        total += size;
+    }
+
+    return total;
+}
+
+
+size_t rawstor_iovec_to_buf(
+    struct iovec *iov, unsigned int niov, size_t offset,
+    void *buf, size_t size)
+{
+    size_t total = 0;
+
+    for (unsigned int i = 0; (offset || size) && i < niov; i++) {
+        if (offset < iov[i].iov_len) {
+            size_t len = iov[i].iov_len - offset < size ?
+                iov[i].iov_len - offset : size;
+            memcpy(buf + total, iov[i].iov_base + offset, len);
+            size -= len;
+            total += len;
+            offset = 0;
+        } else {
+            offset -= iov[i].iov_len;
+        }
+    }
+
+    return total;
 }

--- a/librawstorstd/tests/test_iovec.c
+++ b/librawstorstd/tests/test_iovec.c
@@ -8,7 +8,7 @@
 #include <string.h>
 
 
-static int test_shift_unalligned() {
+static int test_discard_front_unalligned() {
     char data[] = "1234567890";
     struct iovec v[3];
     v[0] = (struct iovec) {
@@ -27,16 +27,17 @@ static int test_shift_unalligned() {
     struct iovec *iov_at = v;
     unsigned int niov_at = 3;
 
-    size_t shift = rawstor_iovec_shift(&iov_at, &niov_at, 12);
+    size_t size = rawstor_iovec_discard_front(&iov_at, &niov_at, 12);
 
     assertTrue(niov_at == 2);
-    assertTrue(strcmp(iov_at[0].iov_base, "34567890") == 0);
-    assertTrue(shift == 0);
+    assertTrue(strncmp(iov_at[0].iov_base, "34567890", 8) == 0);
+    assertTrue(iov_at[0].iov_len == 8);
+    assertTrue(size == 12);
     return 0;
 }
 
 
-static int test_shift_alligned() {
+static int test_discard_front_alligned() {
     char data[] = "1234567890";
     struct iovec v[3];
     v[0] = (struct iovec) {
@@ -55,16 +56,17 @@ static int test_shift_alligned() {
     struct iovec *iov_at = v;
     unsigned int niov_at = 3;
 
-    size_t shift = rawstor_iovec_shift(&iov_at, &niov_at, 10);
+    size_t size = rawstor_iovec_discard_front(&iov_at, &niov_at, 10);
 
     assertTrue(niov_at == 2);
-    assertTrue(strcmp(iov_at[0].iov_base, "1234567890") == 0);
-    assertTrue(shift == 0);
+    assertTrue(strncmp(iov_at[0].iov_base, "1234567890", 10) == 0);
+    assertTrue(iov_at[0].iov_len == 10);
+    assertTrue(size == 10);
     return 0;
 }
 
 
-static int test_shift_all() {
+static int test_discard_front_all() {
     char data[] = "1234567890";
     struct iovec v[3];
     v[0] = (struct iovec) {
@@ -83,15 +85,15 @@ static int test_shift_all() {
     struct iovec *iov_at = v;
     unsigned int niov_at = 3;
 
-    size_t shift = rawstor_iovec_shift(&iov_at, &niov_at, 30);
+    size_t size = rawstor_iovec_discard_front(&iov_at, &niov_at, 30);
 
     assertTrue(niov_at == 0);
-    assertTrue(shift == 0);
+    assertTrue(size == 30);
     return 0;
 }
 
 
-static int test_shift_overflow() {
+static int test_discard_front_overflow() {
     char data[] = "1234567890";
     struct iovec v[3];
     v[0] = (struct iovec) {
@@ -110,19 +112,262 @@ static int test_shift_overflow() {
     struct iovec *iov_at = v;
     unsigned int niov_at = 3;
 
-    size_t shift = rawstor_iovec_shift(&iov_at, &niov_at, 35);
+    size_t size = rawstor_iovec_discard_front(&iov_at, &niov_at, 35);
 
     assertTrue(niov_at == 0);
-    assertTrue(shift == 5);
+    assertTrue(size == 30);
+    return 0;
+}
+
+
+static int test_discard_back_unalligned() {
+    char data[] = "1234567890";
+    struct iovec v[3];
+    v[0] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+    v[1] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+    v[2] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+
+    struct iovec *iov_at = v;
+    unsigned int niov_at = 3;
+
+    size_t size = rawstor_iovec_discard_back(&iov_at, &niov_at, 12);
+
+    assertTrue(niov_at == 2);
+    assertTrue(strncmp(iov_at[1].iov_base, "12345678", 8) == 0);
+    assertTrue(iov_at[1].iov_len == 8);
+    assertTrue(size == 12);
+    return 0;
+}
+
+
+static int test_discard_back_alligned() {
+    char data[] = "1234567890";
+    struct iovec v[3];
+    v[0] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+    v[1] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+    v[2] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+
+    struct iovec *iov_at = v;
+    unsigned int niov_at = 3;
+
+    size_t size = rawstor_iovec_discard_back(&iov_at, &niov_at, 10);
+
+    assertTrue(niov_at == 2);
+    assertTrue(strncmp(iov_at[1].iov_base, "1234567890", 10) == 0);
+    assertTrue(iov_at[1].iov_len == 10);
+    assertTrue(size == 10);
+    return 0;
+}
+
+
+static int test_discard_back_all() {
+    char data[] = "1234567890";
+    struct iovec v[3];
+    v[0] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+    v[1] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+    v[2] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+
+    struct iovec *iov_at = v;
+    unsigned int niov_at = 3;
+
+    size_t size = rawstor_iovec_discard_back(&iov_at, &niov_at, 30);
+
+    assertTrue(niov_at == 0);
+    assertTrue(size == 30);
+    return 0;
+}
+
+
+static int test_discard_back_overflow() {
+    char data[] = "1234567890";
+    struct iovec v[3];
+    v[0] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+    v[1] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+    v[2] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+
+    struct iovec *iov_at = v;
+    unsigned int niov_at = 3;
+
+    size_t size = rawstor_iovec_discard_back(&iov_at, &niov_at, 35);
+
+    assertTrue(niov_at == 0);
+    assertTrue(size == 30);
+    return 0;
+}
+
+
+static int test_to_buf_unalligned() {
+    char data[] = "1234567890";
+    struct iovec v[3];
+    v[0] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+    v[1] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+    v[2] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+
+    char buf[12];
+    size_t size = rawstor_iovec_to_buf(v, 3, 0, buf, sizeof(buf));
+
+    assertTrue(size == 12);
+    assertTrue(strncmp(buf, "123456789012", size) == 0);
+
+    size = rawstor_iovec_to_buf(v, 3, 3, buf, sizeof(buf));
+
+    assertTrue(size == 12);
+    assertTrue(strncmp(buf, "456789012345", size) == 0);
+    return 0;
+}
+
+
+static int test_to_buf_alligned() {
+    char data[] = "1234567890";
+    struct iovec v[3];
+    v[0] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+    v[1] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+    v[2] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+
+    char buf[10];
+    size_t size = rawstor_iovec_to_buf(v, 3, 0, buf, sizeof(buf));
+
+    assertTrue(size == 10);
+    assertTrue(strncmp(buf, "1234567890", size) == 0);
+
+    size = rawstor_iovec_to_buf(v, 3, 10, buf, sizeof(buf));
+
+    assertTrue(size == 10);
+    assertTrue(strncmp(buf, "1234567890", size) == 0);
+
+    return 0;
+}
+
+
+static int test_to_buf_all() {
+    char data[] = "1234567890";
+    struct iovec v[3];
+    v[0] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+    v[1] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+    v[2] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+
+    char buf[30];
+    size_t size = rawstor_iovec_to_buf(v, 3, 0, buf, sizeof(buf));
+
+    assertTrue(size == 30);
+    assertTrue(strncmp(buf, "123456789012345678901234567890", size) == 0);
+
+    size = rawstor_iovec_to_buf(v, 3, 3, buf, sizeof(buf) - 3);
+
+    assertTrue(size == 27);
+    assertTrue(strncmp(buf, "456789012345678901234567890", size) == 0);
+
+    return 0;
+}
+
+
+static int test_to_buf_overflow() {
+    char data[] = "1234567890";
+    struct iovec v[3];
+    v[0] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+    v[1] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+    v[2] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+
+    char buf[35];
+    size_t size = rawstor_iovec_to_buf(v, 3, 0, buf, sizeof(buf));
+
+    assertTrue(size == 30);
+    assertTrue(strncmp(buf, "123456789012345678901234567890", size) == 0);
+
+    size = rawstor_iovec_to_buf(v, 3, 3, buf, sizeof(buf));
+
+    assertTrue(size == 27);
+    assertTrue(strncmp(buf, "456789012345678901234567890", size) == 0);
+
     return 0;
 }
 
 
 int main() {
     int rval = 0;
-    rval += test_shift_unalligned();
-    rval += test_shift_alligned();
-    rval += test_shift_all();
-    rval += test_shift_overflow();
+    rval += test_discard_front_unalligned();
+    rval += test_discard_front_alligned();
+    rval += test_discard_front_all();
+    rval += test_discard_front_overflow();
+    rval += test_discard_back_unalligned();
+    rval += test_discard_back_alligned();
+    rval += test_discard_back_all();
+    rval += test_discard_back_overflow();
+    rval += test_to_buf_unalligned();
+    rval += test_to_buf_alligned();
+    rval += test_to_buf_all();
+    rval += test_to_buf_overflow();
     return rval ? EXIT_FAILURE : EXIT_SUCCESS;
 }


### PR DESCRIPTION
This pull request enhances the `iovec` utility routines by renaming an existing function for better semantic clarity and introducing new functionalities. The changes provide more flexible ways to manage data within `iovec` structures, specifically allowing for discarding data from both the front and back, and efficiently copying data to a flat buffer. These additions improve the library's capabilities for buffer manipulation, supported by thorough testing.

* **Function Renaming**: The `rawstor_iovec_shift` function has been renamed to `rawstor_iovec_discard_front` for improved clarity regarding its purpose of discarding data from the front of an iovec.
* **New `iovec` Utility Functions**: Two new utility functions, `rawstor_iovec_discard_back` and `rawstor_iovec_to_buf`, have been added to provide more comprehensive `iovec` manipulation capabilities. `discard_back` allows removing data from the end of an iovec, and `to_buf` facilitates copying data from an iovec into a contiguous buffer.
* **Updated `poll_event` Module**: The `librawstorio/src/poll_event.cpp` file has been updated to reflect the function rename, now utilizing `rawstor_iovec_discard_front`.
* **Comprehensive Unit Tests**: The `librawstorstd/tests/test_iovec.c` file has been significantly expanded to include new test cases for the `rawstor_iovec_discard_back` and `rawstor_iovec_to_buf` functions, ensuring their correctness and robustness across various scenarios, including unaligned, aligned, full, and overflow conditions.

(cherry picked from commit e93bf76cfb2ed077dd2dfdd4e7392357321f81dd)

Conflicts:
	librawstorio/src/poll_event.cpp