### PR TITLE
add: iovec size and from_buf routines (#140)

### DIFF
--- a/librawstorstd/include/rawstorstd/iovec.h
+++ b/librawstorstd/include/rawstorstd/iovec.h
@@ -17,9 +17,15 @@ size_t rawstor_iovec_discard_front(
 size_t rawstor_iovec_discard_back(
     struct iovec **iov, unsigned int *niov, size_t size);
 
+size_t rawstor_iovec_from_buf(
+    struct iovec *iov, unsigned int niov, size_t offset,
+    const void *buf, size_t size);
+
 size_t rawstor_iovec_to_buf(
     struct iovec *iov, unsigned int niov, size_t offset,
     void *buf, size_t size);
+
+size_t rawstor_iovec_size(struct iovec *iov, unsigned int niov);
 
 
 #ifdef __cplusplus

--- a/librawstorstd/src/iovec.c
+++ b/librawstorstd/src/iovec.c
@@ -48,6 +48,29 @@ size_t rawstor_iovec_discard_back(
 }
 
 
+size_t rawstor_iovec_from_buf(
+    struct iovec *iov, unsigned int niov, size_t offset,
+    const void *buf, size_t size)
+{
+    size_t total = 0;
+
+    for (unsigned int i = 0; (offset || size) && i < niov; i++) {
+        if (offset < iov[i].iov_len) {
+            size_t len = iov[i].iov_len - offset < size ?
+                iov[i].iov_len - offset : size;
+            memcpy(iov[i].iov_base + offset, buf + total, len);
+            size -= len;
+            total += len;
+            offset = 0;
+        } else {
+            offset -= iov[i].iov_len;
+        }
+    }
+
+    return total;
+}
+
+
 size_t rawstor_iovec_to_buf(
     struct iovec *iov, unsigned int niov, size_t offset,
     void *buf, size_t size)
@@ -68,4 +91,15 @@ size_t rawstor_iovec_to_buf(
     }
 
     return total;
+}
+
+
+size_t rawstor_iovec_size(struct iovec *iov, unsigned int niov) {
+    size_t ret = 0;
+
+    for (unsigned int i = 0; i < niov; i++) {
+        ret += iov[i].iov_len;
+    }
+
+    return ret;
 }

--- a/librawstorstd/tests/test_iovec.c
+++ b/librawstorstd/tests/test_iovec.c
@@ -8,7 +8,7 @@
 #include <string.h>
 
 
-static int test_discard_front_unalligned() {
+static int test_discard_front_unaligned() {
     char data[] = "1234567890";
     struct iovec v[3];
     v[0] = (struct iovec) {
@@ -37,7 +37,7 @@ static int test_discard_front_unalligned() {
 }
 
 
-static int test_discard_front_alligned() {
+static int test_discard_front_aligned() {
     char data[] = "1234567890";
     struct iovec v[3];
     v[0] = (struct iovec) {
@@ -120,7 +120,7 @@ static int test_discard_front_overflow() {
 }
 
 
-static int test_discard_back_unalligned() {
+static int test_discard_back_unaligned() {
     char data[] = "1234567890";
     struct iovec v[3];
     v[0] = (struct iovec) {
@@ -149,7 +149,7 @@ static int test_discard_back_unalligned() {
 }
 
 
-static int test_discard_back_alligned() {
+static int test_discard_back_aligned() {
     char data[] = "1234567890";
     struct iovec v[3];
     v[0] = (struct iovec) {
@@ -232,7 +232,127 @@ static int test_discard_back_overflow() {
 }
 
 
-static int test_to_buf_unalligned() {
+static int test_from_buf_unaligned() {
+    struct iovec v[3];
+    char data0[] = "          ";
+    v[0] = (struct iovec) {
+        .iov_base = data0,
+        .iov_len = sizeof(data0) - 1,
+    };
+    char data1[] = "          ";
+    v[1] = (struct iovec) {
+        .iov_base = data1,
+        .iov_len = sizeof(data1) - 1,
+    };
+    char data2[] = "          ";
+    v[2] = (struct iovec) {
+        .iov_base = data2,
+        .iov_len = sizeof(data2) - 1,
+    };
+
+    char buf[] = "123456789012";
+    size_t size = rawstor_iovec_from_buf(v, 3, 0, buf, sizeof(buf) - 1);
+
+    assertTrue(size == 12);
+    assertTrue(strncmp(v[0].iov_base, "1234567890", v[0].iov_len) == 0);
+    assertTrue(strncmp(v[1].iov_base, "12        ", v[1].iov_len) == 0);
+    assertTrue(strncmp(v[2].iov_base, "          ", v[2].iov_len) == 0);
+
+    return 0;
+}
+
+
+static int test_from_buf_aligned() {
+    struct iovec v[3];
+    char data0[] = "          ";
+    v[0] = (struct iovec) {
+        .iov_base = data0,
+        .iov_len = sizeof(data0) - 1,
+    };
+    char data1[] = "          ";
+    v[1] = (struct iovec) {
+        .iov_base = data1,
+        .iov_len = sizeof(data1) - 1,
+    };
+    char data2[] = "          ";
+    v[2] = (struct iovec) {
+        .iov_base = data2,
+        .iov_len = sizeof(data2) - 1,
+    };
+
+    char buf[] = "1234567890";
+    size_t size = rawstor_iovec_from_buf(v, 3, 0, buf, sizeof(buf) - 1);
+
+    assertTrue(size == 10);
+    assertTrue(strncmp(v[0].iov_base, "1234567890", v[0].iov_len) == 0);
+    assertTrue(strncmp(v[1].iov_base, "          ", v[1].iov_len) == 0);
+    assertTrue(strncmp(v[2].iov_base, "          ", v[2].iov_len) == 0);
+
+    return 0;
+}
+
+
+static int test_from_buf_all() {
+    struct iovec v[3];
+    char data0[] = "          ";
+    v[0] = (struct iovec) {
+        .iov_base = data0,
+        .iov_len = sizeof(data0) - 1,
+    };
+    char data1[] = "          ";
+    v[1] = (struct iovec) {
+        .iov_base = data1,
+        .iov_len = sizeof(data1) - 1,
+    };
+    char data2[] = "          ";
+    v[2] = (struct iovec) {
+        .iov_base = data2,
+        .iov_len = sizeof(data2) - 1,
+    };
+
+    char buf[] = "123456789012345678901234567890";
+    size_t size = rawstor_iovec_from_buf(v, 3, 0, buf, sizeof(buf) - 1);
+
+    assertTrue(size == 30);
+    assertTrue(strncmp(v[0].iov_base, "1234567890", v[0].iov_len) == 0);
+    assertTrue(strncmp(v[1].iov_base, "1234567890", v[1].iov_len) == 0);
+    assertTrue(strncmp(v[2].iov_base, "1234567890", v[2].iov_len) == 0);
+
+    return 0;
+}
+
+
+static int test_from_buf_overflow() {
+    struct iovec v[3];
+    char data0[] = "          ";
+    v[0] = (struct iovec) {
+        .iov_base = data0,
+        .iov_len = sizeof(data0) - 1,
+    };
+    char data1[] = "          ";
+    v[1] = (struct iovec) {
+        .iov_base = data1,
+        .iov_len = sizeof(data1) - 1,
+    };
+    char data2[] = "          ";
+    v[2] = (struct iovec) {
+        .iov_base = data2,
+        .iov_len = sizeof(data2) - 1,
+    };
+
+    char buf[] = "12345678901234567890123456789012345";
+    size_t size = rawstor_iovec_from_buf(v, 3, 0, buf, sizeof(buf) - 1);
+
+    assertTrue(size == 30);
+    assertTrue(strncmp(v[0].iov_base, "1234567890", v[0].iov_len) == 0);
+    assertTrue(strncmp(v[1].iov_base, "1234567890", v[1].iov_len) == 0);
+    assertTrue(strncmp(v[2].iov_base, "1234567890", v[2].iov_len) == 0);
+
+    return 0;
+}
+
+
+static int test_to_buf_unaligned() {
     char data[] = "1234567890";
     struct iovec v[3];
     v[0] = (struct iovec) {
@@ -262,7 +382,7 @@ static int test_to_buf_unalligned() {
 }
 
 
-static int test_to_buf_alligned() {
+static int test_to_buf_aligned() {
     char data[] = "1234567890";
     struct iovec v[3];
     v[0] = (struct iovec) {
@@ -355,19 +475,46 @@ static int test_to_buf_overflow() {
 }
 
 
+static int test_size() {
+    char data[] = "1234567890";
+    struct iovec v[3];
+    v[0] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+    v[1] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+    v[2] = (struct iovec) {
+        .iov_base = data,
+        .iov_len = sizeof(data) - 1,
+    };
+
+    assertTrue(rawstor_iovec_size(v, 3) == 30);
+
+    return 0;
+}
+
+
 int main() {
     int rval = 0;
-    rval += test_discard_front_unalligned();
-    rval += test_discard_front_alligned();
+    rval += test_discard_front_unaligned();
+    rval += test_discard_front_aligned();
     rval += test_discard_front_all();
     rval += test_discard_front_overflow();
-    rval += test_discard_back_unalligned();
-    rval += test_discard_back_alligned();
+    rval += test_discard_back_unaligned();
+    rval += test_discard_back_aligned();
     rval += test_discard_back_all();
     rval += test_discard_back_overflow();
-    rval += test_to_buf_unalligned();
-    rval += test_to_buf_alligned();
+    rval += test_from_buf_unaligned();
+    rval += test_from_buf_aligned();
+    rval += test_from_buf_all();
+    rval += test_from_buf_overflow();
+    rval += test_to_buf_unaligned();
+    rval += test_to_buf_aligned();
     rval += test_to_buf_all();
     rval += test_to_buf_overflow();
+    rval += test_size();
     return rval ? EXIT_FAILURE : EXIT_SUCCESS;
 }


### PR DESCRIPTION
This pull request significantly extends the `iovec` utility library by introducing two new functions: `rawstor_iovec_from_buf` and `rawstor_iovec_size`. The `from_buf` function enables efficient data transfer from a flat buffer into a scattered `iovec` array, while `iovec_size` provides a straightforward way to determine the total data length across an `iovec` array. These additions improve the flexibility and robustness of `iovec` handling within the `rawstorstd` library, supported by new and corrected unit tests.

### Highlights

* **New `iovec` Utility Functions**: Two new functions, `rawstor_iovec_from_buf` and `rawstor_iovec_size`, have been introduced to enhance `iovec` manipulation capabilities within the library.
* **`rawstor_iovec_from_buf` Implementation**: This new routine allows copying data from a contiguous buffer into a scatter/gather `iovec` array, correctly handling offsets and lengths across multiple `iovec` segments.
* **`rawstor_iovec_size` Implementation**: A new function has been added to provide a straightforward way to calculate the total byte size represented by an array of `iovec` structures.
* **Test Suite Enhancements**: Comprehensive unit tests have been added for both new functions, covering various scenarios (unaligned, aligned, full, and overflow). Additionally, several spelling errors in existing test function names (e.g., `unalligned` to `unaligned`) have been corrected.

(cherry picked from commit ec05f4d68a693e89b6b04465908179774d4bf0d1)