### PR TITLE
fix: timeout calculation (#142)

### DIFF
--- a/librawstorio/src/uring_queue.cpp
+++ b/librawstorio/src/uring_queue.cpp
@@ -167,8 +167,8 @@ void Queue::wait(unsigned int timeout) {
     int res;
     io_uring_cqe *cqe;
     __kernel_timespec ts = {
-        .tv_sec = 0,
-        .tv_nsec = 1000000u * timeout
+        .tv_sec = timeout / 1000,
+        .tv_nsec = 1000000u * (timeout % 1000)
     };
 
     if (io_uring_sq_ready(&_ring) > 0) {


### PR DESCRIPTION
This pull request resolves an issue where timeouts for `io_uring` operations were being incorrectly calculated and represented. The change ensures that the provided timeout value is accurately split into seconds and nanoseconds, which is crucial for the precise timing of asynchronous I/O operations and overall system reliability.

### Highlights

* **Timeout Calculation Fix**: Corrected the calculation of `tv_sec` and `tv_nsec` within the `__kernel_timespec` structure in `Queue::wait` to properly handle timeouts that span multiple seconds, ensuring accurate time representation for `io_uring` operations.

(cherry picked from commit d745f2f99a5a1e32feec4a372407985d50d5a577)