### PR TITLE
add: clang-format tool (#152)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,11 @@
+---
+BasedOnStyle: LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: BlockIndent
+AllowShortFunctionsOnASingleLine: InlineOnly
+BreakConstructorInitializers: AfterColon
+BreakTemplateDeclarations: Yes
+IndentWidth: 4
+PackConstructorInitializers: CurrentLine
+PointerAlignment: Left
+...

--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,2 @@
+**/3rdparty/**
+./librawstorstd/include/rawstorstd/logging_config.h

--- a/.github/tools/clang-format.sh
+++ b/.github/tools/clang-format.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -f
+
+
+CLANG_FORMAT="clang-format-21"
+if ! command -v ${CLANG_FORMAT} >/dev/null 2>&1
+then
+    echo "${CLANG_FORMAT} could not be found, falling back to clang-format"
+    CLANG_FORMAT="clang-format"
+fi
+
+
+function find_cmd() {
+    IFS=','
+    local paths="$1"
+    local cmd=""
+
+    cmd+="find . -type f "
+
+    cmd+="\( "
+    local is_first=1
+    for path in $paths; do
+        if [ $is_first -ne 1 ]; then
+            cmd+="-o "
+        fi
+        cmd+="-path \"${path}\" "
+        is_first=0
+    done
+    cmd+=" \)"
+
+    echo "${cmd}"
+
+    unset IFS
+}
+
+
+function check_file() {
+    local file="$1"
+    message="$(${CLANG_FORMAT} -n -Werror --ferror-limit=3 --style=file --fallback-style=LLVM "${file}")"
+    local status="$?"
+    if [ $status -ne 0 ]; then
+        echo "$message" >&2
+        return 1
+    fi
+    return 0
+}
+
+
+function main() {
+    local input_pattern=$1
+    echo -e "Sources: $input_pattern"
+    local cmd="$(find_cmd "${input_pattern}")"
+    local -a issues=()
+
+    for file in $(eval $cmd); do
+        echo -e "Checking file: $file"
+        check_file "$file"
+        if [ $? -ne 0 ]; then
+            issues+=("$file")
+        fi
+    done
+
+    if [ ${#issues[@]} -eq 0 ]; then
+        echo -e "Success!!! The sources are clang formatted."
+        exit 0
+    else
+        echo -e "Some file is not formatted correctly."
+        echo -e "You might want to run: "
+        for ((i = 0; i < ${#issues[@]}; i++)); do
+            if [ $i -ne 0 ]; then
+                echo " \\"
+                echo -n " && "
+            fi
+            echo -n "${CLANG_FORMAT} --style=file -i "${issues[$i]}""
+        done
+        echo
+        exit 1
+    fi
+}
+
+
+main "${1:-*.c,*.h,*.cpp,*.hpp}"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,19 @@
+name: linter
+
+on:
+  push:
+
+jobs:
+  clang-format:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: add llvm 21
+      run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh 21 all
+    - name: clang-format
+      run: ./.github/tools/clang-format.sh

--- a/cli/create.c
+++ b/cli/create.c
@@ -6,8 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-
-int rawstor_cli_create(const char *uris, size_t size){
+int rawstor_cli_create(const char* uris, size_t size) {
     struct RawstorObjectSpec spec = {
         .size = size << 30,
     };
@@ -16,12 +15,10 @@ int rawstor_cli_create(const char *uris, size_t size){
     fprintf(stderr, "  size: %zu Gb\n", size);
 
     char object_uris[65536];
-    int res = rawstor_object_create(
-        uris, &spec, object_uris, sizeof(object_uris));
+    int res =
+        rawstor_object_create(uris, &spec, object_uris, sizeof(object_uris));
     if (res < 0) {
-        fprintf(
-            stderr,
-            "rawstor_object_create() failed: %s\n", strerror(-res));
+        fprintf(stderr, "rawstor_object_create() failed: %s\n", strerror(-res));
         return EXIT_FAILURE;
     }
 

--- a/cli/create.h
+++ b/cli/create.h
@@ -5,18 +5,14 @@
 
 #include <stddef.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
-int rawstor_cli_create(const char *uris, size_t size);
-
+int rawstor_cli_create(const char* uris, size_t size);
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // RAWSTOR_CLI_CREATE_H

--- a/cli/main.c
+++ b/cli/main.c
@@ -12,7 +12,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-
 static void usage(void) {
     fprintf(
         stdout,
@@ -36,14 +35,9 @@ static void usage(void) {
     );
 };
 
-
 static void version(void) {
-    fprintf(
-        stdout,
-        "Rawstor CLI " PACKAGE_VERSION "\n"
-    );
+    fprintf(stdout, "Rawstor CLI " PACKAGE_VERSION "\n");
 }
-
 
 static void command_create_usage(void) {
     fprintf(
@@ -59,9 +53,8 @@ static void command_create_usage(void) {
     );
 };
 
-
-static int command_create(int argc, char **argv) {
-    const char *optstring = "hs:u:";
+static int command_create(int argc, char** argv) {
+    const char* optstring = "hs:u:";
     struct option longopts[] = {
         {"help", no_argument, NULL, 'h'},
         {"size", required_argument, NULL, 's'},
@@ -69,8 +62,8 @@ static int command_create(int argc, char **argv) {
         {},
     };
 
-    char *size_arg = NULL;
-    char *uri_arg = NULL;
+    char* size_arg = NULL;
+    char* uri_arg = NULL;
     optind = 1;
     while (1) {
         int c = getopt_long(argc, argv, optstring, longopts, NULL);
@@ -79,21 +72,21 @@ static int command_create(int argc, char **argv) {
         }
 
         switch (c) {
-            case 'h':
-                command_create_usage();
-                return EXIT_SUCCESS;
-                break;
+        case 'h':
+            command_create_usage();
+            return EXIT_SUCCESS;
+            break;
 
-            case 's':
-                size_arg = optarg;
-                break;
+        case 's':
+            size_arg = optarg;
+            break;
 
-            case 'u':
-                uri_arg = optarg;
-                break;
+        case 'u':
+            uri_arg = optarg;
+            break;
 
-            default:
-                return EXIT_FAILURE;
+        default:
+            return EXIT_FAILURE;
         }
     }
 
@@ -121,7 +114,6 @@ static int command_create(int argc, char **argv) {
     return rawstor_cli_create(uri_arg, size);
 }
 
-
 static void command_remove_usage(void) {
     fprintf(
         stdout,
@@ -135,16 +127,15 @@ static void command_remove_usage(void) {
     );
 };
 
-
-static int command_remove(int argc, char **argv) {
-    const char *optstring = "ho:";
+static int command_remove(int argc, char** argv) {
+    const char* optstring = "ho:";
     struct option longopts[] = {
         {"help", no_argument, NULL, 'h'},
         {"object-uri", required_argument, NULL, 'o'},
         {},
     };
 
-    char *object_uri_arg = NULL;
+    char* object_uri_arg = NULL;
     optind = 1;
     while (1) {
         int c = getopt_long(argc, argv, optstring, longopts, NULL);
@@ -153,17 +144,17 @@ static int command_remove(int argc, char **argv) {
         }
 
         switch (c) {
-            case 'h':
-                command_remove_usage();
-                return EXIT_SUCCESS;
-                break;
+        case 'h':
+            command_remove_usage();
+            return EXIT_SUCCESS;
+            break;
 
-            case 'o':
-                object_uri_arg = optarg;
-                break;
+        case 'o':
+            object_uri_arg = optarg;
+            break;
 
-            default:
-                return EXIT_FAILURE;
+        default:
+            return EXIT_FAILURE;
         }
     }
 
@@ -180,7 +171,6 @@ static int command_remove(int argc, char **argv) {
     return rawstor_cli_remove(object_uri_arg);
 }
 
-
 static void command_show_usage(void) {
     fprintf(
         stdout,
@@ -194,16 +184,15 @@ static void command_show_usage(void) {
     );
 };
 
-
-static int command_show(int argc, char **argv) {
-    const char *optstring = "ho:";
+static int command_show(int argc, char** argv) {
+    const char* optstring = "ho:";
     struct option longopts[] = {
         {"help", no_argument, NULL, 'h'},
         {"object-uri", required_argument, NULL, 'o'},
         {},
     };
 
-    char *object_uri_arg = NULL;
+    char* object_uri_arg = NULL;
     optind = 1;
     while (1) {
         int c = getopt_long(argc, argv, optstring, longopts, NULL);
@@ -212,17 +201,17 @@ static int command_show(int argc, char **argv) {
         }
 
         switch (c) {
-            case 'h':
-                command_show_usage();
-                return EXIT_SUCCESS;
-                break;
+        case 'h':
+            command_show_usage();
+            return EXIT_SUCCESS;
+            break;
 
-            case 'o':
-                object_uri_arg = optarg;
-                break;
+        case 'o':
+            object_uri_arg = optarg;
+            break;
 
-            default:
-                return EXIT_FAILURE;
+        default:
+            return EXIT_FAILURE;
         }
     }
 
@@ -238,7 +227,6 @@ static int command_show(int argc, char **argv) {
 
     return rawstor_cli_show(object_uri_arg);
 }
-
 
 static void command_testio_usage(void) {
     fprintf(
@@ -261,9 +249,8 @@ static void command_testio_usage(void) {
     );
 };
 
-
-static int command_testio(int argc, char **argv) {
-    const char *optstring = "b:c:d:ho:s:";
+static int command_testio(int argc, char** argv) {
+    const char* optstring = "b:c:d:ho:s:";
     struct option longopts[] = {
         {"block-size", required_argument, NULL, 'b'},
         {"count", required_argument, NULL, 'c'},
@@ -274,10 +261,10 @@ static int command_testio(int argc, char **argv) {
         {},
     };
 
-    char *block_size_arg = NULL;
-    char *count_arg = NULL;
-    char *io_depth_arg = NULL;
-    char *object_uri_arg = NULL;
+    char* block_size_arg = NULL;
+    char* count_arg = NULL;
+    char* io_depth_arg = NULL;
+    char* object_uri_arg = NULL;
     int vector_mode = 0;
     optind = 1;
     while (1) {
@@ -287,33 +274,33 @@ static int command_testio(int argc, char **argv) {
         }
 
         switch (c) {
-            case 'b':
-                block_size_arg = optarg;
-                break;
+        case 'b':
+            block_size_arg = optarg;
+            break;
 
-            case 'c':
-                count_arg = optarg;
-                break;
+        case 'c':
+            count_arg = optarg;
+            break;
 
-            case 'd':
-                io_depth_arg = optarg;
-                break;
+        case 'd':
+            io_depth_arg = optarg;
+            break;
 
-            case 'h':
-                command_testio_usage();
-                return EXIT_SUCCESS;
-                break;
+        case 'h':
+            command_testio_usage();
+            return EXIT_SUCCESS;
+            break;
 
-            case 'o':
-                object_uri_arg = optarg;
-                break;
+        case 'o':
+            object_uri_arg = optarg;
+            break;
 
-            case 'v':
-                vector_mode = 1;
-                break;
+        case 'v':
+            vector_mode = 1;
+            break;
 
-            default:
-                return EXIT_FAILURE;
+        default:
+            return EXIT_FAILURE;
         }
     }
 
@@ -361,17 +348,13 @@ static int command_testio(int argc, char **argv) {
     }
 
     return rawstor_cli_testio(
-        object_uri_arg,
-        block_size, count, io_depth,
-        vector_mode);
+        object_uri_arg, block_size, count, io_depth, vector_mode
+    );
 }
 
-
 static int run_command(
-    const char *command,
-    const struct RawstorOpts *opts,
-    int argc, char **argv)
-{
+    const char* command, const struct RawstorOpts* opts, int argc, char** argv
+) {
     int res = rawstor_initialize(opts);
     if (res) {
         fprintf(stderr, "rawstor_initialize() failed: %s\n", strerror(-res));
@@ -397,9 +380,8 @@ static int run_command(
     return ret;
 }
 
-
-int main(int argc, char **argv) {
-    const char *optstring = "+hv";
+int main(int argc, char** argv) {
+    const char* optstring = "+hv";
     struct option longopts[] = {
         {"help", no_argument, NULL, 'h'},
         {"sessions", required_argument, NULL, 's'},
@@ -408,34 +390,34 @@ int main(int argc, char **argv) {
         {},
     };
 
-    char *sessions_arg = NULL;
-    char *wait_timeout_arg = NULL;
+    char* sessions_arg = NULL;
+    char* wait_timeout_arg = NULL;
     while (1) {
         int c = getopt_long(argc, argv, optstring, longopts, NULL);
         if (c == -1)
             break;
 
         switch (c) {
-            case 'h':
-                usage();
-                return EXIT_SUCCESS;
-                break;
+        case 'h':
+            usage();
+            return EXIT_SUCCESS;
+            break;
 
-            case 's':
-                sessions_arg = optarg;
-                break;
+        case 's':
+            sessions_arg = optarg;
+            break;
 
-            case 't':
-                wait_timeout_arg = optarg;
-                break;
+        case 't':
+            wait_timeout_arg = optarg;
+            break;
 
-            case 'v':
-                version();
-                return EXIT_SUCCESS;
-                break;
+        case 'v':
+            version();
+            return EXIT_SUCCESS;
+            break;
 
-            default:
-                return EXIT_FAILURE;
+        default:
+            return EXIT_FAILURE;
         }
     }
 
@@ -460,8 +442,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    int ret = run_command(
-        argv[optind], &opts, argc - optind, &argv[optind]);
+    int ret = run_command(argv[optind], &opts, argc - optind, &argv[optind]);
 
     return ret;
 }

--- a/cli/remove.c
+++ b/cli/remove.c
@@ -8,15 +8,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-
-int rawstor_cli_remove(const char *uris) {
+int rawstor_cli_remove(const char* uris) {
     fprintf(stderr, "Removing object: %s\n", uris);
 
     int res = rawstor_object_remove(uris);
     if (res) {
-        fprintf(
-            stderr,
-            "rawstor_object_remove() failed: %s\n", strerror(-res));
+        fprintf(stderr, "rawstor_object_remove() failed: %s\n", strerror(-res));
         return EXIT_FAILURE;
     }
 

--- a/cli/remove.h
+++ b/cli/remove.h
@@ -3,18 +3,14 @@
 
 #include <stddef.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
-int rawstor_cli_remove(const char *uris);
-
+int rawstor_cli_remove(const char* uris);
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // RAWSTOR_CLI_REMOVE_H

--- a/cli/show.c
+++ b/cli/show.c
@@ -8,8 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-
-int rawstor_cli_show(const char *uris) {
+int rawstor_cli_show(const char* uris) {
     struct RawstorObjectSpec spec;
     int res = rawstor_object_spec(uris, &spec);
     if (res) {

--- a/cli/show.h
+++ b/cli/show.h
@@ -3,18 +3,14 @@
 
 #include <stddef.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
-int rawstor_cli_show(const char *uris);
-
+int rawstor_cli_show(const char* uris);
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // RAWSTOR_CLI_SHOW_H

--- a/cli/testio.h
+++ b/cli/testio.h
@@ -3,21 +3,17 @@
 
 #include <stddef.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
 int rawstor_cli_testio(
-    const char *uris,
-    size_t block_size, unsigned int count, unsigned int io_depth,
-    int vector_mode);
-
+    const char* uris, size_t block_size, unsigned int count,
+    unsigned int io_depth, int vector_mode
+);
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // RAWSTOR_CLI_TESTIO_H

--- a/include/rawstor.h
+++ b/include/rawstor.h
@@ -7,10 +7,8 @@
 #ifndef RAWSTOR_H
 #define RAWSTOR_H
 
-
 #include <rawstor/io_callback.h>
 #include <rawstor/object.h>
 #include <rawstor/rawstor.h>
-
 
 #endif // RAWSTOR_H

--- a/include/rawstor/io_callback.h
+++ b/include/rawstor/io_callback.h
@@ -3,18 +3,14 @@
 
 #include <stddef.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
-typedef int(RawstorIOCallback)(size_t result, int error, void *data);
-
+typedef int(RawstorIOCallback)(size_t result, int error, void* data);
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // RAWSTOR_IO_CALLBACK_H

--- a/include/rawstor/object.h
+++ b/include/rawstor/object.h
@@ -15,11 +15,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 
 typedef struct RawstorObject RawstorObject;
 
@@ -28,54 +26,50 @@ struct RawstorObjectSpec {
 };
 
 typedef int(RawstorCallback)(
-    RawstorObject *object, size_t size, size_t result, int error, void *data);
-
+    RawstorObject* object, size_t size, size_t result, int error, void* data
+);
 
 int rawstor_object_spec(
-    const char *object_uris,
-    struct RawstorObjectSpec *spec);
+    const char* object_uris, struct RawstorObjectSpec* spec
+);
 
 int rawstor_object_create(
-    const char *uris,
-    const struct RawstorObjectSpec *spec,
-    char *object_uris, size_t size);
+    const char* uris, const struct RawstorObjectSpec* spec, char* object_uris,
+    size_t size
+);
 
-int rawstor_object_remove(const char *object_uris);
+int rawstor_object_remove(const char* object_uris);
 
-int rawstor_object_open(
-    const char *object_uris,
-    RawstorObject **object);
+int rawstor_object_open(const char* object_uris, RawstorObject** object);
 
-int rawstor_object_close(RawstorObject *object);
+int rawstor_object_close(RawstorObject* object);
 
-int rawstor_object_id(const RawstorObject *object, char *buf, size_t size);
+int rawstor_object_id(const RawstorObject* object, char* buf, size_t size);
 
-int rawstor_object_uris(const RawstorObject *object, char *buf, size_t size);
+int rawstor_object_uris(const RawstorObject* object, char* buf, size_t size);
 
 int rawstor_object_pread(
-    RawstorObject *object,
-    void *buf, size_t size, off_t offset,
-    RawstorCallback *cb, void *data);
+    RawstorObject* object, void* buf, size_t size, off_t offset,
+    RawstorCallback* cb, void* data
+);
 
 int rawstor_object_preadv(
-    RawstorObject *object,
-    struct iovec *iov, unsigned int niov, size_t size, off_t offset,
-    RawstorCallback *cb, void *data);
+    RawstorObject* object, struct iovec* iov, unsigned int niov, size_t size,
+    off_t offset, RawstorCallback* cb, void* data
+);
 
 int rawstor_object_pwrite(
-    RawstorObject *object,
-    void *buf, size_t size, off_t offset,
-    RawstorCallback *cb, void *data);
+    RawstorObject* object, void* buf, size_t size, off_t offset,
+    RawstorCallback* cb, void* data
+);
 
 int rawstor_object_pwritev(
-    RawstorObject *object,
-    struct iovec *iov, unsigned int niov, size_t size, off_t offset,
-    RawstorCallback *cb, void *data);
-
+    RawstorObject* object, struct iovec* iov, unsigned int niov, size_t size,
+    off_t offset, RawstorCallback* cb, void* data
+);
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // RAWSTOR_OBJECT_H

--- a/include/rawstor/rawstor.h
+++ b/include/rawstor/rawstor.h
@@ -15,50 +15,51 @@
 #include <stddef.h>
 #include <stdint.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 
 /**
  * fd
  */
 
 int rawstor_fd_read(
-    int fd, void *buf, size_t size,
-    RawstorIOCallback *cb, void *data);
+    int fd, void* buf, size_t size, RawstorIOCallback* cb, void* data
+);
 
 int rawstor_fd_readv(
-    int fd,
-    struct iovec *iov, unsigned int niov, size_t size,
-    RawstorIOCallback *cb, void *data);
+    int fd, struct iovec* iov, unsigned int niov, size_t size,
+    RawstorIOCallback* cb, void* data
+);
 
 int rawstor_fd_pread(
-    int fd, void *buf, size_t size, off_t offset,
-    RawstorIOCallback *cb, void *data);
+    int fd, void* buf, size_t size, off_t offset, RawstorIOCallback* cb,
+    void* data
+);
 
 int rawstor_fd_preadv(
-    int fd,
-    struct iovec *iov, unsigned int niov, size_t size, off_t offset,
-    RawstorIOCallback *cb, void *data);
+    int fd, struct iovec* iov, unsigned int niov, size_t size, off_t offset,
+    RawstorIOCallback* cb, void* data
+);
 
 int rawstor_fd_write(
-    int fd, void *buf, size_t size,
-    RawstorIOCallback *cb, void *data);
+    int fd, void* buf, size_t size, RawstorIOCallback* cb, void* data
+);
 
 int rawstor_fd_writev(
-    int fd, struct iovec *iov, unsigned int niov, size_t size,
-    RawstorIOCallback *cb, void *data);
+    int fd, struct iovec* iov, unsigned int niov, size_t size,
+    RawstorIOCallback* cb, void* data
+);
 
 int rawstor_fd_pwrite(
-    int fd, void *buf, size_t size, off_t offset,
-    RawstorIOCallback *cb, void *data);
+    int fd, void* buf, size_t size, off_t offset, RawstorIOCallback* cb,
+    void* data
+);
 
 int rawstor_fd_pwritev(
-    int fd, struct iovec *iov, unsigned int niov, size_t size, off_t offset,
-    RawstorIOCallback *cb, void *data);
-
+    int fd, struct iovec* iov, unsigned int niov, size_t size, off_t offset,
+    RawstorIOCallback* cb, void* data
+);
 
 /**
  * Lib
@@ -73,8 +74,7 @@ struct RawstorOpts {
     unsigned int tcp_user_timeout;
 };
 
-
-int rawstor_initialize(const struct RawstorOpts *opts);
+int rawstor_initialize(const struct RawstorOpts* opts);
 
 void rawstor_terminate(void);
 
@@ -82,10 +82,8 @@ int rawstor_empty(void);
 
 int rawstor_wait(void);
 
-
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // RAWSTOR_RAWSTOR_H

--- a/librawstorio/include/rawstorio/queue.hpp
+++ b/librawstorio/include/rawstorio/queue.hpp
@@ -14,50 +14,46 @@
 namespace rawstor {
 namespace io {
 
-
 class Queue {
-    private:
-        unsigned int _depth;
+private:
+    unsigned int _depth;
 
-    public:
-        static const std::string& engine_name();
-        static void setup_fd(int fd);
-        static std::unique_ptr<Queue> create(unsigned int depth);
+public:
+    static const std::string& engine_name();
+    static void setup_fd(int fd);
+    static std::unique_ptr<Queue> create(unsigned int depth);
 
-        Queue(unsigned int depth): _depth(depth) {}
-        Queue(const Queue &) = delete;
-        Queue(Queue &&) = delete;
-        virtual ~Queue() {}
-        Queue& operator=(const Queue &) = delete;
-        Queue& operator=(Queue &&) = delete;
+    Queue(unsigned int depth) : _depth(depth) {}
+    Queue(const Queue&) = delete;
+    Queue(Queue&&) = delete;
+    virtual ~Queue() {}
+    Queue& operator=(const Queue&) = delete;
+    Queue& operator=(Queue&&) = delete;
 
-        inline unsigned int depth() const noexcept {
-            return _depth;
-        }
+    inline unsigned int depth() const noexcept { return _depth; }
 
-        virtual void read(std::unique_ptr<TaskScalar> t) = 0;
+    virtual void read(std::unique_ptr<TaskScalar> t) = 0;
 
-        virtual void read(std::unique_ptr<TaskVector> t) = 0;
+    virtual void read(std::unique_ptr<TaskVector> t) = 0;
 
-        virtual void read(std::unique_ptr<TaskScalarPositional> t) = 0;
+    virtual void read(std::unique_ptr<TaskScalarPositional> t) = 0;
 
-        virtual void read(std::unique_ptr<TaskVectorPositional> t) = 0;
+    virtual void read(std::unique_ptr<TaskVectorPositional> t) = 0;
 
-        virtual void write(std::unique_ptr<TaskScalar> t) = 0;
+    virtual void write(std::unique_ptr<TaskScalar> t) = 0;
 
-        virtual void write(std::unique_ptr<TaskVector> t) = 0;
+    virtual void write(std::unique_ptr<TaskVector> t) = 0;
 
-        virtual void write(std::unique_ptr<TaskScalarPositional> t) = 0;
+    virtual void write(std::unique_ptr<TaskScalarPositional> t) = 0;
 
-        virtual void write(std::unique_ptr<TaskVectorPositional> t) = 0;
+    virtual void write(std::unique_ptr<TaskVectorPositional> t) = 0;
 
-        virtual bool empty() const noexcept = 0;
+    virtual bool empty() const noexcept = 0;
 
-        virtual void wait(unsigned int timeout) = 0;
+    virtual void wait(unsigned int timeout) = 0;
 };
 
-
-}} // rawstor::io
-
+} // namespace io
+} // namespace rawstor
 
 #endif // RAWSTORIO_QUEUE_HPP

--- a/librawstorio/include/rawstorio/task.hpp
+++ b/librawstorio/include/rawstorio/task.hpp
@@ -7,99 +7,93 @@
 
 #include <string>
 
-
 namespace rawstor {
 namespace io {
 
-
 class Task {
-    private:
-        int _fd;
+private:
+    int _fd;
 
 #ifdef RAWSTOR_TRACE_EVENTS
-        size_t _trace_id;
+    size_t _trace_id;
 #endif
 
-    public:
-        Task(int fd):
-            _fd(fd)
+public:
+    Task(int fd) :
+        _fd(fd)
 #ifdef RAWSTOR_TRACE_EVENTS
-            , _trace_id(rawstor_trace_event_begin(
-                '|', __FILE__, __LINE__, __FUNCTION__,
-                "fd %d\n", _fd))
+        ,
+        _trace_id(rawstor_trace_event_begin(
+            '|', __FILE__, __LINE__, __FUNCTION__, "fd %d\n", _fd
+        ))
 #endif
-        {}
-        Task(const Task &) = delete;
-        Task(Task &&) = delete;
-        virtual ~Task() {
+    {
+    }
+    Task(const Task&) = delete;
+    Task(Task&&) = delete;
+    virtual ~Task() {
 #ifdef RAWSTOR_TRACE_EVENTS
-            rawstor_trace_event_end(
-                _trace_id, __FILE__, __LINE__, __FUNCTION__,
-                "fd %d\n", _fd);
+        rawstor_trace_event_end(
+            _trace_id, __FILE__, __LINE__, __FUNCTION__, "fd %d\n", _fd
+        );
 #endif
-        }
+    }
 
-        Task& operator=(const Task &) = delete;
-        Task& operator=(Task &&) = delete;
+    Task& operator=(const Task&) = delete;
+    Task& operator=(Task&&) = delete;
 
-        inline int fd() const noexcept {
-            return _fd;
-        }
+    inline int fd() const noexcept { return _fd; }
 
-        virtual void operator()(size_t result, int error) = 0;
+    virtual void operator()(size_t result, int error) = 0;
 
 #ifdef RAWSTOR_TRACE_EVENTS
-        void trace(
-            const char *file, int line, const char *function,
-            const std::string &message)
-        {
-            rawstor_trace_event_message(
-                _trace_id, file, line, function,
-                "%s\n", message.c_str());
-        }
+    void trace(
+        const char* file, int line, const char* function,
+        const std::string& message
+    ) {
+        rawstor_trace_event_message(
+            _trace_id, file, line, function, "%s\n", message.c_str()
+        );
+    }
 #endif
 };
 
+class TaskScalar : public Task {
+public:
+    TaskScalar(int fd) : Task(fd) {}
+    virtual ~TaskScalar() override = default;
 
-class TaskScalar: public Task {
-    public:
-        TaskScalar(int fd): Task(fd) {}
-        virtual ~TaskScalar() override = default;
-
-        virtual void* buf() noexcept = 0;
-        virtual size_t size() const noexcept = 0;
+    virtual void* buf() noexcept = 0;
+    virtual size_t size() const noexcept = 0;
 };
 
+class TaskVector : public Task {
+public:
+    TaskVector(int fd) : Task(fd) {}
+    virtual ~TaskVector() override = default;
 
-class TaskVector: public Task {
-    public:
-        TaskVector(int fd): Task(fd) {}
-        virtual ~TaskVector() override = default;
-
-        virtual iovec* iov() noexcept = 0;
-        virtual unsigned int niov() const noexcept = 0;
-        virtual size_t size() const noexcept = 0;
+    virtual iovec* iov() noexcept = 0;
+    virtual unsigned int niov() const noexcept = 0;
+    virtual size_t size() const noexcept = 0;
 };
 
+class TaskScalarPositional : public TaskScalar {
+public:
+    TaskScalarPositional(int fd) : TaskScalar(fd) {}
+    virtual ~TaskScalarPositional() override = default;
 
-class TaskScalarPositional: public TaskScalar {
-    public:
-        TaskScalarPositional(int fd): TaskScalar(fd) {}
-        virtual ~TaskScalarPositional() override = default;
-
-        virtual off_t offset() const noexcept = 0;
+    virtual off_t offset() const noexcept = 0;
 };
 
+class TaskVectorPositional : public TaskVector {
+public:
+    TaskVectorPositional(int fd) : TaskVector(fd) {}
+    virtual ~TaskVectorPositional() override = default;
 
-class TaskVectorPositional: public TaskVector {
-    public:
-        TaskVectorPositional(int fd): TaskVector(fd) {}
-        virtual ~TaskVectorPositional() override = default;
-
-        virtual off_t offset() const noexcept = 0;
+    virtual off_t offset() const noexcept = 0;
 };
 
-
-}} // rawstor::io
+} // namespace io
+} // namespace rawstor
 
 #endif // RAWSTORIO_TASK_HPP

--- a/librawstorio/src/poll_event.cpp
+++ b/librawstorio/src/poll_event.cpp
@@ -14,7 +14,6 @@ namespace rawstor {
 namespace io {
 namespace poll {
 
-
 void Event::dispatch() {
 #ifdef RAWSTOR_TRACE_EVENTS
     trace(__FILE__, __LINE__, __FUNCTION__, "callback");
@@ -22,7 +21,7 @@ void Event::dispatch() {
 #endif
         (*_t)(_result, _error);
 #ifdef RAWSTOR_TRACE_EVENTS
-    } catch (std::exception &e) {
+    } catch (const std::exception& e) {
         std::ostringstream oss;
         oss << "callback error: " << e.what();
         trace(__FILE__, __LINE__, __FUNCTION__, oss.str());
@@ -32,13 +31,11 @@ void Event::dispatch() {
 #endif
 }
 
-
-void Event::add_iov(std::vector<iovec> &iov) {
+void Event::add_iov(std::vector<iovec>& iov) {
     for (unsigned int i = 0; i < _niov_at; ++i) {
         iov.push_back(_iov_at[i]);
     }
 }
-
 
 size_t Event::shift(size_t shift) {
     size_t ret;
@@ -53,12 +50,12 @@ size_t Event::shift(size_t shift) {
     return ret;
 }
 
-
 size_t EventP::shift(size_t shift) {
     size_t ret = Event::shift(shift);
     _offset_at += shift - ret;
     return ret;
 }
 
-
-}}} // rawstor::io::poll
+} // namespace poll
+} // namespace io
+} // namespace rawstor

--- a/librawstorio/src/poll_event.hpp
+++ b/librawstorio/src/poll_event.hpp
@@ -21,132 +21,109 @@ namespace rawstor {
 namespace io {
 namespace poll {
 
-
 class Queue;
 
-
 class Event {
-    protected:
-        Queue &_q;
-        std::unique_ptr<rawstor::io::Task> _t;
-        std::vector<iovec> _iov;
-        iovec *_iov_at;
-        unsigned int _niov_at;
-        size_t _size;
-        ssize_t _result;
-        int _error;
+protected:
+    Queue& _q;
+    std::unique_ptr<rawstor::io::Task> _t;
+    std::vector<iovec> _iov;
+    iovec* _iov_at;
+    unsigned int _niov_at;
+    size_t _size;
+    ssize_t _result;
+    int _error;
 
-    public:
-        Event(
-            Queue &q,
-            std::unique_ptr<rawstor::io::TaskScalar> t):
-            _q(q),
-            _t(std::move(t)),
-            _iov(
-                1,
-                (iovec){
-                    .iov_base =
-                        static_cast<rawstor::io::TaskScalar*>(_t.get())->buf(),
-                    .iov_len =
-                        static_cast<rawstor::io::TaskScalar*>(_t.get())->size(),
-                }
-            ),
-            _iov_at(_iov.data()),
-            _niov_at(1),
-            _size(static_cast<rawstor::io::TaskScalar*>(_t.get())->size()),
-            _result(0),
-            _error(0)
-        {}
-
-        Event(
-            Queue &q,
-            std::unique_ptr<rawstor::io::TaskVector> t):
-            _q(q),
-            _t(std::move(t)),
-            _niov_at(static_cast<rawstor::io::TaskVector*>(_t.get())->niov()),
-            _size(static_cast<rawstor::io::TaskVector*>(_t.get())->size()),
-            _result(0),
-            _error(0)
-        {
-            iovec *iov = static_cast<rawstor::io::TaskVector*>(_t.get())->iov();
-            _iov.reserve(_niov_at);
-            for (unsigned int i = 0; i < _niov_at; ++i) {
-                _iov.push_back(iov[i]);
+public:
+    Event(Queue& q, std::unique_ptr<rawstor::io::TaskScalar> t) :
+        _q(q),
+        _t(std::move(t)),
+        _iov(
+            1,
+            (iovec){
+                .iov_base =
+                    static_cast<rawstor::io::TaskScalar*>(_t.get())->buf(),
+                .iov_len =
+                    static_cast<rawstor::io::TaskScalar*>(_t.get())->size(),
             }
-            _iov_at = _iov.data();
+        ),
+        _iov_at(_iov.data()),
+        _niov_at(1),
+        _size(static_cast<rawstor::io::TaskScalar*>(_t.get())->size()),
+        _result(0),
+        _error(0) {}
+
+    Event(Queue& q, std::unique_ptr<rawstor::io::TaskVector> t) :
+        _q(q),
+        _t(std::move(t)),
+        _niov_at(static_cast<rawstor::io::TaskVector*>(_t.get())->niov()),
+        _size(static_cast<rawstor::io::TaskVector*>(_t.get())->size()),
+        _result(0),
+        _error(0) {
+        iovec* iov = static_cast<rawstor::io::TaskVector*>(_t.get())->iov();
+        _iov.reserve(_niov_at);
+        for (unsigned int i = 0; i < _niov_at; ++i) {
+            _iov.push_back(iov[i]);
         }
+        _iov_at = _iov.data();
+    }
 
-        Event(const Event &) = delete;
-        Event(Event &&) = delete;
+    Event(const Event&) = delete;
+    Event(Event&&) = delete;
 
-        virtual ~Event() = default;
+    virtual ~Event() = default;
 
-        Event& operator=(const Event &) = delete;
-        Event& operator=(Event &&) = delete;
+    Event& operator=(const Event&) = delete;
+    Event& operator=(Event&&) = delete;
 
-        inline void set_error(int error) noexcept {
-            _error = error;
-        }
+    inline void set_error(int error) noexcept { _error = error; }
 
-        inline iovec* iov() const noexcept {
-            return _iov_at;
-        }
+    inline iovec* iov() const noexcept { return _iov_at; }
 
-        inline unsigned int niov() const noexcept {
-            return _niov_at;
-        }
+    inline unsigned int niov() const noexcept { return _niov_at; }
 
-        inline bool completed() const noexcept {
-            return _niov_at == 0;
-        }
+    inline bool completed() const noexcept { return _niov_at == 0; }
 
-        void dispatch();
+    void dispatch();
 
-        void add_iov(std::vector<iovec> &iov);
+    void add_iov(std::vector<iovec>& iov);
 
-        virtual size_t shift(size_t shift);
+    virtual size_t shift(size_t shift);
 
 #ifdef RAWSTOR_TRACE_EVENTS
-        void trace(
-            const char *file, int line, const char *function,
-            const std::string &message)
-        {
-            _t->trace(file, line, function, message);
-        }
+    void trace(
+        const char* file, int line, const char* function,
+        const std::string& message
+    ) {
+        _t->trace(file, line, function, message);
+    }
 #endif
 };
 
+class EventP : public Event {
+private:
+    off_t _offset_at;
 
-class EventP: public Event {
-    private:
-        off_t _offset_at;
+public:
+    EventP(Queue& q, std::unique_ptr<rawstor::io::TaskScalarPositional> t) :
+        Event(q, std::move(t)),
+        _offset_at(
+            static_cast<rawstor::io::TaskScalarPositional*>(_t.get())->offset()
+        ) {}
 
-    public:
-        EventP(
-            Queue &q,
-            std::unique_ptr<rawstor::io::TaskScalarPositional> t):
-            Event(q, std::move(t)),
-            _offset_at(static_cast<rawstor::io::TaskScalarPositional*>(
-                _t.get())->offset())
-        {}
+    EventP(Queue& q, std::unique_ptr<rawstor::io::TaskVectorPositional> t) :
+        Event(q, std::move(t)),
+        _offset_at(
+            static_cast<rawstor::io::TaskVectorPositional*>(_t.get())->offset()
+        ) {}
 
-        EventP(
-            Queue &q,
-            std::unique_ptr<rawstor::io::TaskVectorPositional> t):
-            Event(q, std::move(t)),
-            _offset_at(static_cast<rawstor::io::TaskVectorPositional*>(
-                _t.get())->offset())
-        {}
+    inline off_t offset() const noexcept { return _offset_at; }
 
-        inline off_t offset() const noexcept {
-            return _offset_at;
-        }
-
-        size_t shift(size_t shift) override;
+    size_t shift(size_t shift) override;
 };
 
-
-}}} // rawstor::io
-
+} // namespace poll
+} // namespace io
+} // namespace rawstor
 
 #endif // RAWSTORIO_POLL_EVENT_HPP

--- a/librawstorio/src/poll_queue.cpp
+++ b/librawstorio/src/poll_queue.cpp
@@ -14,20 +14,15 @@
 
 #include <cassert>
 
-
 namespace {
-
 
 std::string engine_name = "poll";
 
-
-} // unnamed
-
+} // namespace
 
 namespace rawstor {
 namespace io {
 namespace poll {
-
 
 Session& Queue::_get_session(int fd) {
     std::unordered_map<int, std::shared_ptr<Session>>::iterator it =
@@ -42,11 +37,9 @@ Session& Queue::_get_session(int fd) {
     return *session;
 }
 
-
 const std::string& Queue::engine_name() {
     return ::engine_name;
 }
-
 
 void Queue::setup_fd(int fd) {
     int res;
@@ -73,67 +66,57 @@ void Queue::setup_fd(int fd) {
     }
 }
 
-
 void Queue::read(std::unique_ptr<rawstor::io::TaskScalar> t) {
-    Session &s = _get_session(t->fd());
+    Session& s = _get_session(t->fd());
     s.read(std::move(t));
 }
-
 
 void Queue::read(std::unique_ptr<rawstor::io::TaskVector> t) {
-    Session &s = _get_session(t->fd());
+    Session& s = _get_session(t->fd());
     s.read(std::move(t));
 }
-
 
 void Queue::read(std::unique_ptr<rawstor::io::TaskScalarPositional> t) {
-    Session &s = _get_session(t->fd());
+    Session& s = _get_session(t->fd());
     s.read(std::move(t));
 }
-
 
 void Queue::read(std::unique_ptr<rawstor::io::TaskVectorPositional> t) {
-    Session &s = _get_session(t->fd());
+    Session& s = _get_session(t->fd());
     s.read(std::move(t));
 }
 
-
 void Queue::write(std::unique_ptr<rawstor::io::TaskScalar> t) {
-    Session &s = _get_session(t->fd());
+    Session& s = _get_session(t->fd());
     s.write(std::move(t));
 }
-
 
 void Queue::write(std::unique_ptr<rawstor::io::TaskVector> t) {
-    Session &s = _get_session(t->fd());
+    Session& s = _get_session(t->fd());
     s.write(std::move(t));
 }
-
 
 void Queue::write(std::unique_ptr<rawstor::io::TaskScalarPositional> t) {
-    Session &s = _get_session(t->fd());
+    Session& s = _get_session(t->fd());
     s.write(std::move(t));
 }
-
 
 void Queue::write(std::unique_ptr<rawstor::io::TaskVectorPositional> t) {
-    Session &s = _get_session(t->fd());
+    Session& s = _get_session(t->fd());
     s.write(std::move(t));
 }
-
 
 bool Queue::empty() const noexcept {
     if (!_cqes.empty()) {
         return false;
     }
-    for (const auto &it: _sessions) {
+    for (const auto& it : _sessions) {
         if (!it.second->empty()) {
             return false;
         }
     }
     return true;
 }
-
 
 void Queue::wait(unsigned int timeout) {
     while (_cqes.empty()) {
@@ -177,8 +160,8 @@ void Queue::wait(unsigned int timeout) {
             RAWSTOR_THROW_SYSTEM_ERROR(ETIME);
         }
 
-        for (const pollfd &fd: fds) {
-            std::shared_ptr<Session> &s = _sessions.at(fd.fd);
+        for (const pollfd& fd : fds) {
+            std::shared_ptr<Session>& s = _sessions.at(fd.fd);
             if (fd.revents & POLLHUP) {
                 s->process_read(_cqes, true);
                 s->process_write(_cqes, true);
@@ -196,5 +179,6 @@ void Queue::wait(unsigned int timeout) {
     event->dispatch();
 }
 
-
-}}} // rawstor::io
+} // namespace poll
+} // namespace io
+} // namespace rawstor

--- a/librawstorio/src/poll_queue.hpp
+++ b/librawstorio/src/poll_queue.hpp
@@ -7,68 +7,54 @@
 
 #include <rawstorstd/ringbuf.hpp>
 
-#include <unordered_map>
 #include <memory>
 #include <string>
-
+#include <unordered_map>
 
 namespace rawstor {
 namespace io {
 namespace poll {
 
-
 class Event;
 
 class Session;
 
+class Queue : public rawstor::io::Queue {
+private:
+    std::unordered_map<int, std::shared_ptr<Session>> _sessions;
+    rawstor::RingBuf<Event> _cqes;
 
-class Queue: public rawstor::io::Queue {
-    private:
-        std::unordered_map<int, std::shared_ptr<Session>> _sessions;
-        rawstor::RingBuf<Event> _cqes;
+    Session& _get_session(int fd);
 
-        Session& _get_session(int fd);
+public:
+    static const std::string& engine_name();
+    static void setup_fd(int fd);
 
-    public:
-        static const std::string& engine_name();
-        static void setup_fd(int fd);
+    Queue(unsigned int depth) : rawstor::io::Queue(depth), _cqes(depth) {}
 
-        Queue(unsigned int depth):
-            rawstor::io::Queue(depth),
-            _cqes(depth)
-        {}
+    void read(std::unique_ptr<rawstor::io::TaskScalar> t) override;
 
-        void read(
-            std::unique_ptr<rawstor::io::TaskScalar> t) override;
+    void read(std::unique_ptr<rawstor::io::TaskVector> t) override;
 
-        void read(
-            std::unique_ptr<rawstor::io::TaskVector> t) override;
+    void read(std::unique_ptr<rawstor::io::TaskScalarPositional> t) override;
 
-        void read(
-            std::unique_ptr<rawstor::io::TaskScalarPositional> t) override;
+    void read(std::unique_ptr<rawstor::io::TaskVectorPositional> t) override;
 
-        void read(
-            std::unique_ptr<rawstor::io::TaskVectorPositional> t) override;
+    void write(std::unique_ptr<rawstor::io::TaskScalar> t) override;
 
-        void write(
-            std::unique_ptr<rawstor::io::TaskScalar> t) override;
+    void write(std::unique_ptr<rawstor::io::TaskVector> t) override;
 
-        void write(
-            std::unique_ptr<rawstor::io::TaskVector> t) override;
+    void write(std::unique_ptr<rawstor::io::TaskScalarPositional> t) override;
 
-        void write(
-            std::unique_ptr<rawstor::io::TaskScalarPositional> t) override;
+    void write(std::unique_ptr<rawstor::io::TaskVectorPositional> t) override;
 
-        void write(
-            std::unique_ptr<rawstor::io::TaskVectorPositional> t) override;
+    bool empty() const noexcept override;
 
-        bool empty() const noexcept override;
-
-        void wait(unsigned int timeout) override;
+    void wait(unsigned int timeout) override;
 };
 
-
-}}} // rawstor::io::poll
-
+} // namespace poll
+} // namespace io
+} // namespace rawstor
 
 #endif // RAWSTORIO_POLL_QUEUE_HPP

--- a/librawstorio/src/poll_session.hpp
+++ b/librawstorio/src/poll_session.hpp
@@ -11,61 +11,52 @@ namespace rawstor {
 namespace io {
 namespace poll {
 
-
 class Event;
 
-
 class Session {
-    protected:
-        Queue &_q;
-        int _fd;
+protected:
+    Queue& _q;
+    int _fd;
 
-    public:
-        static std::shared_ptr<Session> create(Queue &q, int fd);
+public:
+    static std::shared_ptr<Session> create(Queue& q, int fd);
 
-        Session(Queue &q, int fd);
-        Session(const Session &) = delete;
-        Session(Session &&) = delete;
-        virtual ~Session() {}
-        Session& operator=(const Session &) = delete;
-        Session& operator=(Session &&) = delete;
+    Session(Queue& q, int fd);
+    Session(const Session&) = delete;
+    Session(Session&&) = delete;
+    virtual ~Session() {}
+    Session& operator=(const Session&) = delete;
+    Session& operator=(Session&&) = delete;
 
-        inline int fd() const noexcept {
-            return _fd;
-        }
+    inline int fd() const noexcept { return _fd; }
 
-        virtual short events() const noexcept = 0;
-        virtual bool empty() const noexcept = 0;
+    virtual short events() const noexcept = 0;
+    virtual bool empty() const noexcept = 0;
 
-        virtual void read(
-            std::unique_ptr<rawstor::io::TaskScalar> t) = 0;
+    virtual void read(std::unique_ptr<rawstor::io::TaskScalar> t) = 0;
 
-        virtual void read(
-            std::unique_ptr<rawstor::io::TaskVector> t) = 0;
+    virtual void read(std::unique_ptr<rawstor::io::TaskVector> t) = 0;
 
-        virtual void read(
-            std::unique_ptr<rawstor::io::TaskScalarPositional> t) = 0;
+    virtual void read(std::unique_ptr<rawstor::io::TaskScalarPositional> t) = 0;
 
-        virtual void read(
-            std::unique_ptr<rawstor::io::TaskVectorPositional> t) = 0;
+    virtual void read(std::unique_ptr<rawstor::io::TaskVectorPositional> t) = 0;
 
-        virtual void write(
-            std::unique_ptr<rawstor::io::TaskScalar> t) = 0;
+    virtual void write(std::unique_ptr<rawstor::io::TaskScalar> t) = 0;
 
-        virtual void write(
-            std::unique_ptr<rawstor::io::TaskVector> t) = 0;
+    virtual void write(std::unique_ptr<rawstor::io::TaskVector> t) = 0;
 
-        virtual void write(
-            std::unique_ptr<rawstor::io::TaskScalarPositional> t) = 0;
+    virtual void
+    write(std::unique_ptr<rawstor::io::TaskScalarPositional> t) = 0;
 
-        virtual void write(
-            std::unique_ptr<rawstor::io::TaskVectorPositional> t) = 0;
+    virtual void
+    write(std::unique_ptr<rawstor::io::TaskVectorPositional> t) = 0;
 
-        virtual void process_read(RingBuf<Event> &cqes, bool pollhup) = 0;
-        virtual void process_write(RingBuf<Event> &cqes, bool pollhup) = 0;
+    virtual void process_read(RingBuf<Event>& cqes, bool pollhup) = 0;
+    virtual void process_write(RingBuf<Event>& cqes, bool pollhup) = 0;
 };
 
-
-}}} // rawstor::io
+} // namespace poll
+} // namespace io
+} // namespace rawstor
 
 #endif // RAWSTORIO_SESSION_POLL_HPP

--- a/librawstorio/src/queue.cpp
+++ b/librawstorio/src/queue.cpp
@@ -13,7 +13,6 @@
 namespace rawstor {
 namespace io {
 
-
 std::unique_ptr<Queue> Queue::create(unsigned int depth) {
 #ifdef RAWSTOR_WITH_LIBURING
     return std::make_unique<rawstor::io::uring::Queue>(depth);
@@ -21,7 +20,6 @@ std::unique_ptr<Queue> Queue::create(unsigned int depth) {
     return std::make_unique<rawstor::io::poll::Queue>(depth);
 #endif
 }
-
 
 const std::string& Queue::engine_name() {
 #ifdef RAWSTOR_WITH_LIBURING
@@ -31,7 +29,6 @@ const std::string& Queue::engine_name() {
 #endif
 }
 
-
 void Queue::setup_fd(int fd) {
 #ifdef RAWSTOR_WITH_LIBURING
     rawstor::io::uring::Queue::setup_fd(fd);
@@ -40,5 +37,5 @@ void Queue::setup_fd(int fd) {
 #endif
 }
 
-
-}} // rawstor::io
+} // namespace io
+} // namespace rawstor

--- a/librawstorio/src/uring_queue.cpp
+++ b/librawstorio/src/uring_queue.cpp
@@ -5,41 +5,30 @@
 
 #include <time.h>
 
-
 namespace {
-
 
 std::string engine_name = "uring";
 
-
-} // unnamed
-
+} // namespace
 
 namespace rawstor {
 namespace io {
 namespace uring {
 
-
-Queue::Queue(unsigned int depth):
-    rawstor::io::Queue(depth),
-    _events(0)
-{
+Queue::Queue(unsigned int depth) : rawstor::io::Queue(depth), _events(0) {
     int res = io_uring_queue_init(depth, &_ring, 0);
     if (res < 0) {
         RAWSTOR_THROW_SYSTEM_ERROR(-res);
     };
 }
 
-
 Queue::~Queue() {
     io_uring_queue_exit(&_ring);
 }
 
-
 const std::string& Queue::engine_name() {
     return ::engine_name;
 }
-
 
 void Queue::setup_fd(int fd) {
     int res;
@@ -61,9 +50,8 @@ void Queue::setup_fd(int fd) {
     }
 }
 
-
 void Queue::read(std::unique_ptr<rawstor::io::TaskScalar> t) {
-    io_uring_sqe *sqe = io_uring_get_sqe(&_ring);
+    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
     if (sqe == nullptr) {
         RAWSTOR_THROW_SYSTEM_ERROR(ENOBUFS);
     }
@@ -73,9 +61,8 @@ void Queue::read(std::unique_ptr<rawstor::io::TaskScalar> t) {
     t.release();
 }
 
-
 void Queue::read(std::unique_ptr<rawstor::io::TaskVector> t) {
-    io_uring_sqe *sqe = io_uring_get_sqe(&_ring);
+    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
     if (sqe == nullptr) {
         RAWSTOR_THROW_SYSTEM_ERROR(ENOBUFS);
     }
@@ -85,9 +72,8 @@ void Queue::read(std::unique_ptr<rawstor::io::TaskVector> t) {
     t.release();
 }
 
-
 void Queue::read(std::unique_ptr<rawstor::io::TaskScalarPositional> t) {
-    io_uring_sqe *sqe = io_uring_get_sqe(&_ring);
+    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
     if (sqe == nullptr) {
         RAWSTOR_THROW_SYSTEM_ERROR(ENOBUFS);
     }
@@ -97,9 +83,8 @@ void Queue::read(std::unique_ptr<rawstor::io::TaskScalarPositional> t) {
     t.release();
 }
 
-
 void Queue::read(std::unique_ptr<rawstor::io::TaskVectorPositional> t) {
-    io_uring_sqe *sqe = io_uring_get_sqe(&_ring);
+    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
     if (sqe == nullptr) {
         RAWSTOR_THROW_SYSTEM_ERROR(ENOBUFS);
     }
@@ -109,9 +94,8 @@ void Queue::read(std::unique_ptr<rawstor::io::TaskVectorPositional> t) {
     t.release();
 }
 
-
 void Queue::write(std::unique_ptr<rawstor::io::TaskScalar> t) {
-    io_uring_sqe *sqe = io_uring_get_sqe(&_ring);
+    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
     if (sqe == nullptr) {
         RAWSTOR_THROW_SYSTEM_ERROR(ENOBUFS);
     }
@@ -121,9 +105,8 @@ void Queue::write(std::unique_ptr<rawstor::io::TaskScalar> t) {
     t.release();
 }
 
-
 void Queue::write(std::unique_ptr<rawstor::io::TaskVector> t) {
-    io_uring_sqe *sqe = io_uring_get_sqe(&_ring);
+    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
     if (sqe == nullptr) {
         RAWSTOR_THROW_SYSTEM_ERROR(ENOBUFS);
     }
@@ -133,9 +116,8 @@ void Queue::write(std::unique_ptr<rawstor::io::TaskVector> t) {
     t.release();
 }
 
-
 void Queue::write(std::unique_ptr<rawstor::io::TaskScalarPositional> t) {
-    io_uring_sqe *sqe = io_uring_get_sqe(&_ring);
+    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
     if (sqe == nullptr) {
         RAWSTOR_THROW_SYSTEM_ERROR(ENOBUFS);
     }
@@ -145,9 +127,8 @@ void Queue::write(std::unique_ptr<rawstor::io::TaskScalarPositional> t) {
     t.release();
 }
 
-
 void Queue::write(std::unique_ptr<rawstor::io::TaskVectorPositional> t) {
-    io_uring_sqe *sqe = io_uring_get_sqe(&_ring);
+    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
     if (sqe == nullptr) {
         RAWSTOR_THROW_SYSTEM_ERROR(ENOBUFS);
     }
@@ -157,18 +138,15 @@ void Queue::write(std::unique_ptr<rawstor::io::TaskVectorPositional> t) {
     t.release();
 }
 
-
 bool Queue::empty() const noexcept {
     return _events == 0;
 }
 
-
 void Queue::wait(unsigned int timeout) {
     int res;
-    io_uring_cqe *cqe;
+    io_uring_cqe* cqe;
     __kernel_timespec ts = {
-        .tv_sec = timeout / 1000,
-        .tv_nsec = 1000000u * (timeout % 1000)
+        .tv_sec = timeout / 1000, .tv_nsec = 1000000u * (timeout % 1000)
     };
 
     if (io_uring_sq_ready(&_ring) > 0) {
@@ -192,7 +170,8 @@ void Queue::wait(unsigned int timeout) {
     }
 
     std::unique_ptr<rawstor::io::Task> t(
-        static_cast<rawstor::io::Task*>(io_uring_cqe_get_data(cqe)));
+        static_cast<rawstor::io::Task*>(io_uring_cqe_get_data(cqe))
+    );
 
     size_t result = cqe->res >= 0 ? cqe->res : 0;
     int error = cqe->res < 0 ? -cqe->res : 0;
@@ -204,5 +183,6 @@ void Queue::wait(unsigned int timeout) {
     (*t)(result, error);
 }
 
-
-}}} // rawstor::io::uring
+} // namespace uring
+} // namespace io
+} // namespace rawstor

--- a/librawstorio/src/uring_queue.hpp
+++ b/librawstorio/src/uring_queue.hpp
@@ -7,58 +7,47 @@
 
 #include <memory>
 
-
 namespace rawstor {
 namespace io {
 namespace uring {
 
+class Queue : public rawstor::io::Queue {
+private:
+    io_uring _ring;
+    unsigned int _events;
 
-class Queue: public rawstor::io::Queue {
-    private:
-        io_uring _ring;
-        unsigned int _events;
+public:
+    static const std::string& engine_name();
+    static void setup_fd(int fd);
 
-    public:
-        static const std::string& engine_name();
-        static void setup_fd(int fd);
+    Queue(unsigned int depth);
+    ~Queue();
 
-        Queue(unsigned int depth);
-        ~Queue();
+    inline io_uring* ring() noexcept { return &_ring; }
 
-        inline io_uring* ring() noexcept {
-            return &_ring;
-        }
+    void read(std::unique_ptr<rawstor::io::TaskScalar> t) override;
 
-        void read(
-            std::unique_ptr<rawstor::io::TaskScalar> t) override;
+    void read(std::unique_ptr<rawstor::io::TaskVector> t) override;
 
-        void read(
-            std::unique_ptr<rawstor::io::TaskVector> t) override;
+    void read(std::unique_ptr<rawstor::io::TaskScalarPositional> t) override;
 
-        void read(
-            std::unique_ptr<rawstor::io::TaskScalarPositional> t) override;
+    void read(std::unique_ptr<rawstor::io::TaskVectorPositional> t) override;
 
-        void read(
-            std::unique_ptr<rawstor::io::TaskVectorPositional> t) override;
+    void write(std::unique_ptr<rawstor::io::TaskScalar> t) override;
 
-        void write(
-            std::unique_ptr<rawstor::io::TaskScalar> t) override;
+    void write(std::unique_ptr<rawstor::io::TaskVector> t) override;
 
-        void write(
-            std::unique_ptr<rawstor::io::TaskVector> t) override;
+    void write(std::unique_ptr<rawstor::io::TaskScalarPositional> t) override;
 
-        void write(
-            std::unique_ptr<rawstor::io::TaskScalarPositional> t) override;
+    void write(std::unique_ptr<rawstor::io::TaskVectorPositional> t) override;
 
-        void write(
-            std::unique_ptr<rawstor::io::TaskVectorPositional> t) override;
+    bool empty() const noexcept override;
 
-        bool empty() const noexcept override;
-
-        void wait(unsigned int timeout) override;
+    void wait(unsigned int timeout) override;
 };
 
-
-}}} // rawstor::io::uring
+} // namespace uring
+} // namespace io
+} // namespace rawstor
 
 #endif // RAWSTORIO_URING_QUEUE_HPP

--- a/librawstorstd/include/rawstorstd/gcc.h
+++ b/librawstorstd/include/rawstorstd/gcc.h
@@ -1,21 +1,17 @@
 #ifndef RAWSTORSTD_GCC_H
 #define RAWSTORSTD_GCC_H
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
 #if defined(__GNUC__) && (__GNUC__ >= 3)
-#define RAWSTOR_UNUSED  __attribute__((unused))
+#define RAWSTOR_UNUSED __attribute__((unused))
 #else
 #define RAWSTOR_UNUSED
 #endif
 
-
 #define RAWSTOR_PACKED __attribute__((packed))
-
 
 #ifdef __APPLE__
 #define RAWSTOR_ON_MACOS
@@ -25,10 +21,8 @@ extern "C" {
 #define RAWSTOR_ON_LINUX
 #endif
 
-
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // RAWSTORSTD_GCC_H

--- a/librawstorstd/include/rawstorstd/gpp.hpp
+++ b/librawstorstd/include/rawstorstd/gpp.hpp
@@ -5,23 +5,20 @@
 
 #include <cerrno>
 
-
 #define _RAWSTOR_STRINGIZE_DETAIL(x) #x
 #define _RAWSTOR_STRINGIZE(x) _RAWSTOR_STRINGIZE_DETAIL(x)
 
+#define RAWSTOR_THROW_SYSTEM_ERROR(err)                                        \
+    throw std::system_error(                                                   \
+        (err), std::generic_category(),                                        \
+        __FILE__ ":" _RAWSTOR_STRINGIZE(__LINE__)                              \
+    )
 
-#define RAWSTOR_THROW_SYSTEM_ERROR(err) \
-    throw std::system_error( \
-        (err), std::generic_category(), \
-        __FILE__ ":" _RAWSTOR_STRINGIZE(__LINE__))
-
-
-#define RAWSTOR_THROW_ERRNO() \
-    do { \
-        int err = errno; \
-        errno = 0; \
-        RAWSTOR_THROW_SYSTEM_ERROR(err); \
+#define RAWSTOR_THROW_ERRNO()                                                  \
+    do {                                                                       \
+        int err = errno;                                                       \
+        errno = 0;                                                             \
+        RAWSTOR_THROW_SYSTEM_ERROR(err);                                       \
     } while (0)
-
 
 #endif // RAWSTORSTD_GPP_HPP

--- a/librawstorstd/include/rawstorstd/hash.h
+++ b/librawstorstd/include/rawstorstd/hash.h
@@ -5,21 +5,18 @@
 
 #include <stdint.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
 uint64_t rawstor_hash_scalar(void* buf, size_t size);
 
 int rawstor_hash_vector(
-    const struct iovec *iov, unsigned int niov, uint64_t *hash);
-
+    const struct iovec* iov, unsigned int niov, uint64_t* hash
+);
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // RAWSTORSTD_HASH_H

--- a/librawstorstd/include/rawstorstd/iovec.h
+++ b/librawstorstd/include/rawstorstd/iovec.h
@@ -5,32 +5,30 @@
 
 #include <stddef.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
 size_t rawstor_iovec_discard_front(
-    struct iovec **iov, unsigned int *niov, size_t size);
+    struct iovec** iov, unsigned int* niov, size_t size
+);
 
-size_t rawstor_iovec_discard_back(
-    struct iovec **iov, unsigned int *niov, size_t size);
+size_t
+rawstor_iovec_discard_back(struct iovec** iov, unsigned int* niov, size_t size);
 
 size_t rawstor_iovec_from_buf(
-    struct iovec *iov, unsigned int niov, size_t offset,
-    const void *buf, size_t size);
+    struct iovec* iov, unsigned int niov, size_t offset, const void* buf,
+    size_t size
+);
 
 size_t rawstor_iovec_to_buf(
-    struct iovec *iov, unsigned int niov, size_t offset,
-    void *buf, size_t size);
+    struct iovec* iov, unsigned int niov, size_t offset, void* buf, size_t size
+);
 
-size_t rawstor_iovec_size(struct iovec *iov, unsigned int niov);
-
+size_t rawstor_iovec_size(struct iovec* iov, unsigned int niov);
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // RAWSTORSTD_IOVEC_ROUTINES_H

--- a/librawstorstd/include/rawstorstd/list.h
+++ b/librawstorstd/include/rawstorstd/list.h
@@ -3,35 +3,30 @@
 
 #include <stddef.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
 typedef struct RawstorList RawstorList;
-
 
 RawstorList* rawstor_list_create(size_t object_size);
 
-void rawstor_list_delete(RawstorList *list);
+void rawstor_list_delete(RawstorList* list);
 
-void* rawstor_list_iter(RawstorList *list);
+void* rawstor_list_iter(RawstorList* list);
 
-void* rawstor_list_next(void *iter);
+void* rawstor_list_next(void* iter);
 
-void* rawstor_list_append(RawstorList *list);
+void* rawstor_list_append(RawstorList* list);
 
-void* rawstor_list_remove(RawstorList *list, void *iter);
+void* rawstor_list_remove(RawstorList* list, void* iter);
 
-int rawstor_list_empty(RawstorList *list);
+int rawstor_list_empty(RawstorList* list);
 
-size_t rawstor_list_size(RawstorList *list);
-
+size_t rawstor_list_size(RawstorList* list);
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // RAWSTORSTD_LIST_H

--- a/librawstorstd/include/rawstorstd/logging.h
+++ b/librawstorstd/include/rawstorstd/logging.h
@@ -7,91 +7,99 @@
 #include <stdio.h>
 #include <unistd.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
-extern RawstorMutex *rawstor_logging_mutex;
-
+extern RawstorMutex* rawstor_logging_mutex;
 
 int rawstor_logging_initialize(void);
 
 void rawstor_logging_terminate(void);
 
-
-#define rawstor_log(level, ...) do { \
-    rawstor_mutex_lock(rawstor_logging_mutex); \
-    rawstor_trace_event_dump(); \
-    dprintf(STDERR_FILENO, "%s %s:%d ", level, __FILE__, __LINE__); \
-    dprintf(STDERR_FILENO, __VA_ARGS__); \
-    rawstor_mutex_unlock(rawstor_logging_mutex); \
-} while(0)
-
+#define rawstor_log(level, ...)                                                \
+    do {                                                                       \
+        rawstor_mutex_lock(rawstor_logging_mutex);                             \
+        rawstor_trace_event_dump();                                            \
+        dprintf(STDERR_FILENO, "%s %s:%d ", level, __FILE__, __LINE__);        \
+        dprintf(STDERR_FILENO, __VA_ARGS__);                                   \
+        rawstor_mutex_unlock(rawstor_logging_mutex);                           \
+    } while (0)
 
 #if RAWSTOR_LOGLEVEL >= RAWSTOR_LOGLEVEL_TRACE
-#define rawstor_trace(...) do { \
-    rawstor_log("TRACE", "%s(): ", __FUNCTION__); \
-    dprintf(STDERR_FILENO, __VA_ARGS__); \
-} while (0)
+#define rawstor_trace(...)                                                     \
+    do {                                                                       \
+        rawstor_log("TRACE", "%s(): ", __FUNCTION__);                          \
+        dprintf(STDERR_FILENO, __VA_ARGS__);                                   \
+    } while (0)
 
 #define RAWSTOR_TRACE_EVENTS
 #else
-#define rawstor_trace(...) while (0) { rawstor_log("TRACE", __VA_ARGS__); }
+#define rawstor_trace(...)                                                     \
+    while (0) {                                                                \
+        rawstor_log("TRACE", __VA_ARGS__);                                     \
+    }
 #endif
-
 
 #if RAWSTOR_LOGLEVEL >= RAWSTOR_LOGLEVEL_DEBUG
 #define rawstor_debug(...) rawstor_log("DEBUG", __VA_ARGS__)
 #else
-#define rawstor_debug(...) while (0) { rawstor_log("DEBUG", __VA_ARGS__); }
+#define rawstor_debug(...)                                                     \
+    while (0) {                                                                \
+        rawstor_log("DEBUG", __VA_ARGS__);                                     \
+    }
 #endif
-
 
 #if RAWSTOR_LOGLEVEL >= RAWSTOR_LOGLEVEL_INFO
 #define rawstor_info(...) rawstor_log("INFO", __VA_ARGS__)
 #else
-#define rawstor_info(...) while (0) { rawstor_log("INFO", __VA_ARGS__); }
+#define rawstor_info(...)                                                      \
+    while (0) {                                                                \
+        rawstor_log("INFO", __VA_ARGS__);                                      \
+    }
 #endif
-
 
 #if RAWSTOR_LOGLEVEL >= RAWSTOR_LOGLEVEL_WARNING
 #define rawstor_warning(...) rawstor_log("WARNING", __VA_ARGS__)
 #else
-#define rawstor_warning(...) while (0) { rawstor_log("WARNING", __VA_ARGS__); }
+#define rawstor_warning(...)                                                   \
+    while (0) {                                                                \
+        rawstor_log("WARNING", __VA_ARGS__);                                   \
+    }
 #endif
-
 
 #if RAWSTOR_LOGLEVEL >= RAWSTOR_LOGLEVEL_ERROR
 #define rawstor_error(...) rawstor_log("ERROR", __VA_ARGS__)
 #else
-#define rawstor_error(...) while (0) { rawstor_log("ERROR", __VA_ARGS__); }
+#define rawstor_error(...)                                                     \
+    while (0) {                                                                \
+        rawstor_log("ERROR", __VA_ARGS__);                                     \
+    }
 #endif
-
 
 #ifdef RAWSTOR_TRACE_EVENTS
 size_t rawstor_trace_event_begin(
-    char appearance, const char *file, int line, const char *function,
-    const char *format, ...);
+    char appearance, const char* file, int line, const char* function,
+    const char* format, ...
+);
 
 void rawstor_trace_event_end(
-    size_t event, const char *file, int line, const char *function,
-    const char *format, ...);
+    size_t event, const char* file, int line, const char* function,
+    const char* format, ...
+);
 
 void rawstor_trace_event_message(
-    size_t event, const char *file, int line, const char *function,
-    const char *format, ...);
+    size_t event, const char* file, int line, const char* function,
+    const char* format, ...
+);
 
 void rawstor_trace_event_dump(void);
 #else
 #define rawstor_trace_event_dump()
 #endif
 
-
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // RAWSTOR_LOGGING_H

--- a/librawstorstd/include/rawstorstd/mempool.h
+++ b/librawstorstd/include/rawstorstd/mempool.h
@@ -3,37 +3,32 @@
 
 #include <stddef.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
 typedef struct RawstorMemPool RawstorMemPool;
-
 
 RawstorMemPool* rawstor_mempool_create(size_t capacity, size_t object_size);
 
-void rawstor_mempool_delete(RawstorMemPool *mempool);
+void rawstor_mempool_delete(RawstorMemPool* mempool);
 
-size_t rawstor_mempool_available(RawstorMemPool *mempool);
+size_t rawstor_mempool_available(RawstorMemPool* mempool);
 
-size_t rawstor_mempool_allocated(RawstorMemPool *mempool);
+size_t rawstor_mempool_allocated(RawstorMemPool* mempool);
 
-size_t rawstor_mempool_capacity(RawstorMemPool *mempool);
+size_t rawstor_mempool_capacity(RawstorMemPool* mempool);
 
-size_t rawstor_mempool_object_size(RawstorMemPool *mempool);
+size_t rawstor_mempool_object_size(RawstorMemPool* mempool);
 
-void* rawstor_mempool_data(RawstorMemPool *mempool);
+void* rawstor_mempool_data(RawstorMemPool* mempool);
 
-void* rawstor_mempool_alloc(RawstorMemPool *mempool);
+void* rawstor_mempool_alloc(RawstorMemPool* mempool);
 
-void rawstor_mempool_free(RawstorMemPool *mempool, void *ptr);
-
+void rawstor_mempool_free(RawstorMemPool* mempool, void* ptr);
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // RAWSTORSTD_MEMPOOL_H

--- a/librawstorstd/include/rawstorstd/mempool.hpp
+++ b/librawstorstd/include/rawstorstd/mempool.hpp
@@ -9,80 +9,72 @@
 
 #include <cstddef>
 
-
 namespace rawstor {
-
 
 template <typename T>
 class MemPool {
-    private:
-        RawstorMemPool *_impl;
+private:
+    RawstorMemPool* _impl;
 
-    public:
-        MemPool(size_t capacity):
-            _impl(rawstor_mempool_create(capacity, sizeof(T)))
-        {
-            if (_impl == nullptr) {
-                RAWSTOR_THROW_ERRNO();
-            }
+public:
+    MemPool(size_t capacity) :
+        _impl(rawstor_mempool_create(capacity, sizeof(T))) {
+        if (_impl == nullptr) {
+            RAWSTOR_THROW_ERRNO();
         }
+    }
 
-        MemPool(const MemPool<T> &) = delete;
+    MemPool(const MemPool<T>&) = delete;
 
-        MemPool(MemPool<T> &&other) noexcept:
-            _impl(std::exchange(other._impl, nullptr))
-        {}
+    MemPool(MemPool<T>&& other) noexcept :
+        _impl(std::exchange(other._impl, nullptr)) {}
 
-        MemPool<T>& operator=(const MemPool<T> &) = delete;
+    MemPool<T>& operator=(const MemPool<T>&) = delete;
 
-        MemPool<T>& operator=(MemPool<T> &&other) noexcept {
-            if (&other != this) {
-                if (_impl != nullptr) {
-                    rawstor_mempool_delete(_impl);
-                }
-
-                _impl = std::exchange(other._impl, nullptr);
-            }
-            return *this;
-        }
-
-        ~MemPool() {
+    MemPool<T>& operator=(MemPool<T>&& other) noexcept {
+        if (&other != this) {
             if (_impl != nullptr) {
                 rawstor_mempool_delete(_impl);
             }
-        }
 
-        inline size_t available() const noexcept {
-            return rawstor_mempool_available(_impl);
+            _impl = std::exchange(other._impl, nullptr);
         }
+        return *this;
+    }
 
-        inline size_t allocated() const noexcept {
-            return rawstor_mempool_allocated(_impl);
+    ~MemPool() {
+        if (_impl != nullptr) {
+            rawstor_mempool_delete(_impl);
         }
+    }
 
-        inline size_t capacity() const noexcept {
-            return rawstor_mempool_capacity(_impl);
+    inline size_t available() const noexcept {
+        return rawstor_mempool_available(_impl);
+    }
+
+    inline size_t allocated() const noexcept {
+        return rawstor_mempool_allocated(_impl);
+    }
+
+    inline size_t capacity() const noexcept {
+        return rawstor_mempool_capacity(_impl);
+    }
+
+    inline T* data() noexcept {
+        return static_cast<T*>(rawstor_mempool_data(_impl));
+    }
+
+    inline T* alloc() {
+        T* ret = static_cast<T*>(rawstor_mempool_alloc(_impl));
+        if (ret == nullptr) {
+            RAWSTOR_THROW_ERRNO();
         }
+        return ret;
+    }
 
-        inline T* data() noexcept {
-            return static_cast<T*>(rawstor_mempool_data(_impl));
-        }
-
-        inline T* alloc() {
-            T* ret = static_cast<T*>(rawstor_mempool_alloc(_impl));
-            if (ret == nullptr) {
-                RAWSTOR_THROW_ERRNO();
-            }
-            return ret;
-        }
-
-        inline void free(T *ptr) noexcept {
-            rawstor_mempool_free(_impl, ptr);
-        };
+    inline void free(T* ptr) noexcept { rawstor_mempool_free(_impl, ptr); };
 };
 
-
-} // rawstor
-
+} // namespace rawstor
 
 #endif // RAWSTORSTD_MEMPOOL_HPP

--- a/librawstorstd/include/rawstorstd/ringbuf.hpp
+++ b/librawstorstd/include/rawstorstd/ringbuf.hpp
@@ -8,77 +8,60 @@
 #include <utility>
 #include <vector>
 
-
 namespace rawstor {
-
 
 template <typename T>
 class RingBuf {
-    private:
-        std::vector<std::unique_ptr<T>> _data;
-        size_t _head;
-        size_t _tail;
-        size_t _count;
+private:
+    std::vector<std::unique_ptr<T>> _data;
+    size_t _head;
+    size_t _tail;
+    size_t _count;
 
-    public:
-        RingBuf(size_t capacity):
-            _data(capacity),
-            _head(0),
-            _tail(0),
-            _count(0)
-        {}
+public:
+    RingBuf(size_t capacity) : _data(capacity), _head(0), _tail(0), _count(0) {}
 
-        RingBuf(const RingBuf<T> &) = delete;
-        RingBuf(RingBuf<T> &&other) = delete;
+    RingBuf(const RingBuf<T>&) = delete;
+    RingBuf(RingBuf<T>&& other) = delete;
 
-        RingBuf<T>& operator=(const RingBuf<T> &) = delete;
-        RingBuf<T>& operator=(RingBuf<T> &&other) = delete;
+    RingBuf<T>& operator=(const RingBuf<T>&) = delete;
+    RingBuf<T>& operator=(RingBuf<T>&& other) = delete;
 
-        inline bool empty() const noexcept {
-            return _count == 0;
+    inline bool empty() const noexcept { return _count == 0; }
+
+    inline bool full() const noexcept { return _count == _data.size(); }
+
+    inline size_t capacity() const noexcept { return _data.size(); }
+
+    inline size_t size() const noexcept { return _count; }
+
+    inline void push(std::unique_ptr<T> item) {
+        if (full()) {
+            RAWSTOR_THROW_SYSTEM_ERROR(ENOBUFS);
         }
+        _data[_head] = std::move(item);
+        _head = (_head + 1) % _data.size();
+        ++_count;
+    }
 
-        inline bool full() const noexcept {
-            return _count == _data.size();
+    inline const T& tail() const {
+        if (empty()) {
+            throw std::out_of_range("RingBuf is empty");
         }
+        return *_data[_tail].get();
+    }
 
-        inline size_t capacity() const noexcept {
-            return _data.size();
+    inline std::unique_ptr<T> pop() {
+        if (empty()) {
+            throw std::out_of_range("RingBuf is empty");
         }
-
-        inline size_t size() const noexcept {
-            return _count;
-        }
-
-        inline void push(std::unique_ptr<T> item) {
-            if (full()) {
-                RAWSTOR_THROW_SYSTEM_ERROR(ENOBUFS);
-            }
-            _data[_head] = std::move(item);
-            _head = (_head + 1) % _data.size();
-            ++_count;
-        }
-
-        inline const T& tail() const {
-            if (empty()) {
-                throw std::out_of_range("RingBuf is empty");
-            }
-            return *_data[_tail].get();
-        }
-
-        inline std::unique_ptr<T> pop() {
-            if (empty()) {
-                throw std::out_of_range("RingBuf is empty");
-            }
-            std::unique_ptr<T> item = std::exchange(_data[_tail], nullptr);
-            _tail = (_tail + 1) % _data.size();
-            --_count;
-            return item;
-        }
+        std::unique_ptr<T> item = std::exchange(_data[_tail], nullptr);
+        _tail = (_tail + 1) % _data.size();
+        --_count;
+        return item;
+    }
 };
 
-
-} // rawstor
-
+} // namespace rawstor
 
 #endif // RAWSTORSTD_RINGBUF_HPP

--- a/librawstorstd/include/rawstorstd/socket.h
+++ b/librawstorstd/include/rawstorstd/socket.h
@@ -1,11 +1,9 @@
 #ifndef RAWSTORSTD_SOCKET_ROUTINES_H
 #define RAWSTORSTD_SOCKET_ROUTINES_H
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 
 int rawstor_socket_set_nonblock(int fd);
 
@@ -21,10 +19,8 @@ int rawstor_socket_set_snd_bufsize(int fd, unsigned int size);
 
 int rawstor_socket_set_rcv_bufsize(int fd, unsigned int size);
 
-
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // RAWSTORSTD_SOCKET_ROUTINES_H

--- a/librawstorstd/include/rawstorstd/threading.h
+++ b/librawstorstd/include/rawstorstd/threading.h
@@ -1,11 +1,9 @@
 #ifndef RAWSTORSTD_THREADING
 #define RAWSTORSTD_THREADING
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 
 typedef struct RawstorThread RawstorThread;
 
@@ -13,40 +11,38 @@ typedef struct RawstorMutex RawstorMutex;
 
 typedef struct RawstorCond RawstorCond;
 
-typedef void*(RawstorThreadRoutine)(void *data);
+typedef void*(RawstorThreadRoutine)(void* data);
 
+RawstorThread* rawstor_thread_create(RawstorThreadRoutine* routine, void* data);
 
-RawstorThread* rawstor_thread_create(RawstorThreadRoutine *routine, void *data);
+void* rawstor_thread_join(RawstorThread* thread);
 
-void* rawstor_thread_join(RawstorThread *thread);
-
-void rawstor_thread_detach(RawstorThread *thread);
+void rawstor_thread_detach(RawstorThread* thread);
 
 RawstorMutex* rawstor_mutex_create(void);
 
-void rawstor_mutex_delete(RawstorMutex *mutex);
+void rawstor_mutex_delete(RawstorMutex* mutex);
 
-void rawstor_mutex_lock(RawstorMutex *mutex);
+void rawstor_mutex_lock(RawstorMutex* mutex);
 
-void rawstor_mutex_unlock(RawstorMutex *mutex);
+void rawstor_mutex_unlock(RawstorMutex* mutex);
 
 RawstorCond* rawstor_cond_create(void);
 
 void rawstor_cond_delete(RawstorCond* cond);
 
-void rawstor_cond_wait(RawstorCond *cond, RawstorMutex *mutex);
+void rawstor_cond_wait(RawstorCond* cond, RawstorMutex* mutex);
 
 int rawstor_cond_wait_timeout(
-    RawstorCond *cond, RawstorMutex *mutex, int timeout);
+    RawstorCond* cond, RawstorMutex* mutex, int timeout
+);
 
-void rawstor_cond_signal(RawstorCond *cond);
+void rawstor_cond_signal(RawstorCond* cond);
 
-void rawstor_cond_broadcast(RawstorCond *cond);
-
+void rawstor_cond_broadcast(RawstorCond* cond);
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // RAWSTORSTD_THREADING

--- a/librawstorstd/include/rawstorstd/uri.hpp
+++ b/librawstorstd/include/rawstorstd/uri.hpp
@@ -3,107 +3,77 @@
 
 #include <string>
 
-
 namespace rawstor {
 
-
 class URIPath {
-    private:
-        std::string _path;
-        std::string _dirname;
-        std::string _filename;
+private:
+    std::string _path;
+    std::string _dirname;
+    std::string _filename;
 
-    public:
-        URIPath() {}
-        explicit URIPath(const std::string &path);
-        URIPath(const URIPath &other);
-        URIPath(URIPath &&other) noexcept;
-        URIPath& operator=(const URIPath &other);
-        URIPath& operator=(URIPath &&other) noexcept;
+public:
+    URIPath() {}
+    explicit URIPath(const std::string& path);
+    URIPath(const URIPath& other);
+    URIPath(URIPath&& other) noexcept;
+    URIPath& operator=(const URIPath& other);
+    URIPath& operator=(URIPath&& other) noexcept;
 
-        inline const std::string& str() const noexcept {
-            return _path;
-        }
+    inline const std::string& str() const noexcept { return _path; }
 
-        inline const std::string& dirname() const noexcept {
-            return _dirname;
-        }
+    inline const std::string& dirname() const noexcept { return _dirname; }
 
-        inline const std::string& filename() const noexcept {
-            return _filename;
-        }
+    inline const std::string& filename() const noexcept { return _filename; }
 };
-
 
 class URI {
-    private:
-        std::string _uri;
-        std::string _scheme;
-        std::string _userinfo;
-        std::string _username;
-        std::string _password;
-        std::string _authority;
-        std::string _host;
-        std::string _hostname;
-        unsigned int _port;
-        URIPath _path;
+private:
+    std::string _uri;
+    std::string _scheme;
+    std::string _userinfo;
+    std::string _username;
+    std::string _password;
+    std::string _authority;
+    std::string _host;
+    std::string _hostname;
+    unsigned int _port;
+    URIPath _path;
 
-    public:
-        explicit URI(const std::string &uri);
-        URI(const URI &parent, const std::string &child);
-        URI(const URI &other);
-        URI(URI &&other) noexcept;
-        URI& operator=(const URI &other);
-        URI& operator=(URI &&other) noexcept;
+public:
+    explicit URI(const std::string& uri);
+    URI(const URI& parent, const std::string& child);
+    URI(const URI& other);
+    URI(URI&& other) noexcept;
+    URI& operator=(const URI& other);
+    URI& operator=(URI&& other) noexcept;
 
-        URI parent() const;
+    URI parent() const;
 
-        bool operator<(const URI &other) const noexcept {
-            return _uri < other._uri;
-        }
+    bool operator<(const URI& other) const noexcept {
+        return _uri < other._uri;
+    }
 
-        inline const std::string& str() const noexcept {
-            return _uri;
-        }
+    inline const std::string& str() const noexcept { return _uri; }
 
-        inline const std::string& scheme() const noexcept {
-            return _scheme;
-        }
+    inline const std::string& scheme() const noexcept { return _scheme; }
 
-        inline const std::string& userinfo() const noexcept {
-            return _userinfo;
-        }
+    inline const std::string& userinfo() const noexcept { return _userinfo; }
 
-        inline const std::string& username() const noexcept {
-            return _username;
-        }
+    inline const std::string& username() const noexcept { return _username; }
 
-        inline const std::string& password() const noexcept {
-            return _password;
-        }
+    inline const std::string& password() const noexcept { return _password; }
 
-        inline const std::string& authority() const noexcept {
-            return _authority;
-        }
+    inline const std::string& authority() const noexcept { return _authority; }
 
-        inline const std::string& host() const noexcept {
-            return _host;
-        }
+    inline const std::string& host() const noexcept { return _host; }
 
-        inline const std::string& hostname() const noexcept {
-            return _hostname;
-        }
+    inline const std::string& hostname() const noexcept { return _hostname; }
 
-        inline unsigned int port() const noexcept {
-            return _port;
-        }
+    inline unsigned int port() const noexcept { return _port; }
 
-        inline const URIPath& path() const noexcept {
-            return _path;
-        }
+    inline const URIPath& path() const noexcept { return _path; }
 };
 
-
-} // rawstor
+} // namespace rawstor
 
 #endif // RAWSTORSTD_URI_HPP

--- a/librawstorstd/include/rawstorstd/uuid.h
+++ b/librawstorstd/include/rawstorstd/uuid.h
@@ -5,11 +5,9 @@
 
 #include <stdint.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 
 struct RawstorUUID {
     uint8_t bytes[16];
@@ -17,18 +15,16 @@ struct RawstorUUID {
 
 typedef char RawstorUUIDString[37];
 
+int rawstor_uuid7_init(struct RawstorUUID* uuid);
 
-int rawstor_uuid7_init(struct RawstorUUID *uuid);
-
-int rawstor_uuid_from_string(struct RawstorUUID *uuid, const char *s);
+int rawstor_uuid_from_string(struct RawstorUUID* uuid, const char* s);
 
 void rawstor_uuid_to_string(
-    const struct RawstorUUID *uuid, RawstorUUIDString *s);
-
+    const struct RawstorUUID* uuid, RawstorUUIDString* s
+);
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // RAWSTORSTD_UUID_H

--- a/librawstorstd/src/hash.c
+++ b/librawstorstd/src/hash.c
@@ -12,7 +12,6 @@
 #include <errno.h>
 #include <stdint.h>
 
-
 uint64_t rawstor_hash_scalar(void* buf, size_t length) {
 #ifdef RAWSTOR_WITH_LIBXXHASH
     return XXH3_64bits(buf, length);
@@ -23,15 +22,14 @@ uint64_t rawstor_hash_scalar(void* buf, size_t length) {
 #endif
 }
 
-
 int rawstor_hash_vector(
-    const struct iovec *iov, unsigned int niov, uint64_t *hash)
-{
+    const struct iovec* iov, unsigned int niov, uint64_t* hash
+) {
     int ret;
 
 #ifdef RAWSTOR_WITH_LIBXXHASH
     // Allocate a state struct. Do not just use malloc() or new.
-    XXH3_state_t *state = XXH3_createState();
+    XXH3_state_t* state = XXH3_createState();
     if (state == NULL) {
         ret = -ENOMEM;
         goto err_state;

--- a/librawstorstd/src/iovec.c
+++ b/librawstorstd/src/iovec.c
@@ -5,10 +5,9 @@
 #include <stddef.h>
 #include <string.h>
 
-
 size_t rawstor_iovec_discard_front(
-    struct iovec **iov, unsigned int *niov, size_t size)
-{
+    struct iovec** iov, unsigned int* niov, size_t size
+) {
     size_t total = 0;
 
     while (*niov > 0 && size >= (*iov)[0].iov_len) {
@@ -27,10 +26,9 @@ size_t rawstor_iovec_discard_front(
     return total;
 }
 
-
 size_t rawstor_iovec_discard_back(
-    struct iovec **iov, unsigned int *niov, size_t size)
-{
+    struct iovec** iov, unsigned int* niov, size_t size
+) {
     size_t total = 0;
 
     while (*niov > 0 && size >= (*iov)[*niov - 1].iov_len) {
@@ -47,17 +45,16 @@ size_t rawstor_iovec_discard_back(
     return total;
 }
 
-
 size_t rawstor_iovec_from_buf(
-    struct iovec *iov, unsigned int niov, size_t offset,
-    const void *buf, size_t size)
-{
+    struct iovec* iov, unsigned int niov, size_t offset, const void* buf,
+    size_t size
+) {
     size_t total = 0;
 
     for (unsigned int i = 0; (offset || size) && i < niov; i++) {
         if (offset < iov[i].iov_len) {
-            size_t len = iov[i].iov_len - offset < size ?
-                iov[i].iov_len - offset : size;
+            size_t len =
+                iov[i].iov_len - offset < size ? iov[i].iov_len - offset : size;
             memcpy(iov[i].iov_base + offset, buf + total, len);
             size -= len;
             total += len;
@@ -70,17 +67,15 @@ size_t rawstor_iovec_from_buf(
     return total;
 }
 
-
 size_t rawstor_iovec_to_buf(
-    struct iovec *iov, unsigned int niov, size_t offset,
-    void *buf, size_t size)
-{
+    struct iovec* iov, unsigned int niov, size_t offset, void* buf, size_t size
+) {
     size_t total = 0;
 
     for (unsigned int i = 0; (offset || size) && i < niov; i++) {
         if (offset < iov[i].iov_len) {
-            size_t len = iov[i].iov_len - offset < size ?
-                iov[i].iov_len - offset : size;
+            size_t len =
+                iov[i].iov_len - offset < size ? iov[i].iov_len - offset : size;
             memcpy(buf + total, iov[i].iov_base + offset, len);
             size -= len;
             total += len;
@@ -93,8 +88,7 @@ size_t rawstor_iovec_to_buf(
     return total;
 }
 
-
-size_t rawstor_iovec_size(struct iovec *iov, unsigned int niov) {
+size_t rawstor_iovec_size(struct iovec* iov, unsigned int niov) {
     size_t ret = 0;
 
     for (unsigned int i = 0; i < niov; i++) {

--- a/librawstorstd/src/list.c
+++ b/librawstorstd/src/list.c
@@ -3,31 +3,26 @@
 #include <stddef.h>
 #include <stdlib.h>
 
-#define RAWSTOR_LIST_ITEM_TO_ITER(item) \
-    ( \
-        (item) != NULL ? (((void*)(item)) + sizeof(RawstorListItem)) : NULL \
-    )
+#define RAWSTOR_LIST_ITEM_TO_ITER(item)                                        \
+    ((item) != NULL ? (((void*)(item)) + sizeof(RawstorListItem)) : NULL)
 
-#define RAWSTOR_LIST_ITEM_FROM_ITER(iter) \
+#define RAWSTOR_LIST_ITEM_FROM_ITER(iter)                                      \
     (((void*)(iter)) - sizeof(RawstorListItem))
 
-
 typedef struct RawstorListItem {
-    struct RawstorListItem *prev;
-    struct RawstorListItem *next;
+    struct RawstorListItem* prev;
+    struct RawstorListItem* next;
 } RawstorListItem;
-
 
 struct RawstorList {
     size_t size;
     size_t object_size;
-    RawstorListItem *head;
-    RawstorListItem *tail;
+    RawstorListItem* head;
+    RawstorListItem* tail;
 };
 
-
 RawstorList* rawstor_list_create(size_t object_size) {
-    RawstorList *list = malloc(sizeof(RawstorList));
+    RawstorList* list = malloc(sizeof(RawstorList));
     if (list == NULL) {
         return NULL;
     }
@@ -40,31 +35,27 @@ RawstorList* rawstor_list_create(size_t object_size) {
     return list;
 }
 
-
-void rawstor_list_delete(RawstorList *list) {
-    RawstorListItem *item = list->head;
+void rawstor_list_delete(RawstorList* list) {
+    RawstorListItem* item = list->head;
     while (item != NULL) {
-        RawstorListItem *next = item->next;
+        RawstorListItem* next = item->next;
         free(item);
         item = next;
     }
     free(list);
 }
 
-
-void* rawstor_list_iter(RawstorList *list) {
+void* rawstor_list_iter(RawstorList* list) {
     return RAWSTOR_LIST_ITEM_TO_ITER(list->head);
 }
 
-
-void* rawstor_list_next(void *iter) {
-    RawstorListItem *item = RAWSTOR_LIST_ITEM_FROM_ITER(iter);
+void* rawstor_list_next(void* iter) {
+    RawstorListItem* item = RAWSTOR_LIST_ITEM_FROM_ITER(iter);
     return RAWSTOR_LIST_ITEM_TO_ITER(item->next);
 }
 
-
-void* rawstor_list_append(RawstorList *list) {
-    RawstorListItem *item = malloc(sizeof(RawstorListItem) + list->object_size);
+void* rawstor_list_append(RawstorList* list) {
+    RawstorListItem* item = malloc(sizeof(RawstorListItem) + list->object_size);
     if (item == NULL) {
         return NULL;
     }
@@ -86,11 +77,10 @@ void* rawstor_list_append(RawstorList *list) {
     return RAWSTOR_LIST_ITEM_TO_ITER(item);
 }
 
-
-void* rawstor_list_remove(RawstorList *list, void *iter) {
-    RawstorListItem *item = RAWSTOR_LIST_ITEM_FROM_ITER(iter);
-    RawstorListItem *next = item->next;
-    RawstorListItem *prev = item->prev;
+void* rawstor_list_remove(RawstorList* list, void* iter) {
+    RawstorListItem* item = RAWSTOR_LIST_ITEM_FROM_ITER(iter);
+    RawstorListItem* next = item->next;
+    RawstorListItem* prev = item->prev;
 
     if (prev != NULL) {
         prev->next = next;
@@ -111,11 +101,10 @@ void* rawstor_list_remove(RawstorList *list, void *iter) {
     return RAWSTOR_LIST_ITEM_TO_ITER(next);
 }
 
-int rawstor_list_empty(RawstorList *list) {
+int rawstor_list_empty(RawstorList* list) {
     return list->size == 0;
 }
 
-
-size_t rawstor_list_size(RawstorList *list) {
+size_t rawstor_list_size(RawstorList* list) {
     return list->size;
 }

--- a/librawstorstd/src/logging.cpp
+++ b/librawstorstd/src/logging.cpp
@@ -13,14 +13,11 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-
-RawstorMutex *rawstor_logging_mutex = NULL;
-
+RawstorMutex* rawstor_logging_mutex = NULL;
 
 #ifdef RAWSTOR_TRACE_EVENTS
 
 namespace {
-
 
 typedef enum {
     EVENT_CREATING,
@@ -30,51 +27,34 @@ typedef enum {
     EVENT_DELETED,
 } EventState;
 
-
 class Event {
-    private:
-        char _appearance;
-        EventState _state;
+private:
+    char _appearance;
+    EventState _state;
 
-    public:
-        explicit Event(char appearance):
-            _appearance(appearance),
-            _state(EVENT_CREATING)
-        {}
+public:
+    explicit Event(char appearance) :
+        _appearance(appearance),
+        _state(EVENT_CREATING) {}
 
-        char appearance() const noexcept {
-            return _appearance;
-        }
+    char appearance() const noexcept { return _appearance; }
 
-        EventState state() const noexcept {
-            return _state;
-        }
+    EventState state() const noexcept { return _state; }
 
-        void deleting() noexcept {
-            _state = EVENT_DELETING;
-        }
+    void deleting() noexcept { _state = EVENT_DELETING; }
 
-        void message() noexcept {
-            _state = EVENT_MESSAGE;
-        }
+    void message() noexcept { _state = EVENT_MESSAGE; }
 
-        void available() noexcept {
-            _state = EVENT_AVAILABLE;
-        }
+    void available() noexcept { _state = EVENT_AVAILABLE; }
 
-        void deleted() noexcept {
-            _state = EVENT_DELETED;
-        }
+    void deleted() noexcept { _state = EVENT_DELETED; }
 };
-
 
 std::vector<Event> events;
 
-
-} // unnamed
+} // namespace
 
 #endif // RAWSTOR_TRACE_EVENTS
-
 
 int rawstor_logging_initialize() {
     rawstor_logging_mutex = rawstor_mutex_create();
@@ -87,24 +67,22 @@ int rawstor_logging_initialize() {
     return 0;
 }
 
-
 void rawstor_logging_terminate(void) {
     rawstor_mutex_delete(rawstor_logging_mutex);
 }
 
-
 #ifdef RAWSTOR_TRACE_EVENTS
 
-
 size_t rawstor_trace_event_begin(
-    char appearance, const char *file, int line, const char *function,
-    const char *format, ...)
-{
+    char appearance, const char* file, int line, const char* function,
+    const char* format, ...
+) {
     rawstor_mutex_lock(rawstor_logging_mutex);
     try {
-        std::vector<Event>::iterator it = std::find_if(
-            events.begin(), events.end(),
-            [](const auto &event){ return event.state() == EVENT_DELETED; });
+        std::vector<Event>::iterator it =
+            std::find_if(events.begin(), events.end(), [](const auto& event) {
+                return event.state() == EVENT_DELETED;
+            });
 
         if (it == events.end()) {
             events.push_back(Event(appearance));
@@ -130,11 +108,10 @@ size_t rawstor_trace_event_begin(
     }
 }
 
-
 void rawstor_trace_event_end(
-    size_t event, const char *file, int line, const char *function,
-    const char *format, ...)
-{
+    size_t event, const char* file, int line, const char* function,
+    const char* format, ...
+) {
     rawstor_mutex_lock(rawstor_logging_mutex);
     try {
         assert(events[event].state() == EVENT_AVAILABLE);
@@ -156,11 +133,10 @@ void rawstor_trace_event_end(
     }
 }
 
-
 void rawstor_trace_event_message(
-    size_t event, const char *file, int line, const char *function,
-    const char *format, ...)
-{
+    size_t event, const char* file, int line, const char* function,
+    const char* format, ...
+) {
     rawstor_mutex_lock(rawstor_logging_mutex);
     try {
         assert(events[event].state() == EVENT_AVAILABLE);
@@ -182,33 +158,31 @@ void rawstor_trace_event_message(
     }
 }
 
-
 void rawstor_trace_event_dump(void) {
-    for (Event &event: events) {
+    for (Event& event : events) {
         char ch = '?';
         switch (event.state()) {
-            case EVENT_CREATING:
-                ch = '+';
-                event.available();
-                break;
-            case EVENT_AVAILABLE:
-                ch = event.appearance();
-                break;
-            case EVENT_MESSAGE:
-                ch = '*';
-                event.available();
-                break;
-            case EVENT_DELETING:
-                ch = '-';
-                event.deleted();
-                break;
-            case EVENT_DELETED:
-                ch = ' ';
-                break;
+        case EVENT_CREATING:
+            ch = '+';
+            event.available();
+            break;
+        case EVENT_AVAILABLE:
+            ch = event.appearance();
+            break;
+        case EVENT_MESSAGE:
+            ch = '*';
+            event.available();
+            break;
+        case EVENT_DELETING:
+            ch = '-';
+            event.deleted();
+            break;
+        case EVENT_DELETED:
+            ch = ' ';
+            break;
         }
         dprintf(STDERR_FILENO, "%c ", ch);
     }
 }
-
 
 #endif // RAWSTOR_TRACE_EVENTS

--- a/librawstorstd/src/mempool.c
+++ b/librawstorstd/src/mempool.c
@@ -4,18 +4,16 @@
 
 #include <stdlib.h>
 
-
 struct RawstorMemPool {
-    void *data;
-    void **head;
-    void **current;
-    void **tail;
+    void* data;
+    void** head;
+    void** current;
+    void** tail;
     size_t object_size;
 };
 
-
 RawstorMemPool* rawstor_mempool_create(size_t capacity, size_t object_size) {
-    RawstorMemPool *mempool = malloc(sizeof(RawstorMemPool));
+    RawstorMemPool* mempool = malloc(sizeof(RawstorMemPool));
     if (mempool == NULL) {
         goto err_mempool;
     }
@@ -48,40 +46,33 @@ err_mempool:
     return NULL;
 }
 
-
-void rawstor_mempool_delete(RawstorMemPool *mempool) {
+void rawstor_mempool_delete(RawstorMemPool* mempool) {
     free(mempool->head);
     free(mempool->data);
     free(mempool);
 }
 
-
-size_t rawstor_mempool_available(RawstorMemPool *mempool) {
+size_t rawstor_mempool_available(RawstorMemPool* mempool) {
     return mempool->tail - mempool->current;
 }
 
-
-size_t rawstor_mempool_allocated(RawstorMemPool *mempool) {
+size_t rawstor_mempool_allocated(RawstorMemPool* mempool) {
     return mempool->current - mempool->head;
 }
 
-
-size_t rawstor_mempool_capacity(RawstorMemPool *mempool) {
+size_t rawstor_mempool_capacity(RawstorMemPool* mempool) {
     return mempool->tail - mempool->head;
 }
 
-
-size_t rawstor_mempool_object_size(RawstorMemPool *mempool) {
+size_t rawstor_mempool_object_size(RawstorMemPool* mempool) {
     return mempool->object_size;
 }
 
-
-void* rawstor_mempool_data(RawstorMemPool *mempool) {
+void* rawstor_mempool_data(RawstorMemPool* mempool) {
     return mempool->data;
 }
 
-
-void* rawstor_mempool_alloc(RawstorMemPool *mempool) {
+void* rawstor_mempool_alloc(RawstorMemPool* mempool) {
     if (mempool->current == mempool->tail) {
         errno = ENOBUFS;
         return NULL;
@@ -89,7 +80,6 @@ void* rawstor_mempool_alloc(RawstorMemPool *mempool) {
     return *(mempool->current++);
 }
 
-
-void rawstor_mempool_free(RawstorMemPool *mempool, void *ptr) {
+void rawstor_mempool_free(RawstorMemPool* mempool, void* ptr) {
     *(--mempool->current) = ptr;
 }

--- a/librawstorstd/src/socket.c
+++ b/librawstorstd/src/socket.c
@@ -6,12 +6,11 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 
-#include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/types.h>
 
 #include <errno.h>
 #include <fcntl.h>
-
 
 static int socket_add_flag(int fd, int flag) {
     int error;
@@ -36,7 +35,6 @@ static int socket_add_flag(int fd, int flag) {
 
     return 0;
 }
-
 
 int rawstor_socket_set_nonblock(int fd) {
     int res = socket_add_flag(fd, O_NONBLOCK);
@@ -64,7 +62,6 @@ int rawstor_socket_set_nodelay(int fd) {
     return 0;
 }
 
-
 int rawstor_socket_set_snd_timeout(int fd, unsigned int timeout) {
     int error;
 
@@ -82,7 +79,6 @@ int rawstor_socket_set_snd_timeout(int fd, unsigned int timeout) {
 
     return 0;
 }
-
 
 int rawstor_socket_set_rcv_timeout(int fd, unsigned int timeout) {
     int error;
@@ -102,39 +98,36 @@ int rawstor_socket_set_rcv_timeout(int fd, unsigned int timeout) {
     return 0;
 }
 
-
 int rawstor_socket_set_user_timeout(int fd, unsigned int timeout) {
     int error;
 
-    #if defined(RAWSTOR_ON_LINUX)
-        if (setsockopt(
-            fd, IPPROTO_TCP, TCP_USER_TIMEOUT,
-            &timeout, sizeof(timeout)))
-        {
-            error = errno;
-            errno = 0;
-            return -error;
-        }
-        rawstor_debug("fd %d: IPPROTO_TCP/TCP_USER_TIMEOUT = %ums\n", fd, timeout);
-    #elif defined(RAWSTOR_ON_MACOS)
-        timeout = (timeout + 999) / 1000;
-        if (setsockopt(
-            fd, IPPROTO_TCP, TCP_CONNECTIONTIMEOUT,
-            &timeout, sizeof(timeout)))
-        {
-            error = errno;
-            errno = 0;
-            return -error;
-        }
-        rawstor_debug(
-            "fd %d: IPPROTO_TCP/TCP_CONNECTIONTIMEOUT = %us\n", fd, timeout);
-    #else
-        #error "Unexpected platform"
-    #endif
+#if defined(RAWSTOR_ON_LINUX)
+    if (setsockopt(
+            fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &timeout, sizeof(timeout)
+        )) {
+        error = errno;
+        errno = 0;
+        return -error;
+    }
+    rawstor_debug("fd %d: IPPROTO_TCP/TCP_USER_TIMEOUT = %ums\n", fd, timeout);
+#elif defined(RAWSTOR_ON_MACOS)
+    timeout = (timeout + 999) / 1000;
+    if (setsockopt(
+            fd, IPPROTO_TCP, TCP_CONNECTIONTIMEOUT, &timeout, sizeof(timeout)
+        )) {
+        error = errno;
+        errno = 0;
+        return -error;
+    }
+    rawstor_debug(
+        "fd %d: IPPROTO_TCP/TCP_CONNECTIONTIMEOUT = %us\n", fd, timeout
+    );
+#else
+#error "Unexpected platform"
+#endif
 
     return 0;
 }
-
 
 int rawstor_socket_set_snd_bufsize(int fd, unsigned int size) {
     int error;
@@ -149,7 +142,6 @@ int rawstor_socket_set_snd_bufsize(int fd, unsigned int size) {
 
     return 0;
 }
-
 
 int rawstor_socket_set_rcv_bufsize(int fd, unsigned int size) {
     int error;

--- a/librawstorstd/src/threading.c
+++ b/librawstorstd/src/threading.c
@@ -7,26 +7,21 @@
 #include <string.h>
 #include <time.h>
 
-
 struct RawstorThread {
     pthread_t pthread;
 };
-
 
 struct RawstorMutex {
     pthread_mutex_t pmutex;
 };
 
-
 struct RawstorCond {
     pthread_cond_t pcond;
 };
 
-
-RawstorThread* rawstor_thread_create(
-    RawstorThreadRoutine *routine, void *data)
-{
-    RawstorThread *ret = malloc(sizeof(RawstorThread));
+RawstorThread*
+rawstor_thread_create(RawstorThreadRoutine* routine, void* data) {
+    RawstorThread* ret = malloc(sizeof(RawstorThread));
     if (ret == NULL) {
         return NULL;
     }
@@ -41,9 +36,8 @@ RawstorThread* rawstor_thread_create(
     return ret;
 }
 
-
-void* rawstor_thread_join(RawstorThread *thread) {
-    void *data;
+void* rawstor_thread_join(RawstorThread* thread) {
+    void* data;
 
     int res = pthread_join(thread->pthread, &data);
     if (res != 0) {
@@ -57,8 +51,7 @@ void* rawstor_thread_join(RawstorThread *thread) {
     return data;
 }
 
-
-void rawstor_thread_detach(RawstorThread *thread) {
+void rawstor_thread_detach(RawstorThread* thread) {
     int res = pthread_detach(thread->pthread);
     if (res != 0) {
         errno = res;
@@ -69,9 +62,8 @@ void rawstor_thread_detach(RawstorThread *thread) {
     free(thread);
 }
 
-
 RawstorMutex* rawstor_mutex_create(void) {
-    RawstorMutex *ret = malloc(sizeof(RawstorMutex));
+    RawstorMutex* ret = malloc(sizeof(RawstorMutex));
     if (ret == NULL) {
         return NULL;
     }
@@ -86,8 +78,7 @@ RawstorMutex* rawstor_mutex_create(void) {
     return ret;
 }
 
-
-void rawstor_mutex_delete(RawstorMutex *mutex) {
+void rawstor_mutex_delete(RawstorMutex* mutex) {
     int res = pthread_mutex_destroy(&mutex->pmutex);
     if (res != 0) {
         errno = res;
@@ -97,7 +88,7 @@ void rawstor_mutex_delete(RawstorMutex *mutex) {
     free(mutex);
 }
 
-void rawstor_mutex_lock(RawstorMutex *mutex) {
+void rawstor_mutex_lock(RawstorMutex* mutex) {
     int res = pthread_mutex_lock(&mutex->pmutex);
     if (res != 0) {
         errno = res;
@@ -106,7 +97,7 @@ void rawstor_mutex_lock(RawstorMutex *mutex) {
     }
 }
 
-void rawstor_mutex_unlock(RawstorMutex *mutex) {
+void rawstor_mutex_unlock(RawstorMutex* mutex) {
     int res = pthread_mutex_unlock(&mutex->pmutex);
     if (res != 0) {
         errno = res;
@@ -115,9 +106,8 @@ void rawstor_mutex_unlock(RawstorMutex *mutex) {
     }
 }
 
-
 RawstorCond* rawstor_cond_create(void) {
-    RawstorCond *ret = malloc(sizeof(RawstorCond));
+    RawstorCond* ret = malloc(sizeof(RawstorCond));
     if (ret == NULL) {
         return NULL;
     }
@@ -132,7 +122,6 @@ RawstorCond* rawstor_cond_create(void) {
     return ret;
 }
 
-
 void rawstor_cond_delete(RawstorCond* cond) {
     int res = pthread_cond_destroy(&cond->pcond);
     if (res != 0) {
@@ -143,8 +132,7 @@ void rawstor_cond_delete(RawstorCond* cond) {
     free(cond);
 }
 
-
-void rawstor_cond_wait(RawstorCond *cond, RawstorMutex *mutex) {
+void rawstor_cond_wait(RawstorCond* cond, RawstorMutex* mutex) {
     int res = pthread_cond_wait(&cond->pcond, &mutex->pmutex);
     if (res != 0) {
         errno = res;
@@ -153,10 +141,9 @@ void rawstor_cond_wait(RawstorCond *cond, RawstorMutex *mutex) {
     }
 }
 
-
 int rawstor_cond_wait_timeout(
-    RawstorCond *cond, RawstorMutex *mutex, int timeout)
-{
+    RawstorCond* cond, RawstorMutex* mutex, int timeout
+) {
     struct timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);
     ts.tv_sec += timeout / 1000;
@@ -177,8 +164,7 @@ int rawstor_cond_wait_timeout(
     return 1;
 }
 
-
-void rawstor_cond_signal(RawstorCond *cond) {
+void rawstor_cond_signal(RawstorCond* cond) {
     int res = pthread_cond_signal(&cond->pcond);
     if (res != 0) {
         errno = res;
@@ -187,8 +173,7 @@ void rawstor_cond_signal(RawstorCond *cond) {
     }
 }
 
-
-void rawstor_cond_broadcast(RawstorCond *cond) {
+void rawstor_cond_broadcast(RawstorCond* cond) {
     int res = pthread_cond_broadcast(&cond->pcond);
     if (res != 0) {
         errno = res;

--- a/librawstorstd/src/uri.cpp
+++ b/librawstorstd/src/uri.cpp
@@ -1,13 +1,12 @@
 #include "rawstorstd/uri.hpp"
 
-#include <string>
 #include <sstream>
+#include <string>
 #include <utility>
 
 namespace {
 
-
-std::string join(const rawstor::URI &parent, const std::string &child) {
+std::string join(const rawstor::URI& parent, const std::string& child) {
     std::string path = parent.str();
     if (path.empty() || path[path.length() - 1] == '/') {
         return path + child;
@@ -15,14 +14,11 @@ std::string join(const rawstor::URI &parent, const std::string &child) {
     return path + '/' + child;
 }
 
-
 void parse_uri(
-    const std::string &uri,
-    std::string *scheme,
-    std::string *username, std::string *password,
-    std::string *hostname, unsigned int *port,
-    std::string *path)
-{
+    const std::string& uri, std::string* scheme, std::string* username,
+    std::string* password, std::string* hostname, unsigned int* port,
+    std::string* path
+) {
     size_t scheme_delim = uri.find("://");
     if (scheme_delim != uri.npos) {
         *scheme = uri.substr(0, scheme_delim);
@@ -38,8 +34,8 @@ void parse_uri(
         size_t colon_delim = uri.find(":", scheme_delim);
         if (colon_delim != uri.npos && colon_delim < at_delim) {
             colon_delim += 1;
-            *username = uri.substr(
-                scheme_delim, colon_delim - scheme_delim - 1);
+            *username =
+                uri.substr(scheme_delim, colon_delim - scheme_delim - 1);
             *password = uri.substr(colon_delim, at_delim - colon_delim - 1);
         } else {
             *username = uri.substr(scheme_delim, at_delim - scheme_delim);
@@ -61,7 +57,8 @@ void parse_uri(
         *hostname = uri.substr(at_delim, colon_delim - at_delim);
         colon_delim += 1;
         std::istringstream iss(
-            uri.substr(colon_delim, path_delim - colon_delim));
+            uri.substr(colon_delim, path_delim - colon_delim)
+        );
         iss >> *port;
     } else {
         *hostname = uri.substr(at_delim, path_delim - at_delim);
@@ -71,10 +68,8 @@ void parse_uri(
     *path = uri.substr(path_delim);
 }
 
-
-std::string get_userinfo(
-    const std::string &username, const std::string &password)
-{
+std::string
+get_userinfo(const std::string& username, const std::string& password) {
     std::ostringstream oss;
 
     oss << username;
@@ -85,10 +80,7 @@ std::string get_userinfo(
     return oss.str();
 }
 
-
-std::string get_host(
-    const std::string &hostname, unsigned int port)
-{
+std::string get_host(const std::string& hostname, unsigned int port) {
     std::ostringstream oss;
 
     oss << hostname;
@@ -99,10 +91,8 @@ std::string get_host(
     return oss.str();
 }
 
-
-std::string get_authority(
-    const std::string &userinfo, const std::string &host)
-{
+std::string
+get_authority(const std::string& userinfo, const std::string& host) {
     std::ostringstream oss;
 
     if (!userinfo.empty()) {
@@ -113,10 +103,9 @@ std::string get_authority(
     return oss.str();
 }
 
-
 void parse_path(
-    const std::string &path, std::string *dirname, std::string *filename)
-{
+    const std::string& path, std::string* dirname, std::string* filename
+) {
     size_t path_delim = path.rfind('/');
     if (path_delim != path.npos) {
         if (path_delim != 0) {
@@ -132,34 +121,27 @@ void parse_path(
     }
 }
 
-
-} // unnamed
+} // namespace
 
 namespace rawstor {
 
-
-URIPath::URIPath(const std::string &path):
-    _path(path)
-{
+URIPath::URIPath(const std::string& path) : _path(path) {
     parse_path(path, &_dirname, &_filename);
 }
 
-
-URIPath::URIPath(const URIPath &other):
+URIPath::URIPath(const URIPath& other) :
     _path(other._path),
     _dirname(other._dirname),
-    _filename(other._filename)
-{}
+    _filename(other._filename) {
+}
 
-
-URIPath::URIPath(URIPath &&other) noexcept:
+URIPath::URIPath(URIPath&& other) noexcept :
     _path(std::move(other._path)),
     _dirname(std::move(other._dirname)),
-    _filename(std::move(other._filename))
-{}
+    _filename(std::move(other._filename)) {
+}
 
-
-URIPath& URIPath::operator=(const URIPath &other) {
+URIPath& URIPath::operator=(const URIPath& other) {
     if (this != &other) {
         URIPath copy(other);
 
@@ -170,8 +152,7 @@ URIPath& URIPath::operator=(const URIPath &other) {
     return *this;
 }
 
-
-URIPath& URIPath::operator=(URIPath &&other) noexcept {
+URIPath& URIPath::operator=(URIPath&& other) noexcept {
     if (this != &other) {
         _path = std::move(other._path);
         _dirname = std::move(other._dirname);
@@ -180,12 +161,11 @@ URIPath& URIPath::operator=(URIPath &&other) noexcept {
     return *this;
 }
 
-
-URI::URI(const std::string &uri):
-    _uri(uri)
-{
+URI::URI(const std::string& uri) : _uri(uri) {
     std::string path;
-    parse_uri(_uri, &_scheme, &_username, &_password, &_hostname, &_port, &path);
+    parse_uri(
+        _uri, &_scheme, &_username, &_password, &_hostname, &_port, &path
+    );
 
     _userinfo = get_userinfo(_username, _password);
     _host = get_host(_hostname, _port);
@@ -193,12 +173,12 @@ URI::URI(const std::string &uri):
     _path = URIPath(path);
 }
 
-
-URI::URI(const URI &parent, const std::string &child):
-    _uri(::join(parent, child))
-{
+URI::URI(const URI& parent, const std::string& child) :
+    _uri(::join(parent, child)) {
     std::string path;
-    parse_uri(_uri, &_scheme, &_username, &_password, &_hostname, &_port, &path);
+    parse_uri(
+        _uri, &_scheme, &_username, &_password, &_hostname, &_port, &path
+    );
 
     _userinfo = get_userinfo(_username, _password);
     _host = get_host(_hostname, _port);
@@ -206,8 +186,7 @@ URI::URI(const URI &parent, const std::string &child):
     _path = URIPath(path);
 }
 
-
-URI::URI(const URI &other):
+URI::URI(const URI& other) :
     _uri(other._uri),
     _scheme(other._scheme),
     _userinfo(other._userinfo),
@@ -217,11 +196,10 @@ URI::URI(const URI &other):
     _host(other._host),
     _hostname(other._hostname),
     _port(other._port),
-    _path(other._path)
-{}
+    _path(other._path) {
+}
 
-
-URI::URI(URI &&other) noexcept:
+URI::URI(URI&& other) noexcept :
     _uri(std::move(other._uri)),
     _scheme(std::move(other._scheme)),
     _userinfo(std::move(other._userinfo)),
@@ -231,11 +209,10 @@ URI::URI(URI &&other) noexcept:
     _host(std::move(other._host)),
     _hostname(std::move(other._hostname)),
     _port(std::exchange(other._port, 0)),
-    _path(std::move(other._path))
-{}
+    _path(std::move(other._path)) {
+}
 
-
-URI& URI::operator=(const URI &other) {
+URI& URI::operator=(const URI& other) {
     if (this != &other) {
         URI copy(other);
 
@@ -253,8 +230,7 @@ URI& URI::operator=(const URI &other) {
     return *this;
 }
 
-
-URI& URI::operator=(URI &&other) noexcept {
+URI& URI::operator=(URI&& other) noexcept {
     if (this != &other) {
         _uri = std::move(other._uri);
         _scheme = std::move(other._scheme);
@@ -270,12 +246,10 @@ URI& URI::operator=(URI &&other) noexcept {
     return *this;
 }
 
-
 URI URI::parent() const {
     std::ostringstream oss;
     oss << _scheme << "://" << _authority << _path.dirname();
     return URI(oss.str());
 }
 
-
-} // rawstor
+} // namespace rawstor

--- a/librawstorstd/src/uuid.c
+++ b/librawstorstd/src/uuid.c
@@ -7,8 +7,7 @@
 #include <stdint.h>
 #include <time.h>
 
-
-static inline uint64_t uuid7_get_timestamp(const struct RawstorUUID *uuid) {
+static inline uint64_t uuid7_get_timestamp(const struct RawstorUUID* uuid) {
     uint64_t ts = 0;
     ts = uuid->bytes[0];
     ts = (ts << 8) | uuid->bytes[1];
@@ -19,8 +18,7 @@ static inline uint64_t uuid7_get_timestamp(const struct RawstorUUID *uuid) {
     return ts;
 }
 
-
-static inline int uuid7_set_timestamp(struct RawstorUUID *uuid, uint64_t ts) {
+static inline int uuid7_set_timestamp(struct RawstorUUID* uuid, uint64_t ts) {
     static const uint64_t MAX_TIMESTAMP = (1ull << 48) - 1;
 
     if (ts > MAX_TIMESTAMP) {
@@ -37,8 +35,7 @@ static inline int uuid7_set_timestamp(struct RawstorUUID *uuid, uint64_t ts) {
     return 0;
 }
 
-
-static inline uint64_t uuid7_get_counter(const struct RawstorUUID *uuid) {
+static inline uint64_t uuid7_get_counter(const struct RawstorUUID* uuid) {
     uint64_t counter = uuid->bytes[6] & 0b00001111;
     counter = (counter << 8) | uuid->bytes[7];
     counter = (counter << 6) | (uuid->bytes[8] & 0b00111111);
@@ -48,10 +45,8 @@ static inline uint64_t uuid7_get_counter(const struct RawstorUUID *uuid) {
     return counter;
 }
 
-
-static inline int uuid7_set_counter(
-    struct RawstorUUID *uuid, uint64_t counter)
-{
+static inline int
+uuid7_set_counter(struct RawstorUUID* uuid, uint64_t counter) {
     static const uint64_t MAX_COUNTER = (1ull << 42) - 1;
 
     if (counter > MAX_COUNTER) {
@@ -61,42 +56,31 @@ static inline int uuid7_set_counter(
     uuid->bytes[6] = (uuid->bytes[6] & 0b11110000) | counter >> 38;
     uuid->bytes[7] = counter >> 30;
     uuid->bytes[8] =
-        (uuid->bytes[8] & 0b11000000)
-        | ((counter >> 24) & 0b00111111);
+        (uuid->bytes[8] & 0b11000000) | ((counter >> 24) & 0b00111111);
     uuid->bytes[9] = counter >> 16;
     uuid->bytes[10] = counter >> 8;
     uuid->bytes[11] = counter;
     return 0;
 }
 
-
-static inline uint8_t uuid_get_version(struct RawstorUUID *uuid) {
+static inline uint8_t uuid_get_version(struct RawstorUUID* uuid) {
     return uuid->bytes[6] >> 4;
 }
 
-
-static inline void uuid_set_version(
-    struct RawstorUUID *uuid, uint8_t version)
-{
+static inline void uuid_set_version(struct RawstorUUID* uuid, uint8_t version) {
     uuid->bytes[6] = (version << 4) | (uuid->bytes[6] & 0b00001111);
 }
 
-
-static inline uint8_t uuid_get_variant(struct RawstorUUID *uuid) {
+static inline uint8_t uuid_get_variant(struct RawstorUUID* uuid) {
     return uuid->bytes[8] >> 6;
 }
 
-
-static inline void uuid_set_variant(
-    struct RawstorUUID *uuid, uint8_t variant)
-{
+static inline void uuid_set_variant(struct RawstorUUID* uuid, uint8_t variant) {
     uuid->bytes[8] = (variant << 6) | (uuid->bytes[8] & 0b00111111);
 }
 
-
-static inline int uuid_add_entropy(
-    struct RawstorUUID *uuid, unsigned int size)
-{
+static inline int
+uuid_add_entropy(struct RawstorUUID* uuid, unsigned int size) {
     int error;
 
     if (getentropy(&uuid->bytes[16 - size], size) == -1) {
@@ -108,47 +92,39 @@ static inline int uuid_add_entropy(
     return 0;
 }
 
-
-uint64_t rawstor_uuid7_get_timestamp(const struct RawstorUUID *uuid) {
+uint64_t rawstor_uuid7_get_timestamp(const struct RawstorUUID* uuid) {
     return uuid7_get_timestamp(uuid);
 }
 
-
-int rawstor_uuid7_set_timestamp(struct RawstorUUID *uuid, uint64_t ts) {
+int rawstor_uuid7_set_timestamp(struct RawstorUUID* uuid, uint64_t ts) {
     return uuid7_set_timestamp(uuid, ts);
 }
 
-
-uint64_t rawstor_uuid7_get_counter(const struct RawstorUUID *uuid) {
+uint64_t rawstor_uuid7_get_counter(const struct RawstorUUID* uuid) {
     return uuid7_get_counter(uuid);
 }
 
-
-int rawstor_uuid7_set_counter(struct RawstorUUID *uuid, uint64_t counter) {
+int rawstor_uuid7_set_counter(struct RawstorUUID* uuid, uint64_t counter) {
     return uuid7_set_counter(uuid, counter);
 }
 
-uint8_t rawstor_uuid_get_version(struct RawstorUUID *uuid) {
+uint8_t rawstor_uuid_get_version(struct RawstorUUID* uuid) {
     return uuid_get_version(uuid);
 }
 
-
-void rawstor_uuid_set_version(struct RawstorUUID *uuid, uint8_t version) {
+void rawstor_uuid_set_version(struct RawstorUUID* uuid, uint8_t version) {
     return uuid_set_version(uuid, version);
 }
 
-
-uint8_t rawstor_uuid_get_variant(struct RawstorUUID *uuid) {
+uint8_t rawstor_uuid_get_variant(struct RawstorUUID* uuid) {
     return uuid_get_variant(uuid);
 }
 
-
-void rawstor_uuid_set_variant(struct RawstorUUID *uuid, uint8_t variant) {
+void rawstor_uuid_set_variant(struct RawstorUUID* uuid, uint8_t variant) {
     uuid_set_variant(uuid, variant);
 }
 
-
-int rawstor_uuid7_init(struct RawstorUUID *uuid) {
+int rawstor_uuid7_init(struct RawstorUUID* uuid) {
     int res;
 
     static struct RawstorUUID prev_uuid = {0};
@@ -195,17 +171,15 @@ int rawstor_uuid7_init(struct RawstorUUID *uuid) {
     return 0;
 }
 
-
-int rawstor_uuid_from_string(struct RawstorUUID *uuid, const char *s) {
-    const char *p = s;
+int rawstor_uuid_from_string(struct RawstorUUID* uuid, const char* s) {
+    const char* p = s;
     for (int i = 0; i < 32; i++) {
         char c = *p++;
 
-        uint8_t x =
-            (c >= '0' && c <= '9') ? c - '0'
-            : (c >= 'a' && c <= 'f') ? 10 + c - 'a'
-            : (c >= 'A' && c <= 'F') ? 10 + c - 'A'
-            : 0xff;
+        uint8_t x = (c >= '0' && c <= '9')   ? c - '0'
+                    : (c >= 'a' && c <= 'f') ? 10 + c - 'a'
+                    : (c >= 'A' && c <= 'F') ? 10 + c - 'A'
+                                             : 0xff;
 
         if (x == 0xff) {
             return -EINVAL;
@@ -224,19 +198,18 @@ int rawstor_uuid_from_string(struct RawstorUUID *uuid, const char *s) {
     return 0;
 }
 
-
 void rawstor_uuid_to_string(
-    const struct RawstorUUID *uuid, RawstorUUIDString *s)
-{
+    const struct RawstorUUID* uuid, RawstorUUIDString* s
+) {
     static const char alphabet[] = "0123456789abcdef";
-    char *p = *s;
+    char* p = *s;
     for (int i = 0; i < 16; ++i) {
-      uint_fast8_t e = uuid->bytes[i];
-      *p++ = alphabet[e >> 4];
-      *p++ = alphabet[e & 0b00001111];
-      if (i == 3 || i == 5 || i == 7 || i == 9) {
-        *p++ = '-';
-      }
+        uint_fast8_t e = uuid->bytes[i];
+        *p++ = alphabet[e >> 4];
+        *p++ = alphabet[e & 0b00001111];
+        if (i == 3 || i == 5 || i == 7 || i == 9) {
+            *p++ = '-';
+        }
     }
     *p = '\0';
 }

--- a/librawstorstd/src/uuid_internals.h
+++ b/librawstorstd/src/uuid_internals.h
@@ -1,37 +1,32 @@
 #ifndef RAWSTOR_UUID_STD_INTERNALS_H
 #define RAWSTOR_UUID_STD_INTERNALS_H
 
-
 #include "rawstorstd/uuid.h"
 
 #include <stdint.h>
-
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+uint64_t rawstor_uuid7_get_timestamp(const struct RawstorUUID* uuid);
 
-uint64_t rawstor_uuid7_get_timestamp(const struct RawstorUUID *uuid);
+int rawstor_uuid7_set_timestamp(struct RawstorUUID* uuid, uint64_t ts);
 
-int rawstor_uuid7_set_timestamp(struct RawstorUUID *uuid, uint64_t ts);
+uint64_t rawstor_uuid7_get_counter(const struct RawstorUUID* uuid);
 
-uint64_t rawstor_uuid7_get_counter(const struct RawstorUUID *uuid);
+int rawstor_uuid7_set_counter(struct RawstorUUID* uuid, uint64_t counter);
 
-int rawstor_uuid7_set_counter(struct RawstorUUID *uuid, uint64_t counter);
+uint8_t rawstor_uuid_get_version(struct RawstorUUID* uuid);
 
-uint8_t rawstor_uuid_get_version(struct RawstorUUID *uuid);
+void rawstor_uuid_set_version(struct RawstorUUID* uuid, uint8_t version);
 
-void rawstor_uuid_set_version(struct RawstorUUID *uuid, uint8_t version);
+uint8_t rawstor_uuid_get_variant(struct RawstorUUID* uuid);
 
-uint8_t rawstor_uuid_get_variant(struct RawstorUUID *uuid);
-
-void rawstor_uuid_set_variant(struct RawstorUUID *uuid, uint8_t variant);
-
+void rawstor_uuid_set_variant(struct RawstorUUID* uuid, uint8_t variant);
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // RAWSTOR_UUID_STD_INTERNALS_H

--- a/librawstorstd/tests/test_hash.c
+++ b/librawstorstd/tests/test_hash.c
@@ -4,13 +4,12 @@
 
 #include "unittest.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
-
 
 static int test_hash_scalar() {
-    const char *buf = "hello world";
+    const char* buf = "hello world";
     uint64_t hash = rawstor_hash_scalar((void*)buf, strlen(buf));
 #ifdef RAWSTOR_WITH_LIBXXHASH
     assertTrue(hash == 0xd447b1ea40e6988b);
@@ -20,18 +19,17 @@ static int test_hash_scalar() {
     return 0;
 }
 
-
 static int test_hash_vector() {
     struct iovec iov[] = {
-        (struct iovec) {
+        (struct iovec){
             .iov_base = "hello",
             .iov_len = strlen("hello"),
         },
-        (struct iovec) {
+        (struct iovec){
             .iov_base = " ",
             .iov_len = strlen(" "),
         },
-        (struct iovec) {
+        (struct iovec){
             .iov_base = "world",
             .iov_len = strlen("world"),
         }
@@ -46,7 +44,6 @@ static int test_hash_vector() {
 #endif
     return 0;
 }
-
 
 int main() {
     int rval = 0;

--- a/librawstorstd/tests/test_iovec.c
+++ b/librawstorstd/tests/test_iovec.c
@@ -7,24 +7,23 @@
 #include <stdlib.h>
 #include <string.h>
 
-
 static int test_discard_front_unaligned() {
     char data[] = "1234567890";
     struct iovec v[3];
-    v[0] = (struct iovec) {
+    v[0] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[1] = (struct iovec) {
+    v[1] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[2] = (struct iovec) {
+    v[2] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
 
-    struct iovec *iov_at = v;
+    struct iovec* iov_at = v;
     unsigned int niov_at = 3;
 
     size_t size = rawstor_iovec_discard_front(&iov_at, &niov_at, 12);
@@ -36,24 +35,23 @@ static int test_discard_front_unaligned() {
     return 0;
 }
 
-
 static int test_discard_front_aligned() {
     char data[] = "1234567890";
     struct iovec v[3];
-    v[0] = (struct iovec) {
+    v[0] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[1] = (struct iovec) {
+    v[1] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[2] = (struct iovec) {
+    v[2] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
 
-    struct iovec *iov_at = v;
+    struct iovec* iov_at = v;
     unsigned int niov_at = 3;
 
     size_t size = rawstor_iovec_discard_front(&iov_at, &niov_at, 10);
@@ -65,24 +63,23 @@ static int test_discard_front_aligned() {
     return 0;
 }
 
-
 static int test_discard_front_all() {
     char data[] = "1234567890";
     struct iovec v[3];
-    v[0] = (struct iovec) {
+    v[0] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[1] = (struct iovec) {
+    v[1] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[2] = (struct iovec) {
+    v[2] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
 
-    struct iovec *iov_at = v;
+    struct iovec* iov_at = v;
     unsigned int niov_at = 3;
 
     size_t size = rawstor_iovec_discard_front(&iov_at, &niov_at, 30);
@@ -92,24 +89,23 @@ static int test_discard_front_all() {
     return 0;
 }
 
-
 static int test_discard_front_overflow() {
     char data[] = "1234567890";
     struct iovec v[3];
-    v[0] = (struct iovec) {
+    v[0] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[1] = (struct iovec) {
+    v[1] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[2] = (struct iovec) {
+    v[2] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
 
-    struct iovec *iov_at = v;
+    struct iovec* iov_at = v;
     unsigned int niov_at = 3;
 
     size_t size = rawstor_iovec_discard_front(&iov_at, &niov_at, 35);
@@ -119,24 +115,23 @@ static int test_discard_front_overflow() {
     return 0;
 }
 
-
 static int test_discard_back_unaligned() {
     char data[] = "1234567890";
     struct iovec v[3];
-    v[0] = (struct iovec) {
+    v[0] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[1] = (struct iovec) {
+    v[1] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[2] = (struct iovec) {
+    v[2] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
 
-    struct iovec *iov_at = v;
+    struct iovec* iov_at = v;
     unsigned int niov_at = 3;
 
     size_t size = rawstor_iovec_discard_back(&iov_at, &niov_at, 12);
@@ -148,24 +143,23 @@ static int test_discard_back_unaligned() {
     return 0;
 }
 
-
 static int test_discard_back_aligned() {
     char data[] = "1234567890";
     struct iovec v[3];
-    v[0] = (struct iovec) {
+    v[0] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[1] = (struct iovec) {
+    v[1] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[2] = (struct iovec) {
+    v[2] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
 
-    struct iovec *iov_at = v;
+    struct iovec* iov_at = v;
     unsigned int niov_at = 3;
 
     size_t size = rawstor_iovec_discard_back(&iov_at, &niov_at, 10);
@@ -177,24 +171,23 @@ static int test_discard_back_aligned() {
     return 0;
 }
 
-
 static int test_discard_back_all() {
     char data[] = "1234567890";
     struct iovec v[3];
-    v[0] = (struct iovec) {
+    v[0] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[1] = (struct iovec) {
+    v[1] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[2] = (struct iovec) {
+    v[2] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
 
-    struct iovec *iov_at = v;
+    struct iovec* iov_at = v;
     unsigned int niov_at = 3;
 
     size_t size = rawstor_iovec_discard_back(&iov_at, &niov_at, 30);
@@ -204,24 +197,23 @@ static int test_discard_back_all() {
     return 0;
 }
 
-
 static int test_discard_back_overflow() {
     char data[] = "1234567890";
     struct iovec v[3];
-    v[0] = (struct iovec) {
+    v[0] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[1] = (struct iovec) {
+    v[1] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[2] = (struct iovec) {
+    v[2] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
 
-    struct iovec *iov_at = v;
+    struct iovec* iov_at = v;
     unsigned int niov_at = 3;
 
     size_t size = rawstor_iovec_discard_back(&iov_at, &niov_at, 35);
@@ -231,21 +223,20 @@ static int test_discard_back_overflow() {
     return 0;
 }
 
-
 static int test_from_buf_unaligned() {
     struct iovec v[3];
     char data0[] = "          ";
-    v[0] = (struct iovec) {
+    v[0] = (struct iovec){
         .iov_base = data0,
         .iov_len = sizeof(data0) - 1,
     };
     char data1[] = "          ";
-    v[1] = (struct iovec) {
+    v[1] = (struct iovec){
         .iov_base = data1,
         .iov_len = sizeof(data1) - 1,
     };
     char data2[] = "          ";
-    v[2] = (struct iovec) {
+    v[2] = (struct iovec){
         .iov_base = data2,
         .iov_len = sizeof(data2) - 1,
     };
@@ -261,21 +252,20 @@ static int test_from_buf_unaligned() {
     return 0;
 }
 
-
 static int test_from_buf_aligned() {
     struct iovec v[3];
     char data0[] = "          ";
-    v[0] = (struct iovec) {
+    v[0] = (struct iovec){
         .iov_base = data0,
         .iov_len = sizeof(data0) - 1,
     };
     char data1[] = "          ";
-    v[1] = (struct iovec) {
+    v[1] = (struct iovec){
         .iov_base = data1,
         .iov_len = sizeof(data1) - 1,
     };
     char data2[] = "          ";
-    v[2] = (struct iovec) {
+    v[2] = (struct iovec){
         .iov_base = data2,
         .iov_len = sizeof(data2) - 1,
     };
@@ -291,21 +281,20 @@ static int test_from_buf_aligned() {
     return 0;
 }
 
-
 static int test_from_buf_all() {
     struct iovec v[3];
     char data0[] = "          ";
-    v[0] = (struct iovec) {
+    v[0] = (struct iovec){
         .iov_base = data0,
         .iov_len = sizeof(data0) - 1,
     };
     char data1[] = "          ";
-    v[1] = (struct iovec) {
+    v[1] = (struct iovec){
         .iov_base = data1,
         .iov_len = sizeof(data1) - 1,
     };
     char data2[] = "          ";
-    v[2] = (struct iovec) {
+    v[2] = (struct iovec){
         .iov_base = data2,
         .iov_len = sizeof(data2) - 1,
     };
@@ -321,21 +310,20 @@ static int test_from_buf_all() {
     return 0;
 }
 
-
 static int test_from_buf_overflow() {
     struct iovec v[3];
     char data0[] = "          ";
-    v[0] = (struct iovec) {
+    v[0] = (struct iovec){
         .iov_base = data0,
         .iov_len = sizeof(data0) - 1,
     };
     char data1[] = "          ";
-    v[1] = (struct iovec) {
+    v[1] = (struct iovec){
         .iov_base = data1,
         .iov_len = sizeof(data1) - 1,
     };
     char data2[] = "          ";
-    v[2] = (struct iovec) {
+    v[2] = (struct iovec){
         .iov_base = data2,
         .iov_len = sizeof(data2) - 1,
     };
@@ -351,19 +339,18 @@ static int test_from_buf_overflow() {
     return 0;
 }
 
-
 static int test_to_buf_unaligned() {
     char data[] = "1234567890";
     struct iovec v[3];
-    v[0] = (struct iovec) {
+    v[0] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[1] = (struct iovec) {
+    v[1] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[2] = (struct iovec) {
+    v[2] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
@@ -381,19 +368,18 @@ static int test_to_buf_unaligned() {
     return 0;
 }
 
-
 static int test_to_buf_aligned() {
     char data[] = "1234567890";
     struct iovec v[3];
-    v[0] = (struct iovec) {
+    v[0] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[1] = (struct iovec) {
+    v[1] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[2] = (struct iovec) {
+    v[2] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
@@ -412,19 +398,18 @@ static int test_to_buf_aligned() {
     return 0;
 }
 
-
 static int test_to_buf_all() {
     char data[] = "1234567890";
     struct iovec v[3];
-    v[0] = (struct iovec) {
+    v[0] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[1] = (struct iovec) {
+    v[1] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[2] = (struct iovec) {
+    v[2] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
@@ -443,19 +428,18 @@ static int test_to_buf_all() {
     return 0;
 }
 
-
 static int test_to_buf_overflow() {
     char data[] = "1234567890";
     struct iovec v[3];
-    v[0] = (struct iovec) {
+    v[0] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[1] = (struct iovec) {
+    v[1] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[2] = (struct iovec) {
+    v[2] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
@@ -474,19 +458,18 @@ static int test_to_buf_overflow() {
     return 0;
 }
 
-
 static int test_size() {
     char data[] = "1234567890";
     struct iovec v[3];
-    v[0] = (struct iovec) {
+    v[0] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[1] = (struct iovec) {
+    v[1] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
-    v[2] = (struct iovec) {
+    v[2] = (struct iovec){
         .iov_base = data,
         .iov_len = sizeof(data) - 1,
     };
@@ -495,7 +478,6 @@ static int test_size() {
 
     return 0;
 }
-
 
 int main() {
     int rval = 0;

--- a/librawstorstd/tests/test_list.c
+++ b/librawstorstd/tests/test_list.c
@@ -5,11 +5,10 @@
 #include <stddef.h>
 #include <stdlib.h>
 
-
 static int test_list_empty() {
-    RawstorList *l = rawstor_list_create(sizeof(int));
+    RawstorList* l = rawstor_list_create(sizeof(int));
 
-    void *it = rawstor_list_iter(l);
+    void* it = rawstor_list_iter(l);
     assertTrue(it == NULL);
 
     assertTrue(rawstor_list_empty(l) != 0);
@@ -20,10 +19,9 @@ static int test_list_empty() {
     return 0;
 }
 
-
 static int test_list_append() {
-    int *it;
-    RawstorList *l = rawstor_list_create(sizeof(int));
+    int* it;
+    RawstorList* l = rawstor_list_create(sizeof(int));
 
     it = rawstor_list_append(l);
     assertTrue(it != NULL);
@@ -41,10 +39,9 @@ static int test_list_append() {
     return 0;
 }
 
-
 static int test_list_iter() {
-    int *it;
-    RawstorList *l = rawstor_list_create(sizeof(int));
+    int* it;
+    RawstorList* l = rawstor_list_create(sizeof(int));
 
     it = rawstor_list_append(l);
     assertTrue(it != NULL);
@@ -77,11 +74,10 @@ static int test_list_iter() {
 
     return 0;
 }
-
 
 static int test_list_remove() {
-    int *it;
-    RawstorList *l = rawstor_list_create(sizeof(int));
+    int* it;
+    RawstorList* l = rawstor_list_create(sizeof(int));
 
     it = rawstor_list_append(l);
     assertTrue(it != NULL);
@@ -115,10 +111,9 @@ static int test_list_remove() {
     return 0;
 }
 
-
 static int test_list_remove_first() {
-    int *it;
-    RawstorList *l = rawstor_list_create(sizeof(int));
+    int* it;
+    RawstorList* l = rawstor_list_create(sizeof(int));
 
     it = rawstor_list_append(l);
     assertTrue(it != NULL);
@@ -146,11 +141,10 @@ static int test_list_remove_first() {
 
     return 0;
 }
-
 
 static int test_list_remove_last() {
-    int *it;
-    RawstorList *l = rawstor_list_create(sizeof(int));
+    int* it;
+    RawstorList* l = rawstor_list_create(sizeof(int));
 
     it = rawstor_list_append(l);
     assertTrue(it != NULL);
@@ -183,10 +177,9 @@ static int test_list_remove_last() {
     return 0;
 }
 
-
 static int test_list_size() {
-    int *it;
-    RawstorList *l = rawstor_list_create(sizeof(int));
+    int* it;
+    RawstorList* l = rawstor_list_create(sizeof(int));
 
     assertTrue(rawstor_list_size(l) == 0);
 
@@ -226,7 +219,6 @@ static int test_list_size() {
 
     return 0;
 }
-
 
 int main() {
     int rval = 0;

--- a/librawstorstd/tests/test_mempool.c
+++ b/librawstorstd/tests/test_mempool.c
@@ -5,26 +5,24 @@
 #include <errno.h>
 #include <stdlib.h>
 
-
 struct MemPoolTest {
     int i1;
     int i2;
 };
 
-
 static int test_mempool_alloc() {
-    RawstorMemPool *p = rawstor_mempool_create(3, sizeof(int));
+    RawstorMemPool* p = rawstor_mempool_create(3, sizeof(int));
     assertTrue(p != NULL);
 
-    int *v1 = rawstor_mempool_alloc(p);
+    int* v1 = rawstor_mempool_alloc(p);
     assertTrue(v1 != NULL);
     *v1 = 1;
 
-    int *v2 = rawstor_mempool_alloc(p);
+    int* v2 = rawstor_mempool_alloc(p);
     assertTrue(v2 != NULL);
     *v2 = 2;
 
-    int *v3 = rawstor_mempool_alloc(p);
+    int* v3 = rawstor_mempool_alloc(p);
     assertTrue(v3 != NULL);
     *v3 = 3;
 
@@ -37,21 +35,20 @@ static int test_mempool_alloc() {
     return 0;
 }
 
-
 static int test_mempool_free() {
-    RawstorMemPool *p = rawstor_mempool_create(3, sizeof(int));
+    RawstorMemPool* p = rawstor_mempool_create(3, sizeof(int));
     assertTrue(p != NULL);
 
     rawstor_mempool_alloc(p);
 
     rawstor_mempool_alloc(p);
 
-    int *v3 = rawstor_mempool_alloc(p);
+    int* v3 = rawstor_mempool_alloc(p);
     assertTrue(v3 != NULL);
 
     rawstor_mempool_free(p, v3);
 
-    int *v3a = rawstor_mempool_alloc(p);
+    int* v3a = rawstor_mempool_alloc(p);
     assertTrue(v3a != NULL);
     assertTrue(v3a == v3);
 
@@ -60,9 +57,8 @@ static int test_mempool_free() {
     return 0;
 }
 
-
 static int test_mempool_create() {
-    RawstorMemPool *p = rawstor_mempool_create(3, sizeof(int));
+    RawstorMemPool* p = rawstor_mempool_create(3, sizeof(int));
     assertTrue(p != NULL);
 
     assertTrue(rawstor_mempool_capacity(p) == 3);
@@ -74,24 +70,23 @@ static int test_mempool_create() {
     return 0;
 }
 
-
 static int test_mempool_data() {
-    RawstorMemPool *p = rawstor_mempool_create(3, sizeof(int));
+    RawstorMemPool* p = rawstor_mempool_create(3, sizeof(int));
     assertTrue(p != NULL);
 
-    int *v1 = rawstor_mempool_alloc(p);
+    int* v1 = rawstor_mempool_alloc(p);
     assertTrue(v1 != NULL);
     *v1 = 1;
 
-    int *v2 = rawstor_mempool_alloc(p);
+    int* v2 = rawstor_mempool_alloc(p);
     assertTrue(v2 != NULL);
     *v2 = 2;
 
-    int *v3 = rawstor_mempool_alloc(p);
+    int* v3 = rawstor_mempool_alloc(p);
     assertTrue(v3 != NULL);
     *v3 = 3;
 
-    int *data = rawstor_mempool_data(p);
+    int* data = rawstor_mempool_data(p);
     assertTrue(data[0] == 1);
     assertTrue(data[1] == 2);
     assertTrue(data[2] == 3);
@@ -101,31 +96,30 @@ static int test_mempool_data() {
     return 0;
 }
 
-
 static int test_mempool_order() {
-    RawstorMemPool *p = rawstor_mempool_create(3, sizeof(int));
+    RawstorMemPool* p = rawstor_mempool_create(3, sizeof(int));
     assertTrue(p != NULL);
 
-    int *v1 = rawstor_mempool_alloc(p);
+    int* v1 = rawstor_mempool_alloc(p);
     assertTrue(v1 != NULL);
-    int *v2 = rawstor_mempool_alloc(p);
+    int* v2 = rawstor_mempool_alloc(p);
     assertTrue(v2 != NULL);
-    int *v3 = rawstor_mempool_alloc(p);
+    int* v3 = rawstor_mempool_alloc(p);
     assertTrue(v3 != NULL);
 
     rawstor_mempool_free(p, v2);
     rawstor_mempool_free(p, v3);
     rawstor_mempool_free(p, v1);
 
-    int *v1a = rawstor_mempool_alloc(p);
+    int* v1a = rawstor_mempool_alloc(p);
     assertTrue(v1a != NULL);
     assertTrue(v1a == v1);
 
-    int *v3a = rawstor_mempool_alloc(p);
+    int* v3a = rawstor_mempool_alloc(p);
     assertTrue(v3a != NULL);
     assertTrue(v3a == v3);
 
-    int *v2a = rawstor_mempool_alloc(p);
+    int* v2a = rawstor_mempool_alloc(p);
     assertTrue(v2a != NULL);
     assertTrue(v2a == v2);
 
@@ -134,25 +128,24 @@ static int test_mempool_order() {
     return 0;
 }
 
-
 static int test_mempool_counters() {
-    RawstorMemPool *p = rawstor_mempool_create(3, sizeof(struct MemPoolTest));
+    RawstorMemPool* p = rawstor_mempool_create(3, sizeof(struct MemPoolTest));
     assertTrue(p != NULL);
 
     assertTrue(rawstor_mempool_available(p) == 3);
     assertTrue(rawstor_mempool_allocated(p) == 0);
 
-    struct MemPoolTest *v1 = rawstor_mempool_alloc(p);
+    struct MemPoolTest* v1 = rawstor_mempool_alloc(p);
     assertTrue(v1 != NULL);
     assertTrue(rawstor_mempool_available(p) == 2);
     assertTrue(rawstor_mempool_allocated(p) == 1);
 
-    struct MemPoolTest *v2 = rawstor_mempool_alloc(p);
+    struct MemPoolTest* v2 = rawstor_mempool_alloc(p);
     assertTrue(v2 != NULL);
     assertTrue(rawstor_mempool_available(p) == 1);
     assertTrue(rawstor_mempool_allocated(p) == 2);
 
-    struct MemPoolTest *v3 = rawstor_mempool_alloc(p);
+    struct MemPoolTest* v3 = rawstor_mempool_alloc(p);
     assertTrue(v3 != NULL);
     assertTrue(rawstor_mempool_available(p) == 0);
     assertTrue(rawstor_mempool_allocated(p) == 3);
@@ -174,18 +167,17 @@ static int test_mempool_counters() {
     return 0;
 }
 
-
 static int test_mempool_overflow() {
-    RawstorMemPool *p = rawstor_mempool_create(3, sizeof(int));
+    RawstorMemPool* p = rawstor_mempool_create(3, sizeof(int));
     assertTrue(p != NULL);
 
-    int *v1 = rawstor_mempool_alloc(p);
+    int* v1 = rawstor_mempool_alloc(p);
     assertTrue(v1 != NULL);
-    int *v2 = rawstor_mempool_alloc(p);
+    int* v2 = rawstor_mempool_alloc(p);
     assertTrue(v2 != NULL);
-    int *v3 = rawstor_mempool_alloc(p);
+    int* v3 = rawstor_mempool_alloc(p);
     assertTrue(v3 != NULL);
-    int *v4 = rawstor_mempool_alloc(p);
+    int* v4 = rawstor_mempool_alloc(p);
     assertTrue(v4 == NULL);
     assertTrue(errno == ENOBUFS);
 
@@ -193,7 +185,6 @@ static int test_mempool_overflow() {
 
     return 0;
 }
-
 
 int main() {
     int rval = 0;

--- a/librawstorstd/tests/test_ringbuf.cpp
+++ b/librawstorstd/tests/test_ringbuf.cpp
@@ -7,12 +7,10 @@
 #include <stdexcept>
 
 #include <cerrno>
-#include <cstdlib>
 #include <cstdio>
-
+#include <cstdlib>
 
 namespace {
-
 
 int test_ringbuf_empty() {
     rawstor::RingBuf<int> buf(3);
@@ -27,7 +25,6 @@ int test_ringbuf_empty() {
     return 0;
 }
 
-
 int test_ringbuf_invalid() {
     rawstor::RingBuf<int> buf(0);
 
@@ -41,7 +38,6 @@ int test_ringbuf_invalid() {
 
     return 0;
 }
-
 
 int test_ringbuf_basics() {
     rawstor::RingBuf<int> buf(3);
@@ -114,7 +110,6 @@ int test_ringbuf_basics() {
     return 0;
 }
 
-
 int test_ringbuf_overlap() {
     rawstor::RingBuf<int> buf(4);
 
@@ -153,9 +148,7 @@ int test_ringbuf_overlap() {
     return 0;
 }
 
-
 } // unnamed namespace
-
 
 int main() {
     int rval = 0;

--- a/librawstorstd/tests/test_threading.c
+++ b/librawstorstd/tests/test_threading.c
@@ -8,18 +8,16 @@
 #include <time.h>
 #include <unistd.h>
 
-
 struct TestThreadingContext {
-    RawstorMutex *mutex;
-    RawstorCond *cond;
+    RawstorMutex* mutex;
+    RawstorCond* cond;
 
     int wait;
     int value;
 };
 
-
-static void* test_thread(void *data) {
-    struct TestThreadingContext *context = data;
+static void* test_thread(void* data) {
+    struct TestThreadingContext* context = data;
 
     rawstor_mutex_lock(context->mutex);
     ++context->wait;
@@ -31,9 +29,8 @@ static void* test_thread(void *data) {
     return context;
 }
 
-
 static int test_cond_signal() {
-    struct TestThreadingContext context = (struct TestThreadingContext) {
+    struct TestThreadingContext context = (struct TestThreadingContext){
         .mutex = rawstor_mutex_create(),
         .cond = rawstor_cond_create(),
         .wait = 0,
@@ -43,7 +40,7 @@ static int test_cond_signal() {
     assertTrue(context.mutex != NULL);
     assertTrue(context.cond != NULL);
 
-    RawstorThread *thread = rawstor_thread_create(test_thread, &context);
+    RawstorThread* thread = rawstor_thread_create(test_thread, &context);
 
     while (1) {
         rawstor_mutex_lock(context.mutex);
@@ -59,7 +56,7 @@ static int test_cond_signal() {
     rawstor_cond_signal(context.cond);
     rawstor_mutex_unlock(context.mutex);
 
-    void *data = rawstor_thread_join(thread);
+    void* data = rawstor_thread_join(thread);
     assertTrue(data == &context);
 
     assertTrue(context.value == 1);
@@ -70,11 +67,10 @@ static int test_cond_signal() {
     return 0;
 }
 
-
 static int test_cond_broadcast() {
     int count = 10;
 
-    struct TestThreadingContext context = (struct TestThreadingContext) {
+    struct TestThreadingContext context = (struct TestThreadingContext){
         .mutex = rawstor_mutex_create(),
         .cond = rawstor_cond_create(),
         .wait = 0,
@@ -84,7 +80,7 @@ static int test_cond_broadcast() {
     assertTrue(context.mutex != NULL);
     assertTrue(context.cond != NULL);
 
-    RawstorThread **threads = calloc(count, sizeof(RawstorThread*));
+    RawstorThread** threads = calloc(count, sizeof(RawstorThread*));
     assertTrue(threads != NULL);
 
     for (int i = 0; i < count; ++i) {
@@ -117,12 +113,11 @@ static int test_cond_broadcast() {
     return 0;
 }
 
+static void* test_wait_thread(void* data) {
+    int* timeout = data;
 
-static void* test_wait_thread(void *data) {
-    int *timeout = data;
-
-    RawstorMutex *mutex = rawstor_mutex_create();
-    RawstorCond *cond = rawstor_cond_create();
+    RawstorMutex* mutex = rawstor_mutex_create();
+    RawstorCond* cond = rawstor_cond_create();
 
     assert(mutex != NULL);
     assert(cond != NULL);
@@ -137,14 +132,13 @@ static void* test_wait_thread(void *data) {
     return NULL;
 }
 
-
 static int test_cond_wait_timeout() {
     static int timeout = 100;
 
     struct timespec ts_start;
     clock_gettime(CLOCK_MONOTONIC, &ts_start);
 
-    RawstorThread *thread = rawstor_thread_create(test_wait_thread, &timeout);
+    RawstorThread* thread = rawstor_thread_create(test_wait_thread, &timeout);
     assertTrue(thread != NULL);
     rawstor_thread_join(thread);
 
@@ -163,7 +157,6 @@ static int test_cond_wait_timeout() {
 
     return 0;
 }
-
 
 int main() {
     int rval = 0;

--- a/librawstorstd/tests/test_uri.cpp
+++ b/librawstorstd/tests/test_uri.cpp
@@ -2,9 +2,7 @@
 
 #include "unittest.h"
 
-
 namespace {
-
 
 int test_uri_empty() {
     rawstor::URI uri("");
@@ -25,7 +23,6 @@ int test_uri_empty() {
     return 0;
 }
 
-
 int test_uri_http() {
     rawstor::URI uri("http://user:password@example.com:80/foo");
 
@@ -44,7 +41,6 @@ int test_uri_http() {
 
     return 0;
 }
-
 
 int test_uri_file() {
     rawstor::URI uri("file:///tmp/foo");
@@ -65,7 +61,6 @@ int test_uri_file() {
     return 0;
 }
 
-
 int test_uri_empty_path() {
     rawstor::URI uri("ost://127.0.0.1:8080");
 
@@ -84,7 +79,6 @@ int test_uri_empty_path() {
 
     return 0;
 }
-
 
 int test_uri_with_uuid() {
     rawstor::URI uri("file:///tmp/objects/uuid");
@@ -105,7 +99,6 @@ int test_uri_with_uuid() {
     return 0;
 }
 
-
 int test_uri_without_uuid_with_slash() {
     rawstor::URI uri("file:///tmp/objects/");
 
@@ -124,7 +117,6 @@ int test_uri_without_uuid_with_slash() {
 
     return 0;
 }
-
 
 int test_uri_without_uuid_without_slash() {
     rawstor::URI uri("file:///tmp/objects");
@@ -145,55 +137,49 @@ int test_uri_without_uuid_without_slash() {
     return 0;
 }
 
-
 int test_uri_parent() {
     rawstor::URI uri("http://user:password@example.com:80/foo/bar/span/");
     assertTrue(
-        uri.str() == "http://user:password@example.com:80/foo/bar/span/");
+        uri.str() == "http://user:password@example.com:80/foo/bar/span/"
+    );
 
     uri = uri.parent();
-    assertTrue(
-        uri.str() == "http://user:password@example.com:80/foo/bar/span");
+    assertTrue(uri.str() == "http://user:password@example.com:80/foo/bar/span");
 
     uri = uri.parent();
-    assertTrue(
-        uri.str() == "http://user:password@example.com:80/foo/bar");
+    assertTrue(uri.str() == "http://user:password@example.com:80/foo/bar");
 
     uri = uri.parent();
-    assertTrue(
-        uri.str() == "http://user:password@example.com:80/foo");
+    assertTrue(uri.str() == "http://user:password@example.com:80/foo");
 
     uri = uri.parent();
-    assertTrue(
-        uri.str() == "http://user:password@example.com:80/");
+    assertTrue(uri.str() == "http://user:password@example.com:80/");
 
     uri = uri.parent();
-    assertTrue(
-        uri.str() == "http://user:password@example.com:80/");
+    assertTrue(uri.str() == "http://user:password@example.com:80/");
 
     return 0;
 }
-
 
 int test_uri_child() {
     rawstor::URI parent_with_slash("http://user:password@example.com:80/");
     rawstor::URI child_with_slash(parent_with_slash, "foo");
 
     assertTrue(
-        child_with_slash.str() == "http://user:password@example.com:80/foo");
+        child_with_slash.str() == "http://user:password@example.com:80/foo"
+    );
 
     rawstor::URI parent_without_slash("http://user:password@example.com:80");
     rawstor::URI child_without_slash(parent_without_slash, "foo");
 
     assertTrue(
-        child_without_slash.str() == "http://user:password@example.com:80/foo");
+        child_without_slash.str() == "http://user:password@example.com:80/foo"
+    );
 
     return 0;
 }
 
-
-} // unnamed
-
+} // namespace
 
 int main() {
     int rval = 0;

--- a/librawstorstd/tests/test_uuid.c
+++ b/librawstorstd/tests/test_uuid.c
@@ -10,7 +10,6 @@
 
 #include <unistd.h>
 
-
 static int test_timestamp() {
     struct RawstorUUID uuid;
     assertTrue(rawstor_uuid7_set_timestamp(&uuid, 100) == 0);
@@ -21,7 +20,6 @@ static int test_timestamp() {
     assertTrue(rawstor_uuid7_get_timestamp(&uuid) == (1ull << 48) - 1);
     return 0;
 }
-
 
 static int test_counter() {
     struct RawstorUUID uuid;
@@ -34,7 +32,6 @@ static int test_counter() {
     return 0;
 }
 
-
 static int test_version() {
     for (int version = 0; version < 16; ++version) {
         struct RawstorUUID uuid;
@@ -44,7 +41,6 @@ static int test_version() {
     return 0;
 }
 
-
 static int test_variant() {
     for (int variant = 0; variant < 4; ++variant) {
         struct RawstorUUID uuid;
@@ -53,7 +49,6 @@ static int test_variant() {
     }
     return 0;
 }
-
 
 static int test_all_at_once() {
     RawstorUUIDString s;
@@ -73,7 +68,6 @@ static int test_all_at_once() {
     return 0;
 }
 
-
 static int test_init() {
     struct RawstorUUID uuid;
     assertTrue(rawstor_uuid7_init(&uuid) == 0);
@@ -84,11 +78,13 @@ static int test_init() {
     return 0;
 }
 
-
 static int test_from_string() {
     struct RawstorUUID uuid;
-    assertTrue(rawstor_uuid_from_string(
-        &uuid, "0195e6ef-3ba8-741d-af22-e02bf9c800ec") == 0);
+    assertTrue(
+        rawstor_uuid_from_string(
+            &uuid, "0195e6ef-3ba8-741d-af22-e02bf9c800ec"
+        ) == 0
+    );
 
     assertTrue(rawstor_uuid_get_version(&uuid) == 7);
     assertTrue(rawstor_uuid_get_variant(&uuid) == 2);
@@ -98,30 +94,46 @@ static int test_from_string() {
     return 0;
 }
 
-
 static int test_from_string_errors() {
     struct RawstorUUID uuid;
-    assertTrue(rawstor_uuid_from_string(
-        &uuid, "0195e6ef-3ba8-741d-af22-e02bf9c800ec") == 0);
+    assertTrue(
+        rawstor_uuid_from_string(
+            &uuid, "0195e6ef-3ba8-741d-af22-e02bf9c800ec"
+        ) == 0
+    );
 
-    assertTrue(rawstor_uuid_from_string(
-        &uuid, "0195E6EF-3BA8-741D-AF22-E02BF9C800EC") == 0);
+    assertTrue(
+        rawstor_uuid_from_string(
+            &uuid, "0195E6EF-3BA8-741D-AF22-E02BF9C800EC"
+        ) == 0
+    );
 
-    assertTrue(rawstor_uuid_from_string(
-        &uuid, "0195e6ef-3ba8-741d-af22-e02bf9c800ecX") == 0);
+    assertTrue(
+        rawstor_uuid_from_string(
+            &uuid, "0195e6ef-3ba8-741d-af22-e02bf9c800ecX"
+        ) == 0
+    );
 
-    assertTrue(rawstor_uuid_from_string(
-        &uuid, "0195e6efX3ba8-741d-af22-e02bf9c800ec") == -EINVAL);
+    assertTrue(
+        rawstor_uuid_from_string(
+            &uuid, "0195e6efX3ba8-741d-af22-e02bf9c800ec"
+        ) == -EINVAL
+    );
 
-    assertTrue(rawstor_uuid_from_string(
-        &uuid, "0195e6ef-3ba8-741d-af22-e02bf9c800e") == -EINVAL);
+    assertTrue(
+        rawstor_uuid_from_string(
+            &uuid, "0195e6ef-3ba8-741d-af22-e02bf9c800e"
+        ) == -EINVAL
+    );
 
-    assertTrue(rawstor_uuid_from_string(
-        &uuid, "X195e6ef-3ba8-741d-af22-e02bf9c800ec") == -EINVAL);
+    assertTrue(
+        rawstor_uuid_from_string(
+            &uuid, "X195e6ef-3ba8-741d-af22-e02bf9c800ec"
+        ) == -EINVAL
+    );
 
     return 0;
 }
-
 
 int main() {
     int rval = 0;

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -17,381 +17,331 @@
 
 #include <cstring>
 
-
 namespace {
-
 
 /**
  * TODO: Remove this class.
  */
 class Queue final {
-    private:
-        unsigned int _operations;
-        std::unique_ptr<rawstor::io::Queue> _q;
+private:
+    unsigned int _operations;
+    std::unique_ptr<rawstor::io::Queue> _q;
 
-    public:
-        Queue(unsigned int operations, unsigned int depth):
-            _operations(operations),
-            _q(rawstor::io::Queue::create(depth))
-        {}
+public:
+    Queue(unsigned int operations, unsigned int depth) :
+        _operations(operations),
+        _q(rawstor::io::Queue::create(depth)) {}
 
-        Queue(const Queue &) = delete;
+    Queue(const Queue&) = delete;
 
-        Queue& operator=(const Queue &) = delete;
+    Queue& operator=(const Queue&) = delete;
 
-        inline void sub_operation() noexcept {
-            --_operations;
+    inline void sub_operation() noexcept { --_operations; }
+
+    inline rawstor::io::Queue& queue() noexcept { return *_q; }
+
+    void wait() {
+        while (!_q->empty()) {
+            _q->wait(rawstor_opts_wait_timeout());
         }
 
-        inline rawstor::io::Queue& queue() noexcept {
-            return *_q;
+        if (_operations > 0) {
+            throw std::runtime_error("Queue not completed");
         }
-
-        void wait() {
-            while (!_q->empty()) {
-                _q->wait(rawstor_opts_wait_timeout());
-            }
-
-            if (_operations > 0) {
-                throw std::runtime_error("Queue not completed");
-            }
-        }
+    }
 };
-
 
 /**
  * TODO: Remove this class.
  */
-class QueueTask final: public rawstor::Task {
-    private:
-        Queue &_q;
+class QueueTask final : public rawstor::Task {
+private:
+    Queue& _q;
 
-    public:
-        QueueTask(Queue &q): _q(q) {}
+public:
+    QueueTask(Queue& q) : _q(q) {}
 
-        void operator()(RawstorObject *, size_t, int error) override {
-            _q.sub_operation();
+    void operator()(RawstorObject*, size_t, int error) override {
+        _q.sub_operation();
 
-            if (error) {
-                RAWSTOR_THROW_SYSTEM_ERROR(error);
-            }
+        if (error) {
+            RAWSTOR_THROW_SYSTEM_ERROR(error);
         }
+    }
 };
 
+class ConnectionOpScalar : public rawstor::TaskScalar {
+protected:
+    rawstor::Connection& _cn;
+    std::shared_ptr<rawstor::Session> _s;
+    unsigned int _attempt;
 
-class ConnectionOpScalar: public rawstor::TaskScalar {
-    protected:
-        rawstor::Connection &_cn;
-        std::shared_ptr<rawstor::Session> _s;
-        unsigned int _attempt;
+    std::unique_ptr<rawstor::TaskScalar> _t;
 
-        std::unique_ptr<rawstor::TaskScalar> _t;
+    virtual void _retry(const std::shared_ptr<rawstor::Session>& s) = 0;
 
-        virtual void _retry(const std::shared_ptr<rawstor::Session> &s) = 0;
+public:
+    ConnectionOpScalar(
+        rawstor::Connection& cn, const std::shared_ptr<rawstor::Session>& s,
+        unsigned int attempt, std::unique_ptr<rawstor::TaskScalar> t
+    ) :
+        _cn(cn),
+        _s(s),
+        _attempt(attempt),
+        _t(std::move(t)) {}
 
-    public:
-        ConnectionOpScalar(
-            rawstor::Connection &cn,
-            const std::shared_ptr<rawstor::Session> &s,
-            unsigned int attempt,
-            std::unique_ptr<rawstor::TaskScalar> t):
-            _cn(cn),
-            _s(s),
-            _attempt(attempt),
-            _t(std::move(t))
-        {}
-
-        void operator()(
-            RawstorObject *o, size_t result, int error) override
-        {
-            if (!error) {
-                if (_attempt > 0) {
-                    rawstor_warning(
-                        "%s; success on %s; attempt: %d of %d\n",
-                        str().c_str(), _s->str().c_str(),
-                        _attempt + 1, rawstor_opts_io_attempts());
-                }
-                (*_t)(o, result, error);
-                return;
+    void operator()(RawstorObject* o, size_t result, int error) override {
+        if (!error) {
+            if (_attempt > 0) {
+                rawstor_warning(
+                    "%s; success on %s; attempt: %d of %d\n", str().c_str(),
+                    _s->str().c_str(), _attempt + 1, rawstor_opts_io_attempts()
+                );
             }
-
-            if (_attempt + 1 >= rawstor_opts_io_attempts()) {
-                rawstor_error(
-                    "%s; error on %s: %s; attempt %d of %d; "
-                    "failing...\n",
-                    str().c_str(), _s->str().c_str(),
-                    std::strerror(error),
-                    _attempt + 1, rawstor_opts_io_attempts());
-                (*_t)(o, result, error);
-                return;
-            }
-
-            rawstor_warning(
-                "%s; error on %s: %s; attempt: %d of %d; "
-                "retrying...\n",
-                str().c_str(), _s->str().c_str(),
-                std::strerror(error),
-                _attempt + 1, rawstor_opts_io_attempts());
-
-            try {
-                _cn.invalidate_session(_s);
-                _retry(_cn.get_next_session());
-            } catch (const std::system_error &e) {
-                (*_t)(o, result, e.code().value());
-            } catch (const std::exception &e) {
-                rawstor_error(
-                    "%s; exception on %s: %s; attempt %d of %d; "
-                    "failing...\n",
-                    str().c_str(), _s->str().c_str(),
-                    e.what(),
-                    _attempt + 1, rawstor_opts_io_attempts());
-                (*_t)(o, result, EIO);
-            }
+            (*_t)(o, result, error);
+            return;
         }
 
-        void* buf() noexcept override {
-            return _t->buf();
+        if (_attempt + 1 >= rawstor_opts_io_attempts()) {
+            rawstor_error(
+                "%s; error on %s: %s; attempt %d of %d; "
+                "failing...\n",
+                str().c_str(), _s->str().c_str(), std::strerror(error),
+                _attempt + 1, rawstor_opts_io_attempts()
+            );
+            (*_t)(o, result, error);
+            return;
         }
 
-        size_t size() const noexcept override {
-            return _t->size();
-        }
+        rawstor_warning(
+            "%s; error on %s: %s; attempt: %d of %d; "
+            "retrying...\n",
+            str().c_str(), _s->str().c_str(), std::strerror(error),
+            _attempt + 1, rawstor_opts_io_attempts()
+        );
 
-        off_t offset() const noexcept override {
-            return _t->offset();
+        try {
+            _cn.invalidate_session(_s);
+            _retry(_cn.get_next_session());
+        } catch (const std::system_error& e) {
+            (*_t)(o, result, e.code().value());
+        } catch (const std::exception& e) {
+            rawstor_error(
+                "%s; exception on %s: %s; attempt %d of %d; "
+                "failing...\n",
+                str().c_str(), _s->str().c_str(), e.what(), _attempt + 1,
+                rawstor_opts_io_attempts()
+            );
+            (*_t)(o, result, EIO);
         }
+    }
 
-        virtual std::string str() const = 0;
+    void* buf() noexcept override { return _t->buf(); }
+
+    size_t size() const noexcept override { return _t->size(); }
+
+    off_t offset() const noexcept override { return _t->offset(); }
+
+    virtual std::string str() const = 0;
 };
 
+class ConnectionOpVector : public rawstor::TaskVector {
+protected:
+    rawstor::Connection& _cn;
+    std::shared_ptr<rawstor::Session> _s;
+    unsigned int _attempt;
 
-class ConnectionOpVector: public rawstor::TaskVector {
-    protected:
-        rawstor::Connection &_cn;
-        std::shared_ptr<rawstor::Session> _s;
-        unsigned int _attempt;
+    std::unique_ptr<rawstor::TaskVector> _t;
 
-        std::unique_ptr<rawstor::TaskVector> _t;
+    virtual void _retry(const std::shared_ptr<rawstor::Session>& s) = 0;
 
-        virtual void _retry(const std::shared_ptr<rawstor::Session> &s) = 0;
+public:
+    ConnectionOpVector(
+        rawstor::Connection& cn, const std::shared_ptr<rawstor::Session>& s,
+        unsigned int attempt, std::unique_ptr<rawstor::TaskVector> t
+    ) :
+        _cn(cn),
+        _s(s),
+        _attempt(attempt),
+        _t(std::move(t)) {}
 
-    public:
-        ConnectionOpVector(
-            rawstor::Connection &cn,
-            const std::shared_ptr<rawstor::Session> &s,
-            unsigned int attempt,
-            std::unique_ptr<rawstor::TaskVector> t):
-            _cn(cn),
-            _s(s),
-            _attempt(attempt),
-            _t(std::move(t))
-        {}
-
-        void operator()(
-            RawstorObject *o, size_t result, int error) override
-        {
-            if (!error) {
-                if (_attempt > 0) {
-                    rawstor_warning(
-                        "%s; success on %s; attempt: %d of %d\n",
-                        str().c_str(), _s->str().c_str(),
-                        _attempt + 1, rawstor_opts_io_attempts());
-                }
-                (*_t)(o, result, error);
-                return;
+    void operator()(RawstorObject* o, size_t result, int error) override {
+        if (!error) {
+            if (_attempt > 0) {
+                rawstor_warning(
+                    "%s; success on %s; attempt: %d of %d\n", str().c_str(),
+                    _s->str().c_str(), _attempt + 1, rawstor_opts_io_attempts()
+                );
             }
-
-            if (_attempt + 1 >= rawstor_opts_io_attempts()) {
-                rawstor_error(
-                    "%s; error on %s: %s; attempt %d of %d; "
-                    "failing...\n",
-                    str().c_str(), _s->str().c_str(),
-                    std::strerror(error),
-                    _attempt + 1, rawstor_opts_io_attempts());
-                (*_t)(o, result, error);
-                return;
-            }
-
-            rawstor_warning(
-                "%s; error on %s: %s; attempt: %d of %d; "
-                "retrying...\n",
-                str().c_str(), _s->str().c_str(),
-                std::strerror(error),
-                _attempt + 1, rawstor_opts_io_attempts());
-
-            try {
-                _cn.invalidate_session(_s);
-                _retry(_cn.get_next_session());
-            } catch (const std::system_error &e) {
-                (*_t)(o, result, e.code().value());
-            } catch (const std::exception &e) {
-                rawstor_error(
-                    "%s; exception on %s: %s; attempt %d of %d; "
-                    "failing...\n",
-                    str().c_str(), _s->str().c_str(),
-                    e.what(),
-                    _attempt + 1, rawstor_opts_io_attempts());
-                (*_t)(o, result, EIO);
-            }
+            (*_t)(o, result, error);
+            return;
         }
 
-        iovec* iov() noexcept override {
-            return _t->iov();
+        if (_attempt + 1 >= rawstor_opts_io_attempts()) {
+            rawstor_error(
+                "%s; error on %s: %s; attempt %d of %d; "
+                "failing...\n",
+                str().c_str(), _s->str().c_str(), std::strerror(error),
+                _attempt + 1, rawstor_opts_io_attempts()
+            );
+            (*_t)(o, result, error);
+            return;
         }
 
-        unsigned int niov() const noexcept override {
-            return _t->niov();
-        }
+        rawstor_warning(
+            "%s; error on %s: %s; attempt: %d of %d; "
+            "retrying...\n",
+            str().c_str(), _s->str().c_str(), std::strerror(error),
+            _attempt + 1, rawstor_opts_io_attempts()
+        );
 
-        size_t size() const noexcept override {
-            return _t->size();
+        try {
+            _cn.invalidate_session(_s);
+            _retry(_cn.get_next_session());
+        } catch (const std::system_error& e) {
+            (*_t)(o, result, e.code().value());
+        } catch (const std::exception& e) {
+            rawstor_error(
+                "%s; exception on %s: %s; attempt %d of %d; "
+                "failing...\n",
+                str().c_str(), _s->str().c_str(), e.what(), _attempt + 1,
+                rawstor_opts_io_attempts()
+            );
+            (*_t)(o, result, EIO);
         }
+    }
 
-        off_t offset() const noexcept override {
-            return _t->offset();
-        }
+    iovec* iov() noexcept override { return _t->iov(); }
 
-        virtual std::string str() const = 0;
+    unsigned int niov() const noexcept override { return _t->niov(); }
+
+    size_t size() const noexcept override { return _t->size(); }
+
+    off_t offset() const noexcept override { return _t->offset(); }
+
+    virtual std::string str() const = 0;
 };
 
+class ConnectionOpPRead final : public ConnectionOpScalar {
+protected:
+    void _retry(const std::shared_ptr<rawstor::Session>& s) override {
+        std::unique_ptr<rawstor::TaskScalar> op =
+            std::make_unique<ConnectionOpPRead>(
+                _cn, s, _attempt + 1, std::move(_t)
+            );
+        s->read(std::move(op));
+    }
 
-class ConnectionOpPRead final: public ConnectionOpScalar {
-    protected:
-        void _retry(const std::shared_ptr<rawstor::Session> &s) override {
-            std::unique_ptr<rawstor::TaskScalar> op =
-                std::make_unique<ConnectionOpPRead>(
-                    _cn, s, _attempt + 1, std::move(_t));
-            s->read(std::move(op));
-        }
+public:
+    ConnectionOpPRead(
+        rawstor::Connection& cn, const std::shared_ptr<rawstor::Session>& s,
+        unsigned int attempt, std::unique_ptr<rawstor::TaskScalar> t
+    ) :
+        ConnectionOpScalar(cn, s, attempt, std::move(t)) {}
 
-    public:
-        ConnectionOpPRead(
-            rawstor::Connection &cn,
-            const std::shared_ptr<rawstor::Session> &s,
-            unsigned int attempt,
-            std::unique_ptr<rawstor::TaskScalar> t):
-            ConnectionOpScalar(cn, s, attempt, std::move(t))
-        {}
-
-        std::string str() const override {
-            std::ostringstream oss;
-            oss << "IO pread: size = " << size() << ", offset = " << offset();
-            return oss.str();
-        }
+    std::string str() const override {
+        std::ostringstream oss;
+        oss << "IO pread: size = " << size() << ", offset = " << offset();
+        return oss.str();
+    }
 };
 
+class ConnectionOpPReadV final : public ConnectionOpVector {
+protected:
+    void _retry(const std::shared_ptr<rawstor::Session>& s) override {
+        std::unique_ptr<rawstor::TaskVector> op =
+            std::make_unique<ConnectionOpPReadV>(
+                _cn, s, _attempt + 1, std::move(_t)
+            );
+        s->read(std::move(op));
+    }
 
-class ConnectionOpPReadV final: public ConnectionOpVector {
-    protected:
-        void _retry(const std::shared_ptr<rawstor::Session> &s) override {
-            std::unique_ptr<rawstor::TaskVector> op =
-                std::make_unique<ConnectionOpPReadV>(
-                    _cn, s, _attempt + 1, std::move(_t));
-            s->read(std::move(op));
-        }
+public:
+    ConnectionOpPReadV(
+        rawstor::Connection& cn, const std::shared_ptr<rawstor::Session>& s,
+        unsigned int attempt, std::unique_ptr<rawstor::TaskVector> t
+    ) :
+        ConnectionOpVector(cn, s, attempt, std::move(t)) {}
 
-    public:
-        ConnectionOpPReadV(
-            rawstor::Connection &cn,
-            const std::shared_ptr<rawstor::Session> &s,
-            unsigned int attempt,
-            std::unique_ptr<rawstor::TaskVector> t):
-            ConnectionOpVector(cn, s, attempt, std::move(t))
-        {}
-
-        std::string str() const override {
-            std::ostringstream oss;
-            oss << "IO preadv: size = " << size() << ", offset = " << offset();
-            return oss.str();
-        }
+    std::string str() const override {
+        std::ostringstream oss;
+        oss << "IO preadv: size = " << size() << ", offset = " << offset();
+        return oss.str();
+    }
 };
 
+class ConnectionOpPWrite final : public ConnectionOpScalar {
+protected:
+    void _retry(const std::shared_ptr<rawstor::Session>& s) override {
+        std::unique_ptr<rawstor::TaskScalar> op =
+            std::make_unique<ConnectionOpPWrite>(
+                _cn, s, _attempt + 1, std::move(_t)
+            );
+        s->write(std::move(op));
+    }
 
-class ConnectionOpPWrite final: public ConnectionOpScalar {
-    protected:
-        void _retry(const std::shared_ptr<rawstor::Session> &s) override {
-            std::unique_ptr<rawstor::TaskScalar> op =
-                std::make_unique<ConnectionOpPWrite>(
-                    _cn, s, _attempt + 1, std::move(_t));
-            s->write(std::move(op));
-        }
+public:
+    ConnectionOpPWrite(
+        rawstor::Connection& cn, const std::shared_ptr<rawstor::Session>& s,
+        unsigned int attempt, std::unique_ptr<rawstor::TaskScalar> t
+    ) :
+        ConnectionOpScalar(cn, s, attempt, std::move(t)) {}
 
-    public:
-        ConnectionOpPWrite(
-            rawstor::Connection &cn,
-            const std::shared_ptr<rawstor::Session> &s,
-            unsigned int attempt,
-            std::unique_ptr<rawstor::TaskScalar> t):
-            ConnectionOpScalar(cn, s, attempt, std::move(t))
-        {}
-
-        std::string str() const override {
-            std::ostringstream oss;
-            oss << "IO pwrite: size = " << size() << ", offset = " << offset();
-            return oss.str();
-        }
+    std::string str() const override {
+        std::ostringstream oss;
+        oss << "IO pwrite: size = " << size() << ", offset = " << offset();
+        return oss.str();
+    }
 };
 
+class ConnectionOpPWriteV final : public ConnectionOpVector {
+private:
+    void _retry(const std::shared_ptr<rawstor::Session>& s) override {
+        std::unique_ptr<rawstor::TaskVector> op =
+            std::make_unique<ConnectionOpPWriteV>(
+                _cn, s, _attempt + 1, std::move(_t)
+            );
+        s->write(std::move(op));
+    }
 
-class ConnectionOpPWriteV final: public ConnectionOpVector {
-    private:
-        void _retry(const std::shared_ptr<rawstor::Session> &s) override {
-            std::unique_ptr<rawstor::TaskVector> op =
-                std::make_unique<ConnectionOpPWriteV>(
-                    _cn, s, _attempt + 1, std::move(_t));
-            s->write(std::move(op));
-        }
+public:
+    ConnectionOpPWriteV(
+        rawstor::Connection& cn, const std::shared_ptr<rawstor::Session>& s,
+        unsigned int attempt, std::unique_ptr<rawstor::TaskVector> t
+    ) :
+        ConnectionOpVector(cn, s, attempt, std::move(t)) {}
 
-    public:
-        ConnectionOpPWriteV(
-            rawstor::Connection &cn,
-            const std::shared_ptr<rawstor::Session> &s,
-            unsigned int attempt,
-            std::unique_ptr<rawstor::TaskVector> t):
-            ConnectionOpVector(cn, s, attempt, std::move(t))
-        {}
-
-        std::string str() const override {
-            std::ostringstream oss;
-            oss << "IO pwritev: size = " << size() << ", offset = " << offset();
-            return oss.str();
-        }
+    std::string str() const override {
+        std::ostringstream oss;
+        oss << "IO pwritev: size = " << size() << ", offset = " << offset();
+        return oss.str();
+    }
 };
 
-
-} // unnamed
+} // namespace
 
 namespace rawstor {
 
-
-Connection::Connection(unsigned int depth):
+Connection::Connection(unsigned int depth) :
     _object(nullptr),
     _depth(depth),
-    _session_index(0)
-{}
-
+    _session_index(0) {
+}
 
 Connection::~Connection() {
     try {
         close();
-    } catch (const std::system_error &e) {
+    } catch (const std::system_error& e) {
         rawstor_error("Connection::close(): %s\n", e.what());
     }
 }
 
-
-std::vector<std::shared_ptr<Session>> Connection::_open(
-    const URI &uri,
-    RawstorObject *object,
-    size_t nsessions)
-{
+std::vector<std::shared_ptr<Session>>
+Connection::_open(const URI& uri, RawstorObject* object, size_t nsessions) {
     std::vector<std::shared_ptr<Session>> sessions;
 
-    for (
-        unsigned int attempt = 1;
-        attempt <= rawstor_opts_io_attempts();
-        ++attempt)
-    {
+    for (unsigned int attempt = 1; attempt <= rawstor_opts_io_attempts();
+         ++attempt) {
         try {
             Queue q(nsessions, _depth);
 
@@ -401,7 +351,7 @@ std::vector<std::shared_ptr<Session>> Connection::_open(
                 sessions.push_back(Session::create(uri, _depth));
             }
 
-            for (std::shared_ptr<Session> s: sessions) {
+            for (std::shared_ptr<Session> s : sessions) {
                 std::unique_ptr<QueueTask> t = std::make_unique<QueueTask>(q);
                 s->set_object(q.queue(), object, std::move(t));
             }
@@ -409,19 +359,19 @@ std::vector<std::shared_ptr<Session>> Connection::_open(
             q.wait();
 
             break;
-        } catch (const std::system_error &e) {
+        } catch (const std::system_error& e) {
             if (attempt != rawstor_opts_io_attempts()) {
                 rawstor_warning(
                     "Open session failed; error: %s; "
                     "attempt: %d of %d; retrying...\n",
-                    e.what(),
-                    attempt, rawstor_opts_io_attempts());
+                    e.what(), attempt, rawstor_opts_io_attempts()
+                );
             } else {
                 rawstor_warning(
                     "Open session failed; error: %s; "
                     "attempt: %d of %d; failing...\n",
-                    e.what(),
-                    attempt, rawstor_opts_io_attempts());
+                    e.what(), attempt, rawstor_opts_io_attempts()
+                );
                 throw;
             }
         }
@@ -429,7 +379,6 @@ std::vector<std::shared_ptr<Session>> Connection::_open(
 
     return sessions;
 }
-
 
 std::shared_ptr<Session> Connection::get_next_session() {
     if (_sessions.empty()) {
@@ -444,21 +393,19 @@ std::shared_ptr<Session> Connection::get_next_session() {
     return s;
 }
 
-
-void Connection::invalidate_session(const std::shared_ptr<Session> &s) {
-    typename std::vector<std::shared_ptr<Session>>::iterator it = std::find(
-        _sessions.begin(), _sessions.end(), s);
+void Connection::invalidate_session(const std::shared_ptr<Session>& s) {
+    typename std::vector<std::shared_ptr<Session>>::iterator it =
+        std::find(_sessions.begin(), _sessions.end(), s);
 
     if (it != _sessions.end()) {
         _sessions.erase(it);
 
-        std::vector<std::shared_ptr<Session>> new_sessions = _open(
-            s->uri(), _object, 1);
+        std::vector<std::shared_ptr<Session>> new_sessions =
+            _open(s->uri(), _object, 1);
 
         _sessions.push_back(new_sessions.front());
     }
 }
-
 
 const URI* Connection::uri() const noexcept {
     if (_sessions.empty()) {
@@ -468,8 +415,7 @@ const URI* Connection::uri() const noexcept {
     return &_sessions.front()->uri();
 }
 
-
-void Connection::create(const URI &uri, const RawstorObjectSpec &sp) {
+void Connection::create(const URI& uri, const RawstorObjectSpec& sp) {
     RawstorUUID id;
     int res = rawstor_uuid_from_string(&id, uri.path().filename().c_str());
     if (res) {
@@ -485,8 +431,7 @@ void Connection::create(const URI &uri, const RawstorObjectSpec &sp) {
     q.wait();
 }
 
-
-void Connection::remove(const URI &uri) {
+void Connection::remove(const URI& uri) {
     RawstorUUID id;
     int res = rawstor_uuid_from_string(&id, uri.path().filename().c_str());
     if (res) {
@@ -502,8 +447,7 @@ void Connection::remove(const URI &uri) {
     q.wait();
 }
 
-
-void Connection::spec(const URI &uri, RawstorObjectSpec *sp) {
+void Connection::spec(const URI& uri, RawstorObjectSpec* sp) {
     RawstorUUID id;
     int res = rawstor_uuid_from_string(&id, uri.path().filename().c_str());
     if (res) {
@@ -519,57 +463,42 @@ void Connection::spec(const URI &uri, RawstorObjectSpec *sp) {
     q.wait();
 }
 
-
-void Connection::open(
-    const URI &uri,
-    RawstorObject *object,
-    size_t nsessions)
-{
+void Connection::open(const URI& uri, RawstorObject* object, size_t nsessions) {
     _sessions = _open(uri, object, nsessions);
     _object = object;
 }
-
 
 void Connection::close() {
     _sessions.clear();
     _object = nullptr;
 }
 
-
 void Connection::read(std::unique_ptr<TaskScalar> t) {
     std::shared_ptr<Session> s = get_next_session();
     std::unique_ptr<TaskScalar> op =
-        std::make_unique<ConnectionOpPRead>(
-            *this, s, 0, std::move(t));
+        std::make_unique<ConnectionOpPRead>(*this, s, 0, std::move(t));
     s->read(std::move(op));
 }
-
 
 void Connection::read(std::unique_ptr<TaskVector> t) {
     std::shared_ptr<Session> s = get_next_session();
     std::unique_ptr<TaskVector> op =
-        std::make_unique<ConnectionOpPReadV>(
-            *this, s, 0, std::move(t));
+        std::make_unique<ConnectionOpPReadV>(*this, s, 0, std::move(t));
     s->read(std::move(op));
 }
-
 
 void Connection::write(std::unique_ptr<TaskScalar> t) {
     std::shared_ptr<Session> s = get_next_session();
     std::unique_ptr<TaskScalar> op =
-        std::make_unique<ConnectionOpPWrite>(
-            *this, s, 0, std::move(t));
+        std::make_unique<ConnectionOpPWrite>(*this, s, 0, std::move(t));
     s->write(std::move(op));
 }
-
 
 void Connection::write(std::unique_ptr<TaskVector> t) {
     std::shared_ptr<Session> s = get_next_session();
     std::unique_ptr<TaskVector> op =
-        std::make_unique<ConnectionOpPWriteV>(
-            *this, s, 0, std::move(t));
+        std::make_unique<ConnectionOpPWriteV>(*this, s, 0, std::move(t));
     s->write(std::move(op));
 }
 
-
-} // rawstor
+} // namespace rawstor

--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -11,63 +11,56 @@
 
 #include <cstddef>
 
-
 namespace rawstor {
-
 
 class TaskScalar;
 
 class TaskVector;
 
-
 class Session;
 
-
 class Connection final {
-    private:
-        RawstorObject *_object;
-        unsigned int _depth;
+private:
+    RawstorObject* _object;
+    unsigned int _depth;
 
-        std::vector<std::shared_ptr<Session>> _sessions;
-        size_t _session_index;
+    std::vector<std::shared_ptr<Session>> _sessions;
+    size_t _session_index;
 
-        std::vector<std::shared_ptr<Session>> _open(
-            const URI &uri,
-            RawstorObject *object,
-            size_t nsessions);
+    std::vector<std::shared_ptr<Session>>
+    _open(const URI& uri, RawstorObject* object, size_t nsessions);
 
-    public:
-        Connection(unsigned int depth);
-        Connection(const Connection &) = delete;
-        ~Connection();
+public:
+    Connection(unsigned int depth);
+    Connection(const Connection&) = delete;
+    ~Connection();
 
-        Connection& operator=(const Connection&) = delete;
+    Connection& operator=(const Connection&) = delete;
 
-        std::shared_ptr<Session> get_next_session();
-        void invalidate_session(const std::shared_ptr<Session> &s);
+    std::shared_ptr<Session> get_next_session();
+    void invalidate_session(const std::shared_ptr<Session>& s);
 
-        const URI* uri() const noexcept;
+    const URI* uri() const noexcept;
 
-        void create(const URI &uri, const RawstorObjectSpec &sp);
+    void create(const URI& uri, const RawstorObjectSpec& sp);
 
-        void remove(const URI &uri);
+    void remove(const URI& uri);
 
-        void spec(const URI &uri, RawstorObjectSpec *sp);
+    void spec(const URI& uri, RawstorObjectSpec* sp);
 
-        void open(const URI &uri, RawstorObject *object, size_t nsessions);
+    void open(const URI& uri, RawstorObject* object, size_t nsessions);
 
-        void close();
+    void close();
 
-        void read(std::unique_ptr<TaskScalar> t);
+    void read(std::unique_ptr<TaskScalar> t);
 
-        void read(std::unique_ptr<TaskVector> t);
+    void read(std::unique_ptr<TaskVector> t);
 
-        void write(std::unique_ptr<TaskScalar> t);
+    void write(std::unique_ptr<TaskScalar> t);
 
-        void write(std::unique_ptr<TaskVector> t);
+    void write(std::unique_ptr<TaskVector> t);
 };
 
-
-} // rawstor
+} // namespace rawstor
 
 #endif // RAWSTOR_CONNECTION_HPP

--- a/src/file_session.cpp
+++ b/src/file_session.cpp
@@ -15,23 +15,21 @@
 #include <sys/types.h>
 #include <sys/uio.h>
 
-#include <unistd.h>
 #include <fcntl.h>
+#include <unistd.h>
 
 #include <cerrno>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <memory>
-#include <string>
 #include <sstream>
+#include <string>
 #include <utility>
-
 
 namespace {
 
-
-std::string get_ost_path(const rawstor::URI &uri) {
+std::string get_ost_path(const rawstor::URI& uri) {
     if (uri.scheme() != "file") {
         std::ostringstream oss;
         oss << "Unexpected URI scheme: " << uri.str();
@@ -45,10 +43,9 @@ std::string get_ost_path(const rawstor::URI &uri) {
     return uri.path().str();
 }
 
-
 std::string get_object_spec_path(
-    const std::string &ost_path, const RawstorUUIDString &uuid)
-{
+    const std::string& ost_path, const RawstorUUIDString& uuid
+) {
     std::ostringstream oss;
 
     oss << ost_path << "/" << uuid << ".spec";
@@ -56,10 +53,9 @@ std::string get_object_spec_path(
     return oss.str();
 }
 
-
 std::string get_object_dat_path(
-    const std::string &ost_path, const RawstorUUIDString &uuid)
-{
+    const std::string& ost_path, const RawstorUUIDString& uuid
+) {
     std::ostringstream oss;
 
     oss << ost_path << "/" << uuid << ".dat";
@@ -67,12 +63,10 @@ std::string get_object_dat_path(
     return oss.str();
 }
 
-
 void write_dat(
-    const std:: string &ost_path,
-    const RawstorObjectSpec &spec,
-    const RawstorUUID &id)
-{
+    const std::string& ost_path, const RawstorObjectSpec& spec,
+    const RawstorUUID& id
+) {
     RawstorUUIDString uuid_string;
     rawstor_uuid_to_string(&id, &uuid_string);
 
@@ -91,101 +85,75 @@ void write_dat(
         if (close(fd) == -1) {
             RAWSTOR_THROW_ERRNO();
         }
-    } catch (const std::system_error &e) {
+    } catch (const std::system_error& e) {
         close(fd);
         unlink(dat_path.c_str());
         throw;
     }
 }
 
-
 } // unnamed namespace
-
 
 namespace rawstor {
 namespace file {
 
+class SessionOpScalarPositional final
+    : public rawstor::io::TaskScalarPositional {
+private:
+    RawstorObject* _o;
+    std::unique_ptr<rawstor::TaskScalar> _t;
 
-class SessionOpScalarPositional final:
-    public rawstor::io::TaskScalarPositional
-{
-    private:
-        RawstorObject *_o;
-        std::unique_ptr<rawstor::TaskScalar> _t;
+public:
+    SessionOpScalarPositional(
+        RawstorObject* o, int fd, std::unique_ptr<rawstor::TaskScalar> t
+    ) :
+        rawstor::io::TaskScalarPositional(fd),
+        _o(o),
+        _t(std::move(t)) {}
 
-    public:
-        SessionOpScalarPositional(
-            RawstorObject *o,
-            int fd,
-            std::unique_ptr<rawstor::TaskScalar> t):
-            rawstor::io::TaskScalarPositional(fd),
-            _o(o),
-            _t(std::move(t))
-        {}
+    void operator()(size_t result, int error) override {
+        (*_t)(_o, result, error);
+    }
 
-        void operator()(size_t result, int error) override {
-            (*_t)(_o, result, error);
-        }
+    void* buf() noexcept override { return _t->buf(); }
 
-        void* buf() noexcept override {
-            return _t->buf();
-        }
+    size_t size() const noexcept override { return _t->size(); }
 
-        size_t size() const noexcept override {
-            return _t->size();
-        }
-
-        off_t offset() const noexcept override {
-            return _t->offset();
-        }
+    off_t offset() const noexcept override { return _t->offset(); }
 };
 
+class SessionOpVectorPositional final
+    : public rawstor::io::TaskVectorPositional {
+private:
+    RawstorObject* _o;
+    std::unique_ptr<rawstor::TaskVector> _t;
 
-class SessionOpVectorPositional final:
-    public rawstor::io::TaskVectorPositional
-{
-    private:
-        RawstorObject *_o;
-        std::unique_ptr<rawstor::TaskVector> _t;
+public:
+    SessionOpVectorPositional(
+        RawstorObject* o, int fd, std::unique_ptr<rawstor::TaskVector> t
+    ) :
+        rawstor::io::TaskVectorPositional(fd),
+        _o(o),
+        _t(std::move(t)) {}
 
-    public:
-        SessionOpVectorPositional(
-            RawstorObject *o,
-            int fd,
-            std::unique_ptr<rawstor::TaskVector> t):
-            rawstor::io::TaskVectorPositional(fd),
-            _o(o),
-            _t(std::move(t))
-        {}
+    void operator()(size_t result, int error) override {
+        (*_t)(_o, result, error);
+    }
 
-        void operator()(size_t result, int error) override {
-            (*_t)(_o, result, error);
-        }
+    iovec* iov() noexcept override { return _t->iov(); }
 
-        iovec* iov() noexcept override {
-            return _t->iov();
-        }
+    unsigned int niov() const noexcept override { return _t->niov(); }
 
-        unsigned int niov() const noexcept override {
-            return _t->niov();
-        }
+    size_t size() const noexcept override { return _t->size(); }
 
-        size_t size() const noexcept override {
-            return _t->size();
-        }
-
-        off_t offset() const noexcept override {
-            return _t->offset();
-        }
+    off_t offset() const noexcept override { return _t->offset(); }
 };
 
+Session::Session(const URI& uri, unsigned int depth) :
+    rawstor::Session(uri, depth) {
+}
 
-Session::Session(const URI &uri, unsigned int depth):
-    rawstor::Session(uri, depth)
-{}
-
-
-int Session::_connect(const RawstorUUID &id) {
+int Session::_connect(const RawstorUUID& id) {
     std::string ost_path = get_ost_path(uri());
 
     RawstorUUIDString uuid_string;
@@ -201,12 +169,10 @@ int Session::_connect(const RawstorUUID &id) {
     return fd;
 }
 
-
 void Session::create(
-    rawstor::io::Queue &,
-    const RawstorUUID &id, const RawstorObjectSpec &sp,
-    std::unique_ptr<rawstor::Task> t)
-{
+    rawstor::io::Queue&, const RawstorUUID& id, const RawstorObjectSpec& sp,
+    std::unique_ptr<rawstor::Task> t
+) {
     std::string ost_path = get_ost_path(uri());
     if (mkdir(ost_path.c_str(), 0755) == -1) {
         if (errno == EEXIST) {
@@ -223,8 +189,8 @@ void Session::create(
     spec_path = get_object_spec_path(ost_path, uuid_string);
 
     int fd = ::open(
-        spec_path.c_str(),
-        O_EXCL | O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
+        spec_path.c_str(), O_EXCL | O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR
+    );
     if (fd == -1) {
         RAWSTOR_THROW_ERRNO();
     }
@@ -249,12 +215,9 @@ void Session::create(
     (*t)(nullptr, 0, 0);
 }
 
-
 void Session::remove(
-    rawstor::io::Queue &,
-    const RawstorUUID &id,
-    std::unique_ptr<rawstor::Task> t)
-{
+    rawstor::io::Queue&, const RawstorUUID& id, std::unique_ptr<rawstor::Task> t
+) {
     std::string ost_path = get_ost_path(uri());
 
     RawstorUUIDString uuid_string;
@@ -281,12 +244,10 @@ void Session::remove(
     (*t)(nullptr, 0, 0);
 }
 
-
 void Session::spec(
-    rawstor::io::Queue &,
-    const RawstorUUID &id, RawstorObjectSpec *sp,
-    std::unique_ptr<rawstor::Task> t)
-{
+    rawstor::io::Queue&, const RawstorUUID& id, RawstorObjectSpec* sp,
+    std::unique_ptr<rawstor::Task> t
+) {
     std::string ost_path = get_ost_path(uri());
 
     RawstorUUIDString uuid_string;
@@ -316,12 +277,9 @@ void Session::spec(
     (*t)(nullptr, 0, 0);
 }
 
-
 void Session::set_object(
-    rawstor::io::Queue &,
-    RawstorObject *object,
-    std::unique_ptr<rawstor::Task> t)
-{
+    rawstor::io::Queue&, RawstorObject* object, std::unique_ptr<rawstor::Task> t
+) {
     if (fd() != -1) {
         throw std::runtime_error("Object already set");
     }
@@ -338,13 +296,11 @@ void Session::set_object(
     _o = object;
 }
 
-
 void Session::read(std::unique_ptr<rawstor::TaskScalar> t) {
     std::unique_ptr<rawstor::io::TaskScalarPositional> op =
         std::make_unique<SessionOpScalarPositional>(_o, fd(), std::move(t));
     io_queue->read(std::move(op));
 }
-
 
 void Session::read(std::unique_ptr<rawstor::TaskVector> t) {
     std::unique_ptr<rawstor::io::TaskVectorPositional> op =
@@ -352,13 +308,11 @@ void Session::read(std::unique_ptr<rawstor::TaskVector> t) {
     io_queue->read(std::move(op));
 }
 
-
 void Session::write(std::unique_ptr<rawstor::TaskScalar> t) {
     std::unique_ptr<rawstor::io::TaskScalarPositional> op =
         std::make_unique<SessionOpScalarPositional>(_o, fd(), std::move(t));
     io_queue->write(std::move(op));
 }
-
 
 void Session::write(std::unique_ptr<rawstor::TaskVector> t) {
     std::unique_ptr<rawstor::io::TaskVectorPositional> op =
@@ -366,5 +320,5 @@ void Session::write(std::unique_ptr<rawstor::TaskVector> t) {
     io_queue->write(std::move(op));
 }
 
-
-}} // rawstor::file
+} // namespace file
+} // namespace rawstor

--- a/src/file_session.hpp
+++ b/src/file_session.hpp
@@ -15,50 +15,47 @@
 namespace rawstor {
 namespace file {
 
-
 class SessionOp;
 
+class Session final : public rawstor::Session {
+private:
+    RawstorObject* _o;
 
-class Session final: public rawstor::Session {
-    private:
-        RawstorObject *_o;
+    int _connect(const RawstorUUID& id);
 
-        int _connect(const RawstorUUID &id);
+public:
+    Session(const URI& uri, unsigned int depth);
 
-    public:
-        Session(const URI &uri, unsigned int depth);
+    void create(
+        rawstor::io::Queue& queue, const RawstorUUID& id,
+        const RawstorObjectSpec& sp, std::unique_ptr<rawstor::Task> t
+    ) override;
 
-        void create(
-            rawstor::io::Queue &queue,
-            const RawstorUUID &id, const RawstorObjectSpec &sp,
-            std::unique_ptr<rawstor::Task> t) override;
+    void remove(
+        rawstor::io::Queue& queue, const RawstorUUID& id,
+        std::unique_ptr<rawstor::Task> t
+    ) override;
 
-        void remove(
-            rawstor::io::Queue &queue,
-            const RawstorUUID &id,
-            std::unique_ptr<rawstor::Task> t) override;
+    void spec(
+        rawstor::io::Queue& queue, const RawstorUUID& id, RawstorObjectSpec* sp,
+        std::unique_ptr<rawstor::Task> t
+    ) override;
 
-        void spec(
-            rawstor::io::Queue &queue,
-            const RawstorUUID &id, RawstorObjectSpec *sp,
-            std::unique_ptr<rawstor::Task> t) override;
+    void set_object(
+        rawstor::io::Queue& queue, RawstorObject* object,
+        std::unique_ptr<rawstor::Task> t
+    ) override;
 
-        void set_object(
-            rawstor::io::Queue &queue,
-            RawstorObject *object,
-            std::unique_ptr<rawstor::Task> t) override;
+    void read(std::unique_ptr<rawstor::TaskScalar> t) override;
 
-        void read(std::unique_ptr<rawstor::TaskScalar> t) override;
+    void read(std::unique_ptr<rawstor::TaskVector> t) override;
 
-        void read(std::unique_ptr<rawstor::TaskVector> t) override;
+    void write(std::unique_ptr<rawstor::TaskScalar> t) override;
 
-        void write(std::unique_ptr<rawstor::TaskScalar> t) override;
-
-        void write(std::unique_ptr<rawstor::TaskVector> t) override;
+    void write(std::unique_ptr<rawstor::TaskVector> t) override;
 };
 
-
-}} // rawstor::file
-
+} // namespace file
+} // namespace rawstor
 
 #endif // RAWSTOR_FILE_SESSION_HPP

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -9,58 +9,53 @@
 #include <memory>
 #include <vector>
 
-
 namespace rawstor {
-
 
 class Connection;
 
-
-} // rawstor
-
+} // namespace rawstor
 
 struct RawstorObject final {
-    private:
-        RawstorUUID _id;
-        std::vector<std::unique_ptr<rawstor::Connection>> _cns;
+private:
+    RawstorUUID _id;
+    std::vector<std::unique_ptr<rawstor::Connection>> _cns;
 
-    public:
-        static void create(
-            const std::vector<rawstor::URI> &uris,
-            const RawstorObjectSpec &sp,
-            std::vector<rawstor::URI> *object_uris);
-        static void remove(const std::vector<rawstor::URI> &uris);
-        static void spec(
-            const std::vector<rawstor::URI> &uris, RawstorObjectSpec *sp);
+public:
+    static void create(
+        const std::vector<rawstor::URI>& uris, const RawstorObjectSpec& sp,
+        std::vector<rawstor::URI>* object_uris
+    );
+    static void remove(const std::vector<rawstor::URI>& uris);
+    static void
+    spec(const std::vector<rawstor::URI>& uris, RawstorObjectSpec* sp);
 
-        explicit RawstorObject(const std::vector<rawstor::URI> &uris);
-        RawstorObject(const RawstorObject &) = delete;
-        RawstorObject(RawstorObject &&) = delete;
-        RawstorObject& operator=(const RawstorObject &) = delete;
-        RawstorObject& operator=(RawstorObject &&) = delete;
+    explicit RawstorObject(const std::vector<rawstor::URI>& uris);
+    RawstorObject(const RawstorObject&) = delete;
+    RawstorObject(RawstorObject&&) = delete;
+    RawstorObject& operator=(const RawstorObject&) = delete;
+    RawstorObject& operator=(RawstorObject&&) = delete;
 
-        std::vector<rawstor::URI> uris() const;
+    std::vector<rawstor::URI> uris() const;
 
-        inline const RawstorUUID& id() const noexcept {
-            return _id;
-        }
+    inline const RawstorUUID& id() const noexcept { return _id; }
 
-        void pread(
-            void *buf, size_t size, off_t offset,
-            RawstorCallback *cb, void *data);
+    void pread(
+        void* buf, size_t size, off_t offset, RawstorCallback* cb, void* data
+    );
 
-        void preadv(
-            iovec *iov, unsigned int niov, size_t size, off_t offset,
-            RawstorCallback *cb, void *data);
+    void preadv(
+        iovec* iov, unsigned int niov, size_t size, off_t offset,
+        RawstorCallback* cb, void* data
+    );
 
-        void pwrite(
-            void *buf, size_t size, off_t offset,
-            RawstorCallback *cb, void *data);
+    void pwrite(
+        void* buf, size_t size, off_t offset, RawstorCallback* cb, void* data
+    );
 
-        void pwritev(
-            iovec *iov, unsigned int niov, size_t size, off_t offset,
-            RawstorCallback *cb, void *data);
+    void pwritev(
+        iovec* iov, unsigned int niov, size_t size, off_t offset,
+        RawstorCallback* cb, void* data
+    );
 };
-
 
 #endif // RAWSTOR_OBJECT_HPP

--- a/src/opts.c
+++ b/src/opts.c
@@ -11,12 +11,10 @@
 #define RAWSTOR_OPTS_SO_RCVTIMEO 5000
 #define RAWSTOR_OPTS_TCP_USER_TIMEOUT 5000
 
-
 static struct RawstorOpts _rawstor_opts = {};
 
-
-static unsigned int get_env_uint(const char *name, int def) {
-    const char *strval = getenv(name);
+static unsigned int get_env_uint(const char* name, int def) {
+    const char* strval = getenv(name);
     if (strval == NULL) {
         return def;
     }
@@ -29,47 +27,49 @@ static unsigned int get_env_uint(const char *name, int def) {
     return uintval;
 }
 
-
-int rawstor_opts_initialize(const struct RawstorOpts *opts) {
+int rawstor_opts_initialize(const struct RawstorOpts* opts) {
     _rawstor_opts.wait_timeout =
-        (opts != NULL && opts->wait_timeout != 0) ?
-        opts->wait_timeout : get_env_uint(
-            "RAWSTOR_OPTS_WAIT_TIMEOUT",
-            RAWSTOR_OPTS_WAIT_TIMEOUT);
+        (opts != NULL && opts->wait_timeout != 0)
+            ? opts->wait_timeout
+            : get_env_uint(
+                  "RAWSTOR_OPTS_WAIT_TIMEOUT", RAWSTOR_OPTS_WAIT_TIMEOUT
+              );
 
     _rawstor_opts.io_attempts =
-        (opts != NULL && opts->io_attempts != 0) ?
-        opts->io_attempts : get_env_uint(
-            "RAWSTOR_OPTS_IO_ATTEMPTS",
-            RAWSTOR_OPTS_IO_ATTEMPTS);
+        (opts != NULL && opts->io_attempts != 0)
+            ? opts->io_attempts
+            : get_env_uint(
+                  "RAWSTOR_OPTS_IO_ATTEMPTS", RAWSTOR_OPTS_IO_ATTEMPTS
+              );
 
     _rawstor_opts.sessions =
-        (opts != NULL && opts->sessions != 0) ?
-        opts->sessions : get_env_uint(
-            "RAWSTOR_OPTS_SESSIONS",
-            RAWSTOR_OPTS_SESSIONS);
+        (opts != NULL && opts->sessions != 0)
+            ? opts->sessions
+            : get_env_uint("RAWSTOR_OPTS_SESSIONS", RAWSTOR_OPTS_SESSIONS);
 
     _rawstor_opts.so_sndtimeo =
-        (opts != NULL && opts->so_sndtimeo != 0) ?
-        opts->so_sndtimeo : get_env_uint(
-            "RAWSTOR_OPTS_SO_SNDTIMEO",
-            RAWSTOR_OPTS_SO_SNDTIMEO);
+        (opts != NULL && opts->so_sndtimeo != 0)
+            ? opts->so_sndtimeo
+            : get_env_uint(
+                  "RAWSTOR_OPTS_SO_SNDTIMEO", RAWSTOR_OPTS_SO_SNDTIMEO
+              );
 
     _rawstor_opts.so_rcvtimeo =
-        (opts != NULL && opts->so_rcvtimeo != 0) ?
-        opts->so_rcvtimeo : get_env_uint(
-            "RAWSTOR_OPTS_SO_RCVTIMEO",
-            RAWSTOR_OPTS_SO_RCVTIMEO);
+        (opts != NULL && opts->so_rcvtimeo != 0)
+            ? opts->so_rcvtimeo
+            : get_env_uint(
+                  "RAWSTOR_OPTS_SO_RCVTIMEO", RAWSTOR_OPTS_SO_RCVTIMEO
+              );
 
     _rawstor_opts.tcp_user_timeout =
-        (opts != NULL && opts->tcp_user_timeout != 0) ?
-        opts->tcp_user_timeout : get_env_uint(
-            "RAWSTOR_OPTS_TCP_USER_TIMEOUT",
-            RAWSTOR_OPTS_TCP_USER_TIMEOUT);
+        (opts != NULL && opts->tcp_user_timeout != 0)
+            ? opts->tcp_user_timeout
+            : get_env_uint(
+                  "RAWSTOR_OPTS_TCP_USER_TIMEOUT", RAWSTOR_OPTS_TCP_USER_TIMEOUT
+              );
 
     return 0;
 }
-
 
 void rawstor_opts_terminate(void) {
     /**
@@ -77,31 +77,25 @@ void rawstor_opts_terminate(void) {
      */
 }
 
-
 unsigned int rawstor_opts_wait_timeout(void) {
     return _rawstor_opts.wait_timeout;
 }
-
 
 unsigned int rawstor_opts_io_attempts(void) {
     return _rawstor_opts.io_attempts;
 }
 
-
 unsigned int rawstor_opts_sessions(void) {
     return _rawstor_opts.sessions;
 }
-
 
 unsigned int rawstor_opts_so_sndtimeo(void) {
     return _rawstor_opts.so_sndtimeo;
 }
 
-
 unsigned int rawstor_opts_so_rcvtimeo(void) {
     return _rawstor_opts.so_rcvtimeo;
 }
-
 
 unsigned int rawstor_opts_tcp_user_timeout(void) {
     return _rawstor_opts.tcp_user_timeout;

--- a/src/opts.h
+++ b/src/opts.h
@@ -3,11 +3,9 @@
 
 #include <rawstor.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 
 // defined in rawstor.h
 // struct RawstorOpts {
@@ -19,8 +17,7 @@ extern "C" {
 //     unsigned int tcp_user_timeout;
 // };
 
-
-int rawstor_opts_initialize(const struct RawstorOpts *opts);
+int rawstor_opts_initialize(const struct RawstorOpts* opts);
 
 void rawstor_opts_terminate(void);
 
@@ -36,10 +33,8 @@ unsigned int rawstor_opts_so_rcvtimeo(void);
 
 unsigned int rawstor_opts_tcp_user_timeout(void);
 
-
 #ifdef __cplusplus
 }
 #endif
 
-
-#endif  // RAWSTOR_OPTS_H
+#endif // RAWSTOR_OPTS_H

--- a/src/ost_protocol.h
+++ b/src/ost_protocol.h
@@ -7,14 +7,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
 #define RAWSTOR_MAGIC 0x72737472 // "rstr" as ascii
-
 
 enum RawstorOSTCommandType {
     RAWSTOR_CMD_SET_OBJECT,
@@ -23,13 +20,11 @@ enum RawstorOSTCommandType {
     RAWSTOR_CMD_DISCARD,
 };
 
-
 /* Just for basic validation only */
 struct RawstorOSTFrameCmdOnly {
     uint32_t magic;
     enum RawstorOSTCommandType cmd;
 } RAWSTOR_PACKED;
-
 
 /* Minimalistic protocol frame */
 struct RawstorOSTFrameBasic {
@@ -42,7 +37,6 @@ struct RawstorOSTFrameBasic {
     uint64_t val;
 } RAWSTOR_PACKED;
 
-
 struct RawstorOSTFrameIO {
     uint32_t magic;
     enum RawstorOSTCommandType cmd;
@@ -52,7 +46,6 @@ struct RawstorOSTFrameIO {
     uint64_t hash;
     bool sync;
 } RAWSTOR_PACKED;
-
 
 /* response frames */
 struct RawstorOSTFrameResponse {
@@ -65,10 +58,8 @@ struct RawstorOSTFrameResponse {
     uint64_t hash;
 } RAWSTOR_PACKED;
 
-
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // RAWSTOR_OST_PROTOCOL_H

--- a/src/ost_session.cpp
+++ b/src/ost_session.cpp
@@ -37,63 +37,56 @@
  */
 #define IOVEC_SIZE 256
 
-
-#define t_trace(t, result, error) \
-    rawstor_debug( \
-        "%s(): %zu of %zu, error = %d\n", \
-        __FUNCTION__, \
-        (result), (t).size(), error)
-
+#define t_trace(t, result, error)                                              \
+    rawstor_debug(                                                             \
+        "%s(): %zu of %zu, error = %d\n", __FUNCTION__, (result), (t).size(),  \
+        error                                                                  \
+    )
 
 namespace {
 
-
 class SessionOp;
 
-
 template <class Task>
-int validate_result(size_t result, Task &t) {
+int validate_result(size_t result, Task& t) {
     if (result == t.size()) {
         return 0;
     }
 
     rawstor_error(
-        "fd %d: Unexpected event size: %zu != %zu\n",
-        t.fd(), result, t.size());
+        "fd %d: Unexpected event size: %zu != %zu\n", t.fd(), result, t.size()
+    );
 
     return EAGAIN;
 }
 
-
 int validate_response(
-    rawstor::ost::Session &s, const RawstorOSTFrameResponse *response)
-{
+    rawstor::ost::Session& s, const RawstorOSTFrameResponse* response
+) {
     assert(response != nullptr);
 
     if (response->magic != RAWSTOR_MAGIC) {
         rawstor_error(
-            "%s: Unexpected magic number: %x != %x\n",
-            s.str().c_str(),
-            response->magic, RAWSTOR_MAGIC);
+            "%s: Unexpected magic number: %x != %x\n", s.str().c_str(),
+            response->magic, RAWSTOR_MAGIC
+        );
         return EPROTO;
     }
 
     if (response->res < 0) {
         rawstor_error(
-            "%s: Server error: %s\n",
-            s.str().c_str(),
-            strerror(-response->res));
+            "%s: Server error: %s\n", s.str().c_str(), strerror(-response->res)
+        );
         return EPROTO;
     }
 
     return 0;
 }
 
-
 int validate_cmd(
-    rawstor::ost::Session &s,
-    enum RawstorOSTCommandType cmd, enum RawstorOSTCommandType expected)
-{
+    rawstor::ost::Session& s, enum RawstorOSTCommandType cmd,
+    enum RawstorOSTCommandType expected
+) {
     if (cmd == expected) {
         return 0;
     }
@@ -102,99 +95,76 @@ int validate_cmd(
     return EPROTO;
 }
 
-
-int validate_hash(rawstor::ost::Session &s, uint64_t hash, uint64_t expected) {
+int validate_hash(rawstor::ost::Session& s, uint64_t hash, uint64_t expected) {
     if (hash == expected) {
         return 0;
     }
 
     rawstor_error(
-        "%s: Hash mismatch: %llx != %llx\n",
-        s.str().c_str(),
-        (unsigned long long)hash,
-        (unsigned long long)expected);
+        "%s: Hash mismatch: %llx != %llx\n", s.str().c_str(),
+        (unsigned long long)hash, (unsigned long long)expected
+    );
     return EPROTO;
 }
 
-
-}
-
+} // namespace
 
 namespace rawstor {
 namespace ost {
 
-
 class Context final {
-    private:
-        rawstor::ost::Session *_s;
-        std::unordered_map<uint16_t, std::shared_ptr<SessionOp>> _ops;
-        unsigned int _reads;
+private:
+    rawstor::ost::Session* _s;
+    std::unordered_map<uint16_t, std::shared_ptr<SessionOp>> _ops;
+    unsigned int _reads;
 
-    public:
-        Context(rawstor::ost::Session &s):
-            _s(&s),
-            _reads(0)
-        {}
+public:
+    Context(rawstor::ost::Session& s) : _s(&s), _reads(0) {}
 
-        void detach() noexcept {
-            _s = nullptr;
+    void detach() noexcept { _s = nullptr; }
+
+    inline rawstor::ost::Session& session() {
+        if (_s == nullptr) {
+            throw std::runtime_error("Context detached");
+        }
+        return *_s;
+    }
+
+    inline bool has_ops() const noexcept { return !_ops.empty(); }
+
+    inline bool has_reads() const noexcept { return _reads > 0; }
+
+    inline void add_read() noexcept { ++_reads; }
+
+    inline void sub_read() noexcept { --_reads; }
+
+    void register_op(const std::shared_ptr<SessionOp>& op);
+
+    void unregister_op(uint16_t cid) { _ops.erase(cid); }
+
+    SessionOp& find_op(uint16_t cid) {
+        auto it = _ops.find(cid);
+        if (it == _ops.end()) {
+            rawstor_error("Unexpected cid: %u\n", cid);
+            RAWSTOR_THROW_SYSTEM_ERROR(EPROTO);
         }
 
-        inline rawstor::ost::Session& session() {
-            if (_s == nullptr) {
-                throw std::runtime_error("Context detached");
-            }
-            return *_s;
-        }
+        return *it->second.get();
+    }
 
-        inline bool has_ops() const noexcept {
-            return !_ops.empty();
-        }
-
-        inline bool has_reads() const noexcept {
-            return _reads > 0;
-        }
-
-        inline void add_read() noexcept {
-            ++_reads;
-        }
-
-        inline void sub_read() noexcept {
-            --_reads;
-        }
-
-        void register_op(const std::shared_ptr<SessionOp> &op);
-
-        void unregister_op(uint16_t cid) {
-            _ops.erase(cid);
-        }
-
-        SessionOp& find_op(uint16_t cid) {
-            auto it = _ops.find(cid);
-            if (it == _ops.end()) {
-                rawstor_error("Unexpected cid: %u\n", cid);
-                RAWSTOR_THROW_SYSTEM_ERROR(EPROTO);
-            }
-
-            return *it->second.get();
-        }
-
-        void fail_in_flight(int error);
+    void fail_in_flight(int error);
 };
 
-
-}} // rawstor::ost
-
+} // namespace ost
+} // namespace rawstor
 
 namespace {
 
-
-uint64_t hash(void *buf, size_t size) {
+uint64_t hash(void* buf, size_t size) {
     return rawstor_hash_scalar(buf, size);
 }
 
-
-uint64_t hash(iovec *iov, unsigned int niov) {
+uint64_t hash(iovec* iov, unsigned int niov) {
     uint64_t ret;
     int res = rawstor_hash_vector(iov, niov, &ret);
     if (res) {
@@ -203,775 +173,664 @@ uint64_t hash(iovec *iov, unsigned int niov) {
     return ret;
 }
 
-
 class SessionOp {
-    private:
-        uint16_t _cid;
-        bool _in_flight;
+private:
+    uint16_t _cid;
+    bool _in_flight;
 
-    protected:
-        RawstorObject *_o;
-        std::shared_ptr<rawstor::ost::Context> _context;
+protected:
+    RawstorObject* _o;
+    std::shared_ptr<rawstor::ost::Context> _context;
 
-        std::unique_ptr<rawstor::Task> _t;
+    std::unique_ptr<rawstor::Task> _t;
 
-        inline void _dispatch(size_t result, int error) {
-            _in_flight = false;
+    inline void _dispatch(size_t result, int error) {
+        _in_flight = false;
 #ifdef RAWSTOR_TRACE_EVENTS
-            _t->trace(
-                __FILE__, __LINE__, __FUNCTION__,
-                "in-flight end");
+        _t->trace(__FILE__, __LINE__, __FUNCTION__, "in-flight end");
 #endif
 
-            try {
-                (*_t)(_o, result, error);
-            } catch(...) {
-                _context->unregister_op(_cid);
-                throw;
-            }
-
+        try {
+            (*_t)(_o, result, error);
+        } catch (...) {
             _context->unregister_op(_cid);
+            throw;
         }
 
-    public:
-        SessionOp(
-            RawstorObject *o,
-            const std::shared_ptr<rawstor::ost::Context> &context,
-            uint16_t cid,
-            std::unique_ptr<rawstor::Task> t):
-            _cid(cid),
-            _in_flight(false),
-            _o(o),
-            _context(context),
-            _t(std::move(t))
-        {}
+        _context->unregister_op(_cid);
+    }
 
-        SessionOp(const SessionOp &) = delete;
-        SessionOp(SessionOp &&) = delete;
-        virtual ~SessionOp() = default;
+public:
+    SessionOp(
+        RawstorObject* o, const std::shared_ptr<rawstor::ost::Context>& context,
+        uint16_t cid, std::unique_ptr<rawstor::Task> t
+    ) :
+        _cid(cid),
+        _in_flight(false),
+        _o(o),
+        _context(context),
+        _t(std::move(t)) {}
 
-        SessionOp& operator=(const SessionOp &) = delete;
-        SessionOp& operator=(SessionOp &&) = delete;
+    SessionOp(const SessionOp&) = delete;
+    SessionOp(SessionOp&&) = delete;
+    virtual ~SessionOp() = default;
 
-        inline rawstor::ost::Context& context() noexcept {
-            return *_context;
-        }
+    SessionOp& operator=(const SessionOp&) = delete;
+    SessionOp& operator=(SessionOp&&) = delete;
 
-        inline uint16_t cid() const noexcept {
-            return _cid;
-        }
+    inline rawstor::ost::Context& context() noexcept { return *_context; }
 
-        inline bool in_flight() const noexcept {
-            return _in_flight;
-        }
+    inline uint16_t cid() const noexcept { return _cid; }
 
-        void request_cb(int error) {
-            _in_flight = true;
+    inline bool in_flight() const noexcept { return _in_flight; }
+
+    void request_cb(int error) {
+        _in_flight = true;
 #ifdef RAWSTOR_TRACE_EVENTS
-            _t->trace(
-                __FILE__, __LINE__, __FUNCTION__,
-                "in-flight begin");
+        _t->trace(__FILE__, __LINE__, __FUNCTION__, "in-flight begin");
 #endif
 
-            if (error) {
-                _dispatch(0, error);
-            }
-        }
-
-        virtual void response_head_cb(
-            RawstorOSTFrameResponse *, int error) = 0;
-};
-
-
-class SessionOpSetObjectId final: public SessionOp {
-    public:
-        SessionOpSetObjectId(
-            RawstorObject *o,
-            const std::shared_ptr<rawstor::ost::Context> &context,
-            uint16_t cid,
-            std::unique_ptr<rawstor::Task> t):
-            SessionOp(o, context, cid, std::move(t))
-        {
-            rawstor::ost::Session &s = _context->session();
-            rawstor_info("%s: Setting object id\n", s.str().c_str());
-        }
-
-        void response_head_cb(
-            RawstorOSTFrameResponse *response, int error) override
-        {
-            rawstor::ost::Session &s = _context->session();
-
-            if (!error) {
-                error = validate_response(s, response);
-            }
-
-            if (!error) {
-                error = validate_cmd(s, response->cmd, RAWSTOR_CMD_SET_OBJECT);
-            }
-
-            if (!error) {
-                rawstor_info(
-                    "%s: Object id successfully set\n", s.str().c_str());
-            }
-
+        if (error) {
             _dispatch(0, error);
         }
+    }
+
+    virtual void response_head_cb(RawstorOSTFrameResponse*, int error) = 0;
 };
 
+class SessionOpSetObjectId final : public SessionOp {
+public:
+    SessionOpSetObjectId(
+        RawstorObject* o, const std::shared_ptr<rawstor::ost::Context>& context,
+        uint16_t cid, std::unique_ptr<rawstor::Task> t
+    ) :
+        SessionOp(o, context, cid, std::move(t)) {
+        rawstor::ost::Session& s = _context->session();
+        rawstor_info("%s: Setting object id\n", s.str().c_str());
+    }
 
-class SessionOpRead final: public SessionOp {
-    private:
-        uint64_t _hash;
+    void
+    response_head_cb(RawstorOSTFrameResponse* response, int error) override {
+        rawstor::ost::Session& s = _context->session();
 
-    public:
-        SessionOpRead(
-            RawstorObject *o,
-            const std::shared_ptr<rawstor::ost::Context> &context,
-            uint16_t cid,
-            std::unique_ptr<rawstor::TaskScalar> t):
-            SessionOp(o, context, cid, std::move(t)),
-            _hash(0)
-        {}
-
-        size_t size() const noexcept {
-            return static_cast<rawstor::TaskScalar*>(_t.get())->size();
+        if (!error) {
+            error = validate_response(s, response);
         }
 
-        off_t offset() const noexcept {
-            return static_cast<rawstor::TaskScalar*>(_t.get())->offset();
+        if (!error) {
+            error = validate_cmd(s, response->cmd, RAWSTOR_CMD_SET_OBJECT);
         }
 
-        void response_head_cb(
-            RawstorOSTFrameResponse *response, int error) override
-        {
-            rawstor::ost::Session &s = _context->session();
+        if (!error) {
+            rawstor_info("%s: Object id successfully set\n", s.str().c_str());
+        }
 
-            if (!error) {
-                error = validate_response(s, response);
-            }
+        _dispatch(0, error);
+    }
+};
 
-            if (!error) {
-                error = validate_cmd(s, response->cmd, RAWSTOR_CMD_READ);
-            }
+class SessionOpRead final : public SessionOp {
+private:
+    uint64_t _hash;
 
-            if (!error) {
-                _hash = response->hash;
-                s.read_response_body(
-                    *rawstor::io_queue,
-                    cid(),
+public:
+    SessionOpRead(
+        RawstorObject* o, const std::shared_ptr<rawstor::ost::Context>& context,
+        uint16_t cid, std::unique_ptr<rawstor::TaskScalar> t
+    ) :
+        SessionOp(o, context, cid, std::move(t)),
+        _hash(0) {}
+
+    size_t size() const noexcept {
+        return static_cast<rawstor::TaskScalar*>(_t.get())->size();
+    }
+
+    off_t offset() const noexcept {
+        return static_cast<rawstor::TaskScalar*>(_t.get())->offset();
+    }
+
+    void
+    response_head_cb(RawstorOSTFrameResponse* response, int error) override {
+        rawstor::ost::Session& s = _context->session();
+
+        if (!error) {
+            error = validate_response(s, response);
+        }
+
+        if (!error) {
+            error = validate_cmd(s, response->cmd, RAWSTOR_CMD_READ);
+        }
+
+        if (!error) {
+            _hash = response->hash;
+            s.read_response_body(
+                *rawstor::io_queue, cid(),
+                static_cast<rawstor::TaskScalar*>(_t.get())->buf(),
+                static_cast<rawstor::TaskScalar*>(_t.get())->size()
+            );
+        } else {
+            _dispatch(0, error);
+        }
+    }
+
+    void response_body_cb(size_t result, int error) {
+        if (!error) {
+            rawstor::ost::Session& s = _context->session();
+            error = validate_hash(
+                s,
+                hash(
                     static_cast<rawstor::TaskScalar*>(_t.get())->buf(),
-                    static_cast<rawstor::TaskScalar*>(_t.get())->size());
-            } else {
-                _dispatch(0, error);
-            }
+                    static_cast<rawstor::TaskScalar*>(_t.get())->size()
+                ),
+                _hash
+            );
         }
 
-        void response_body_cb(size_t result, int error) {
-            if (!error) {
-                rawstor::ost::Session &s = _context->session();
-                error = validate_hash(
-                    s,
-                    hash(
-                        static_cast<rawstor::TaskScalar*>(_t.get())->buf(),
-                        static_cast<rawstor::TaskScalar*>(_t.get())->size()),
-                    _hash);
-            }
-
-            _dispatch(result, error);
-        }
+        _dispatch(result, error);
+    }
 };
 
+class SessionOpReadV final : public SessionOp {
+private:
+    uint64_t _hash;
 
-class SessionOpReadV final: public SessionOp {
-    private:
-        uint64_t _hash;
+public:
+    SessionOpReadV(
+        RawstorObject* o, const std::shared_ptr<rawstor::ost::Context>& context,
+        uint16_t cid, std::unique_ptr<rawstor::TaskVector> t
+    ) :
+        SessionOp(o, context, cid, std::move(t)),
+        _hash(0) {}
 
-    public:
-        SessionOpReadV(
-            RawstorObject *o,
-            const std::shared_ptr<rawstor::ost::Context> &context,
-            uint16_t cid,
-            std::unique_ptr<rawstor::TaskVector> t):
-            SessionOp(o, context, cid, std::move(t)),
-            _hash(0)
-        {}
+    size_t size() const noexcept {
+        return static_cast<rawstor::TaskVector*>(_t.get())->size();
+    }
 
-        size_t size() const noexcept {
-            return static_cast<rawstor::TaskVector*>(_t.get())->size();
+    off_t offset() const noexcept {
+        return static_cast<rawstor::TaskVector*>(_t.get())->offset();
+    }
+
+    void
+    response_head_cb(RawstorOSTFrameResponse* response, int error) override {
+        rawstor::ost::Session& s = _context->session();
+
+        if (!error) {
+            error = validate_response(s, response);
         }
 
-        off_t offset() const noexcept {
-            return static_cast<rawstor::TaskVector*>(_t.get())->offset();
+        if (!error) {
+            error = validate_cmd(s, response->cmd, RAWSTOR_CMD_READ);
         }
 
-        void response_head_cb(
-            RawstorOSTFrameResponse *response, int error) override
-        {
-            rawstor::ost::Session &s = _context->session();
+        if (!error) {
+            _hash = response->hash;
+            s.read_response_body(
+                *rawstor::io_queue, cid(),
+                static_cast<rawstor::TaskVector*>(_t.get())->iov(),
+                static_cast<rawstor::TaskVector*>(_t.get())->niov(),
+                static_cast<rawstor::TaskVector*>(_t.get())->size()
+            );
+        } else {
+            _dispatch(0, error);
+        }
+    }
 
-            if (!error) {
-                error = validate_response(s, response);
-            }
-
-            if (!error) {
-                error = validate_cmd(s, response->cmd, RAWSTOR_CMD_READ);
-            }
-
-            if (!error) {
-                _hash = response->hash;
-                s.read_response_body(
-                    *rawstor::io_queue,
-                    cid(),
+    void response_body_cb(size_t result, int error) {
+        if (!error) {
+            rawstor::ost::Session& s = _context->session();
+            error = validate_hash(
+                s,
+                hash(
                     static_cast<rawstor::TaskVector*>(_t.get())->iov(),
-                    static_cast<rawstor::TaskVector*>(_t.get())->niov(),
-                    static_cast<rawstor::TaskVector*>(_t.get())->size());
-            } else {
-                _dispatch(0, error);
-            }
+                    static_cast<rawstor::TaskVector*>(_t.get())->niov()
+                ),
+                _hash
+            );
         }
 
-        void response_body_cb(size_t result, int error) {
-            if (!error) {
-                rawstor::ost::Session &s = _context->session();
-                error = validate_hash(
-                    s,
-                    hash(
-                        static_cast<rawstor::TaskVector*>(_t.get())->iov(),
-                        static_cast<rawstor::TaskVector*>(_t.get())->niov()),
-                    _hash);
-            }
-
-            _dispatch(result, error);
-        }
+        _dispatch(result, error);
+    }
 };
 
+class SessionOpWrite final : public SessionOp {
+public:
+    SessionOpWrite(
+        RawstorObject* o, const std::shared_ptr<rawstor::ost::Context>& context,
+        uint16_t cid, std::unique_ptr<rawstor::TaskScalar> t
+    ) :
+        SessionOp(o, context, cid, std::move(t)) {}
 
-class SessionOpWrite final: public SessionOp {
-    public:
-        SessionOpWrite(
-            RawstorObject *o,
-            const std::shared_ptr<rawstor::ost::Context> &context,
-            uint16_t cid,
-            std::unique_ptr<rawstor::TaskScalar> t):
-            SessionOp(o, context, cid, std::move(t))
-        {}
+    void* buf() noexcept {
+        return static_cast<rawstor::TaskScalar*>(_t.get())->buf();
+    }
 
-        void* buf() noexcept {
-            return static_cast<rawstor::TaskScalar*>(_t.get())->buf();
+    size_t size() const noexcept {
+        return static_cast<rawstor::TaskScalar*>(_t.get())->size();
+    }
+
+    off_t offset() const noexcept {
+        return static_cast<rawstor::TaskScalar*>(_t.get())->offset();
+    }
+
+    void
+    response_head_cb(RawstorOSTFrameResponse* response, int error) override {
+        rawstor::ost::Session& s = _context->session();
+
+        if (!error) {
+            error = validate_response(s, response);
         }
 
-        size_t size() const noexcept {
-            return static_cast<rawstor::TaskScalar*>(_t.get())->size();
+        if (!error) {
+            error = validate_cmd(s, response->cmd, RAWSTOR_CMD_WRITE);
         }
 
-        off_t offset() const noexcept {
-            return static_cast<rawstor::TaskScalar*>(_t.get())->offset();
-        }
-
-        void response_head_cb(
-            RawstorOSTFrameResponse *response, int error) override
-        {
-            rawstor::ost::Session &s = _context->session();
-
-            if (!error) {
-                error = validate_response(s, response);
-            }
-
-            if (!error) {
-                error = validate_cmd(s, response->cmd, RAWSTOR_CMD_WRITE);
-            }
-
-            _dispatch(response != nullptr ? response->res : 0, error);
-        }
+        _dispatch(response != nullptr ? response->res : 0, error);
+    }
 };
 
+class SessionOpWriteV final : public SessionOp {
+public:
+    SessionOpWriteV(
+        RawstorObject* o, const std::shared_ptr<rawstor::ost::Context>& context,
+        uint16_t cid, std::unique_ptr<rawstor::TaskVector> t
+    ) :
+        SessionOp(o, context, cid, std::move(t)) {}
 
-class SessionOpWriteV final: public SessionOp {
-    public:
-        SessionOpWriteV(
-            RawstorObject *o,
-            const std::shared_ptr<rawstor::ost::Context> &context,
-            uint16_t cid,
-            std::unique_ptr<rawstor::TaskVector> t):
-            SessionOp(o, context, cid, std::move(t))
-        {}
+    iovec* iov() noexcept {
+        return static_cast<rawstor::TaskVector*>(_t.get())->iov();
+    }
 
-        iovec* iov() noexcept {
-            return static_cast<rawstor::TaskVector*>(_t.get())->iov();
+    unsigned int niov() noexcept {
+        return static_cast<rawstor::TaskVector*>(_t.get())->niov();
+    }
+
+    size_t size() const noexcept {
+        return static_cast<rawstor::TaskVector*>(_t.get())->size();
+    }
+
+    off_t offset() const noexcept {
+        return static_cast<rawstor::TaskVector*>(_t.get())->offset();
+    }
+
+    void
+    response_head_cb(RawstorOSTFrameResponse* response, int error) override {
+        rawstor::ost::Session& s = _context->session();
+
+        if (!error) {
+            error = validate_response(s, response);
         }
 
-        unsigned int niov() noexcept {
-            return static_cast<rawstor::TaskVector*>(_t.get())->niov();
+        if (!error) {
+            error = validate_cmd(s, response->cmd, RAWSTOR_CMD_WRITE);
         }
 
-        size_t size() const noexcept {
-            return static_cast<rawstor::TaskVector*>(_t.get())->size();
-        }
-
-        off_t offset() const noexcept {
-            return static_cast<rawstor::TaskVector*>(_t.get())->offset();
-        }
-
-        void response_head_cb(
-            RawstorOSTFrameResponse *response, int error) override
-        {
-            rawstor::ost::Session &s = _context->session();
-
-            if (!error) {
-                error = validate_response(s, response);
-            }
-
-            if (!error) {
-                error = validate_cmd(s, response->cmd, RAWSTOR_CMD_WRITE);
-            }
-
-            _dispatch(response != nullptr ? response->res : 0, error);
-        }
+        _dispatch(response != nullptr ? response->res : 0, error);
+    }
 };
 
+class RequestScalar : public rawstor::io::TaskScalar {
+protected:
+    std::shared_ptr<SessionOp> _op;
 
-class RequestScalar: public rawstor::io::TaskScalar {
-    protected:
-        std::shared_ptr<SessionOp> _op;
+public:
+    RequestScalar(int fd, const std::shared_ptr<SessionOp>& op) :
+        rawstor::io::TaskScalar(fd),
+        _op(op) {}
 
-    public:
-        RequestScalar(int fd, const std::shared_ptr<SessionOp> &op):
-            rawstor::io::TaskScalar(fd),
-            _op(op)
-        {}
+    void operator()(size_t result, int error) override {
+        t_trace(*this, result, error);
 
-        void operator()(size_t result, int error) override {
-            t_trace(*this, result, error);
-
-            if (!error) {
-                error = validate_result(result, *this);
-            }
-
-            _op->request_cb(error);
-        }
-};
-
-
-class RequestVector: public rawstor::io::TaskVector {
-    protected:
-        std::shared_ptr<SessionOp> _op;
-
-    public:
-        RequestVector(int fd, const std::shared_ptr<SessionOp> &op):
-            rawstor::io::TaskVector(fd),
-            _op(op)
-        {}
-
-        void operator()(size_t result, int error) override {
-            t_trace(*this, result, error);
-
-            if (!error) {
-                error = validate_result(result, *this);
-            }
-
-            _op->request_cb(error);
-        }
-};
-
-
-class RequestBasic: public RequestScalar {
-    protected:
-        RawstorOSTFrameBasic _request;
-
-    public:
-        RequestBasic(
-            int fd,
-            const std::shared_ptr<SessionOp> &op,
-            const RawstorUUID &id,
-            const RawstorOSTCommandType &cmd):
-            RequestScalar(fd, op),
-            _request({
-                .magic = RAWSTOR_MAGIC,
-                .cmd = cmd,
-                .obj_id = {},
-                .offset = 0,
-                .val = 0,
-            })
-        {
-            memcpy(
-                _request.obj_id,
-                id.bytes,
-                sizeof(_request.obj_id));
+        if (!error) {
+            error = validate_result(result, *this);
         }
 
-        void* buf() noexcept override {
-            return &_request;
+        _op->request_cb(error);
+    }
+};
+
+class RequestVector : public rawstor::io::TaskVector {
+protected:
+    std::shared_ptr<SessionOp> _op;
+
+public:
+    RequestVector(int fd, const std::shared_ptr<SessionOp>& op) :
+        rawstor::io::TaskVector(fd),
+        _op(op) {}
+
+    void operator()(size_t result, int error) override {
+        t_trace(*this, result, error);
+
+        if (!error) {
+            error = validate_result(result, *this);
         }
 
-        size_t size() const noexcept override {
-            return sizeof(_request);
-        }
+        _op->request_cb(error);
+    }
 };
 
+class RequestBasic : public RequestScalar {
+protected:
+    RawstorOSTFrameBasic _request;
 
-class RequestSetObjectId final: public RequestBasic {
-    public:
-        RequestSetObjectId(
-            int fd,
-            const std::shared_ptr<SessionOp> &op,
-            const RawstorUUID &id):
-            RequestBasic(fd, op, id, RAWSTOR_CMD_SET_OBJECT)
-        {}
+public:
+    RequestBasic(
+        int fd, const std::shared_ptr<SessionOp>& op, const RawstorUUID& id,
+        const RawstorOSTCommandType& cmd
+    ) :
+        RequestScalar(fd, op),
+        _request({
+            .magic = RAWSTOR_MAGIC,
+            .cmd = cmd,
+            .obj_id = {},
+            .offset = 0,
+            .val = 0,
+        }) {
+        memcpy(_request.obj_id, id.bytes, sizeof(_request.obj_id));
+    }
+
+    void* buf() noexcept override { return &_request; }
+
+    size_t size() const noexcept override { return sizeof(_request); }
 };
 
-
-class RequestIOScalar: public RequestScalar {
-    protected:
-        RawstorOSTFrameIO _request;
-
-    public:
-        RequestIOScalar(
-            int fd,
-            const std::shared_ptr<SessionOpRead> &op,
-            const RawstorOSTCommandType &cmd,
-            uint64_t hash):
-            RequestScalar(fd, op),
-            _request({
-                .magic = RAWSTOR_MAGIC,
-                .cmd = cmd,
-                .cid = op->cid(),
-                .offset = (uint64_t)op->offset(),
-                .len = (uint32_t)op->size(),
-                .hash = hash,
-                .sync = 0,
-            })
-        {}
-
-        RequestIOScalar(
-            int fd,
-            const std::shared_ptr<SessionOpReadV> &op,
-            const RawstorOSTCommandType &cmd,
-            uint64_t hash):
-            RequestScalar(fd, op),
-            _request({
-                .magic = RAWSTOR_MAGIC,
-                .cmd = cmd,
-                .cid = op->cid(),
-                .offset = (uint64_t)op->offset(),
-                .len = (uint32_t)op->size(),
-                .hash = hash,
-                .sync = 0,
-            })
-        {}
+class RequestSetObjectId final : public RequestBasic {
+public:
+    RequestSetObjectId(
+        int fd, const std::shared_ptr<SessionOp>& op, const RawstorUUID& id
+    ) :
+        RequestBasic(fd, op, id, RAWSTOR_CMD_SET_OBJECT) {}
 };
 
+class RequestIOScalar : public RequestScalar {
+protected:
+    RawstorOSTFrameIO _request;
 
-class RequestIOVector: public RequestVector {
-    protected:
-        RawstorOSTFrameIO _request;
+public:
+    RequestIOScalar(
+        int fd, const std::shared_ptr<SessionOpRead>& op,
+        const RawstorOSTCommandType& cmd, uint64_t hash
+    ) :
+        RequestScalar(fd, op),
+        _request({
+            .magic = RAWSTOR_MAGIC,
+            .cmd = cmd,
+            .cid = op->cid(),
+            .offset = (uint64_t)op->offset(),
+            .len = (uint32_t)op->size(),
+            .hash = hash,
+            .sync = 0,
+        }) {}
 
-    public:
+    RequestIOScalar(
+        int fd, const std::shared_ptr<SessionOpReadV>& op,
+        const RawstorOSTCommandType& cmd, uint64_t hash
+    ) :
+        RequestScalar(fd, op),
+        _request({
+            .magic = RAWSTOR_MAGIC,
+            .cmd = cmd,
+            .cid = op->cid(),
+            .offset = (uint64_t)op->offset(),
+            .len = (uint32_t)op->size(),
+            .hash = hash,
+            .sync = 0,
+        }) {}
+};
+
+class RequestIOVector : public RequestVector {
+protected:
+    RawstorOSTFrameIO _request;
+
+public:
+    RequestIOVector(
+        int fd, const std::shared_ptr<SessionOpWrite>& op,
+        const RawstorOSTCommandType& cmd, uint64_t hash
+    ) :
+        RequestVector(fd, op),
+        _request({
+            .magic = RAWSTOR_MAGIC,
+            .cmd = cmd,
+            .cid = op->cid(),
+            .offset = (uint64_t)op->offset(),
+            .len = (uint32_t)op->size(),
+            .hash = hash,
+            .sync = 0,
+        }) {}
+
+    RequestIOVector(
+        int fd, const std::shared_ptr<SessionOpWriteV>& op,
+        const RawstorOSTCommandType& cmd, uint64_t hash
+    ) :
+        RequestVector(fd, op),
+        _request({
+            .magic = RAWSTOR_MAGIC,
+            .cmd = cmd,
+            .cid = op->cid(),
+            .offset = (uint64_t)op->offset(),
+            .len = (uint32_t)op->size(),
+            .hash = hash,
+            .sync = 0,
+        }) {}
+};
+
+class RequestCmdRead final : public RequestIOScalar {
+public:
+    RequestCmdRead(int fd, const std::shared_ptr<SessionOpRead>& op) :
+        RequestIOScalar(fd, op, RAWSTOR_CMD_READ, 0) {}
+
+    RequestCmdRead(int fd, const std::shared_ptr<SessionOpReadV>& op) :
+        RequestIOScalar(fd, op, RAWSTOR_CMD_READ, 0) {}
+
+    void* buf() noexcept override { return &_request; }
+
+    size_t size() const noexcept override { return sizeof(_request); }
+};
+
+class RequestCmdWrite final : public RequestIOVector {
+private:
+    std::vector<iovec> _iov;
+
+public:
+    RequestCmdWrite(int fd, const std::shared_ptr<SessionOpWrite>& op) :
         RequestIOVector(
-            int fd,
-            const std::shared_ptr<SessionOpWrite> &op,
-            const RawstorOSTCommandType &cmd,
-            uint64_t hash):
-            RequestVector(fd, op),
-            _request({
-                .magic = RAWSTOR_MAGIC,
-                .cmd = cmd,
-                .cid = op->cid(),
-                .offset = (uint64_t)op->offset(),
-                .len = (uint32_t)op->size(),
-                .hash = hash,
-                .sync = 0,
-            })
-        {}
+            fd, op, RAWSTOR_CMD_WRITE, hash(op->buf(), op->size())
+        ) {
+        _iov.reserve(2);
+        _iov.push_back({
+            .iov_base = &_request,
+            .iov_len = sizeof(_request),
+        });
+        _iov.push_back({
+            .iov_base = op->buf(),
+            .iov_len = op->size(),
+        });
+    }
 
+    RequestCmdWrite(int fd, const std::shared_ptr<SessionOpWriteV>& op) :
         RequestIOVector(
-            int fd,
-            const std::shared_ptr<SessionOpWriteV> &op,
-            const RawstorOSTCommandType &cmd,
-            uint64_t hash):
-            RequestVector(fd, op),
-            _request({
-                .magic = RAWSTOR_MAGIC,
-                .cmd = cmd,
-                .cid = op->cid(),
-                .offset = (uint64_t)op->offset(),
-                .len = (uint32_t)op->size(),
-                .hash = hash,
-                .sync = 0,
-            })
-        {}
+            fd, op, RAWSTOR_CMD_WRITE, hash(op->iov(), op->niov())
+        ) {
+        _iov.reserve(op->niov() + 1);
+        _iov.push_back({
+            .iov_base = &_request,
+            .iov_len = sizeof(_request),
+        });
+        for (unsigned int i = 0; i < op->niov(); ++i) {
+            _iov.push_back(op->iov()[i]);
+        }
+    }
+
+    iovec* iov() noexcept override { return _iov.data(); }
+
+    unsigned int niov() const noexcept override { return _iov.size(); }
+
+    size_t size() const noexcept override {
+        return sizeof(_request) + _request.len;
+    }
 };
 
+class ResponseHead final : public rawstor::io::TaskScalar {
+private:
+    std::shared_ptr<rawstor::ost::Context> _context;
+    RawstorOSTFrameResponse _response;
 
-class RequestCmdRead final: public RequestIOScalar {
-    public:
-        RequestCmdRead(
-            int fd,
-            const std::shared_ptr<SessionOpRead> &op):
-            RequestIOScalar(fd, op, RAWSTOR_CMD_READ, 0)
-        {}
+public:
+    ResponseHead(
+        int fd, const std::shared_ptr<rawstor::ost::Context>& context
+    ) :
+        rawstor::io::TaskScalar(fd),
+        _context(context) {
+        _context->add_read();
+    }
 
-        RequestCmdRead(
-            int fd,
-            const std::shared_ptr<SessionOpReadV> &op):
-            RequestIOScalar(fd, op, RAWSTOR_CMD_READ, 0)
-        {}
+    void operator()(size_t result, int error) override {
+        t_trace(*this, result, error);
 
-        void* buf() noexcept override {
-            return &_request;
+        _context->sub_read();
+        if (!error) {
+            error = validate_result(result, *this);
         }
 
-        size_t size() const noexcept override {
-            return sizeof(_request);
+        if (error) {
+            _context->fail_in_flight(error);
+        } else {
+            try {
+                SessionOp& op = _context->find_op(_response.cid);
+                op.response_head_cb(&_response, 0);
+            } catch (const std::system_error& e) {
+                _context->fail_in_flight(e.code().value());
+            }
         }
+        if (_context->has_ops() && !_context->has_reads()) {
+            _context->session().read_response_head(*rawstor::io_queue);
+        }
+    }
+
+    inline void* buf() noexcept override { return &_response; }
+
+    inline size_t size() const noexcept override { return sizeof(_response); }
 };
 
+class ResponseBodyScalar final : public rawstor::io::TaskScalar {
+private:
+    std::shared_ptr<rawstor::ost::Context> _context;
+    uint16_t _cid;
+    void* _buf;
+    size_t _size;
 
-class RequestCmdWrite final: public RequestIOVector {
-    private:
-        std::vector<iovec> _iov;
+public:
+    ResponseBodyScalar(
+        int fd, const std::shared_ptr<rawstor::ost::Context>& context,
+        uint16_t cid, void* buf, size_t size
+    ) :
+        rawstor::io::TaskScalar(fd),
+        _context(context),
+        _cid(cid),
+        _buf(buf),
+        _size(size) {
+        _context->add_read();
+    }
 
-    public:
-        RequestCmdWrite(
-            int fd,
-            const std::shared_ptr<SessionOpWrite> &op):
-            RequestIOVector(
-                fd, op, RAWSTOR_CMD_WRITE,
-                hash(op->buf(), op->size()))
-        {
-            _iov.reserve(2);
-            _iov.push_back({
-                .iov_base = &_request,
-                .iov_len = sizeof(_request),
-            });
-            _iov.push_back({
-                .iov_base = op->buf(),
-                .iov_len = op->size(),
-            });
+    void operator()(size_t result, int error) override {
+        t_trace(*this, result, error);
+
+        _context->sub_read();
+        SessionOp& op = _context->find_op(_cid);
+
+        if (!error) {
+            error = validate_result(result, *this);
         }
 
-        RequestCmdWrite(
-            int fd,
-            const std::shared_ptr<SessionOpWriteV> &op):
-            RequestIOVector(
-                fd, op, RAWSTOR_CMD_WRITE,
-                hash(op->iov(), op->niov()))
-        {
-            _iov.reserve(op->niov() + 1);
-            _iov.push_back({
-                .iov_base = &_request,
-                .iov_len = sizeof(_request),
-            });
-            for (unsigned int i = 0; i < op->niov(); ++i) {
-                _iov.push_back(op->iov()[i]);
-            }
-        }
+        static_cast<SessionOpRead&>(op).response_body_cb(result, error);
 
-        iovec* iov() noexcept override {
-            return _iov.data();
+        if (_context->has_ops() && !_context->has_reads()) {
+            _context->session().read_response_head(*rawstor::io_queue);
         }
+    }
 
-        unsigned int niov() const noexcept override {
-            return _iov.size();
-        }
-
-        size_t size() const noexcept override {
-            return sizeof(_request) + _request.len;
-        }
+    void* buf() noexcept override { return _buf; }
+    size_t size() const noexcept override { return _size; }
 };
 
+class ResponseBodyVector final : public rawstor::io::TaskVector {
+private:
+    std::shared_ptr<rawstor::ost::Context> _context;
+    uint16_t _cid;
+    iovec* _iov;
+    unsigned int _niov;
+    size_t _size;
 
-class ResponseHead final: public rawstor::io::TaskScalar {
-    private:
-        std::shared_ptr<rawstor::ost::Context> _context;
-        RawstorOSTFrameResponse _response;
+public:
+    ResponseBodyVector(
+        int fd, const std::shared_ptr<rawstor::ost::Context>& context,
+        uint16_t cid, iovec* iov, unsigned int niov, size_t size
+    ) :
+        rawstor::io::TaskVector(fd),
+        _context(context),
+        _cid(cid),
+        _iov(iov),
+        _niov(niov),
+        _size(size) {
+        _context->add_read();
+    }
 
-    public:
-        ResponseHead(
-            int fd,
-            const std::shared_ptr<rawstor::ost::Context> &context):
-            rawstor::io::TaskScalar(fd),
-            _context(context)
-        {
-            _context->add_read();
+    void operator()(size_t result, int error) override {
+        t_trace(*this, result, error);
+
+        _context->sub_read();
+        SessionOp& op = _context->find_op(_cid);
+
+        if (!error) {
+            error = validate_result(result, *this);
         }
 
-        void operator()(size_t result, int error) override {
-            t_trace(*this, result, error);
+        static_cast<SessionOpReadV&>(op).response_body_cb(result, error);
 
-            _context->sub_read();
-            if (!error) {
-                error = validate_result(result, *this);
-            }
-
-            if (error) {
-                _context->fail_in_flight(error);
-            } else {
-                try {
-                    SessionOp &op = _context->find_op(_response.cid);
-                    op.response_head_cb(&_response, 0);
-                } catch (std::system_error &e) {
-                    _context->fail_in_flight(e.code().value());
-                }
-            }
-            if (_context->has_ops() && !_context->has_reads()) {
-                _context->session().read_response_head(
-                    *rawstor::io_queue);
-            }
+        if (_context->has_ops() && !_context->has_reads()) {
+            _context->session().read_response_head(*rawstor::io_queue);
         }
+    }
 
-        inline void* buf() noexcept override {
-            return &_response;
-        }
+    iovec* iov() noexcept override { return _iov; }
 
-        inline size_t size() const noexcept override {
-            return sizeof(_response);
-        }
+    unsigned int niov() const noexcept override { return _niov; }
+
+    size_t size() const noexcept override { return _size; }
 };
 
-
-class ResponseBodyScalar final: public rawstor::io::TaskScalar {
-    private:
-        std::shared_ptr<rawstor::ost::Context> _context;
-        uint16_t _cid;
-        void *_buf;
-        size_t _size;
-
-    public:
-        ResponseBodyScalar(
-            int fd,
-            const std::shared_ptr<rawstor::ost::Context> &context,
-            uint16_t cid,
-            void *buf, size_t size):
-            rawstor::io::TaskScalar(fd),
-            _context(context),
-            _cid(cid),
-            _buf(buf),
-            _size(size)
-        {
-            _context->add_read();
-        }
-
-        void operator()(size_t result, int error) override {
-            t_trace(*this, result, error);
-
-            _context->sub_read();
-            SessionOp &op = _context->find_op(_cid);
-
-            if (!error) {
-                error = validate_result(result, *this);
-            }
-
-            static_cast<SessionOpRead&>(op).response_body_cb(result, error);
-
-            if (_context->has_ops() && !_context->has_reads()) {
-                _context->session().read_response_head(*rawstor::io_queue);
-            }
-        }
-
-        void* buf() noexcept override {
-            return _buf;
-        }
-        size_t size() const noexcept override {
-            return _size;
-        }
-};
-
-
-class ResponseBodyVector final: public rawstor::io::TaskVector {
-    private:
-        std::shared_ptr<rawstor::ost::Context> _context;
-        uint16_t _cid;
-        iovec *_iov;
-        unsigned int _niov;
-        size_t _size;
-
-    public:
-        ResponseBodyVector(
-            int fd,
-            const std::shared_ptr<rawstor::ost::Context> &context,
-            uint16_t cid,
-            iovec *iov, unsigned int niov, size_t size):
-            rawstor::io::TaskVector(fd),
-            _context(context),
-            _cid(cid),
-            _iov(iov),
-            _niov(niov),
-            _size(size)
-        {
-            _context->add_read();
-        }
-
-        void operator()(size_t result, int error) override {
-            t_trace(*this, result, error);
-
-            _context->sub_read();
-            SessionOp &op = _context->find_op(_cid);
-
-            if (!error) {
-                error = validate_result(result, *this);
-            }
-
-            static_cast<SessionOpReadV&>(op).response_body_cb(result, error);
-
-            if (_context->has_ops() && !_context->has_reads()) {
-                _context->session().read_response_head(*rawstor::io_queue);
-            }
-        }
-
-        iovec* iov() noexcept override {
-            return _iov;
-        }
-
-        unsigned int niov() const noexcept override {
-            return _niov;
-        }
-
-        size_t size() const noexcept override {
-            return _size;
-        }
-};
-
-
-} // unnamed
-
+} // namespace
 
 namespace rawstor {
 namespace ost {
 
-
-void Context::register_op(const std::shared_ptr<SessionOp> &op) {
+void Context::register_op(const std::shared_ptr<SessionOp>& op) {
     _ops[op->cid()] = op;
 }
-
 
 void Context::fail_in_flight(int error) {
     std::vector<std::shared_ptr<SessionOp>> in_flight_ops;
     in_flight_ops.reserve(_ops.size());
-    for (const auto &i: _ops) {
+    for (const auto& i : _ops) {
         if (i.second->in_flight()) {
             in_flight_ops.push_back(i.second);
         }
     }
-    for (auto i: in_flight_ops) {
+    for (auto i : in_flight_ops) {
         i->response_head_cb(nullptr, error);
     }
 }
 
-
-Session::Session(const URI &uri, unsigned int depth):
+Session::Session(const URI& uri, unsigned int depth) :
     rawstor::Session(uri, depth),
     _cid_counter(0),
-    _context(std::make_shared<Context>(*this))
-{
+    _context(std::make_shared<Context>(*this)) {
     int fd = _connect();
     set_fd(fd);
 }
 
-
 Session::~Session() {
     _context->detach();
 }
-
 
 int Session::_connect() {
     if (!uri().path().str().empty() && uri().path().str() != "/") {
@@ -1039,63 +898,51 @@ int Session::_connect() {
     return fd;
 }
 
-
-void Session::read_response_head(rawstor::io::Queue &queue) {
+void Session::read_response_head(rawstor::io::Queue& queue) {
     std::unique_ptr<ResponseHead> res =
-        std::make_unique<ResponseHead>(
-            fd(), _context);
+        std::make_unique<ResponseHead>(fd(), _context);
     queue.read(std::move(res));
 }
 
-
 void Session::read_response_body(
-    rawstor::io::Queue &queue, uint16_t cid,
-    void *buf, size_t size)
-{
+    rawstor::io::Queue& queue, uint16_t cid, void* buf, size_t size
+) {
     std::unique_ptr<ResponseBodyScalar> res =
-        std::make_unique<ResponseBodyScalar>(
-            fd(), _context, cid, buf, size);
+        std::make_unique<ResponseBodyScalar>(fd(), _context, cid, buf, size);
     queue.read(std::move(res));
 }
 
-
 void Session::read_response_body(
-    rawstor::io::Queue &queue, uint16_t cid,
-    iovec *iov, unsigned int niov, size_t size)
-{
+    rawstor::io::Queue& queue, uint16_t cid, iovec* iov, unsigned int niov,
+    size_t size
+) {
     std::unique_ptr<ResponseBodyVector> res =
         std::make_unique<ResponseBodyVector>(
-            fd(), _context, cid, iov, niov, size);
+            fd(), _context, cid, iov, niov, size
+        );
     queue.read(std::move(res));
 }
 
-
 void Session::create(
-    rawstor::io::Queue &,
-    const RawstorUUID &, const RawstorObjectSpec &,
-    std::unique_ptr<rawstor::Task> t)
-{
+    rawstor::io::Queue&, const RawstorUUID&, const RawstorObjectSpec&,
+    std::unique_ptr<rawstor::Task> t
+) {
     /**
      * TODO: Implement me.
      */
     (*t)(nullptr, 0, 0);
 }
 
-
 void Session::remove(
-    rawstor::io::Queue &,
-    const RawstorUUID &,
-    std::unique_ptr<rawstor::Task>)
-{
+    rawstor::io::Queue&, const RawstorUUID&, std::unique_ptr<rawstor::Task>
+) {
     throw std::runtime_error("Session::remove() not implemented");
 }
 
-
 void Session::spec(
-    rawstor::io::Queue &,
-    const RawstorUUID &, RawstorObjectSpec *sp,
-    std::unique_ptr<rawstor::Task> t)
-{
+    rawstor::io::Queue&, const RawstorUUID&, RawstorObjectSpec* sp,
+    std::unique_ptr<rawstor::Task> t
+) {
     rawstor_info("%s: Reading object specification...\n", str().c_str());
 
     /**
@@ -1107,22 +954,22 @@ void Session::spec(
 
     rawstor_info(
         "%s: Object specification successfully received (emulated)\n",
-        str().c_str());
+        str().c_str()
+    );
 
     (*t)(nullptr, 0, 0);
 }
 
-
 void Session::set_object(
-    rawstor::io::Queue &queue,
-    RawstorObject *object,
-    std::unique_ptr<rawstor::Task> t)
-{
+    rawstor::io::Queue& queue, RawstorObject* object,
+    std::unique_ptr<rawstor::Task> t
+) {
     assert(_cid_counter == 0); // OST returns always 0.
 
     std::shared_ptr<SessionOpSetObjectId> op =
         std::make_shared<SessionOpSetObjectId>(
-            object, _context, _cid_counter++, std::move(t));
+            object, _context, _cid_counter++, std::move(t)
+        );
     _context->register_op(op);
 
     std::unique_ptr<RequestSetObjectId> req =
@@ -1136,15 +983,15 @@ void Session::set_object(
     _o = object;
 }
 
-
 void Session::read(std::unique_ptr<rawstor::TaskScalar> t) {
     rawstor_debug(
-        "%s(): fd = %d, offset = %jd, size = %zu\n",
-        __FUNCTION__, fd(), (intmax_t)t->offset(), t->size());
+        "%s(): fd = %d, offset = %jd, size = %zu\n", __FUNCTION__, fd(),
+        (intmax_t)t->offset(), t->size()
+    );
 
-    std::shared_ptr<SessionOpRead> op =
-        std::make_shared<SessionOpRead>(
-            _o, _context, _cid_counter++, std::move(t));
+    std::shared_ptr<SessionOpRead> op = std::make_shared<SessionOpRead>(
+        _o, _context, _cid_counter++, std::move(t)
+    );
     _context->register_op(op);
 
     std::unique_ptr<RequestCmdRead> req =
@@ -1155,16 +1002,16 @@ void Session::read(std::unique_ptr<rawstor::TaskScalar> t) {
         read_response_head(*io_queue);
     }
 }
-
 
 void Session::read(std::unique_ptr<rawstor::TaskVector> t) {
     rawstor_debug(
-        "%s(): fd = %d, offset = %jd, niov = %u, size = %zu\n",
-        __FUNCTION__, fd(), (intmax_t)t->offset(), t->niov(), t->size());
+        "%s(): fd = %d, offset = %jd, niov = %u, size = %zu\n", __FUNCTION__,
+        fd(), (intmax_t)t->offset(), t->niov(), t->size()
+    );
 
-    std::shared_ptr<SessionOpReadV> op =
-        std::make_shared<SessionOpReadV>(
-            _o, _context, _cid_counter++, std::move(t));
+    std::shared_ptr<SessionOpReadV> op = std::make_shared<SessionOpReadV>(
+        _o, _context, _cid_counter++, std::move(t)
+    );
     _context->register_op(op);
 
     std::unique_ptr<RequestCmdRead> req =
@@ -1176,15 +1023,15 @@ void Session::read(std::unique_ptr<rawstor::TaskVector> t) {
     }
 }
 
-
 void Session::write(std::unique_ptr<rawstor::TaskScalar> t) {
     rawstor_debug(
-        "%s(): fd = %d, offset = %jd, size = %zu\n",
-        __FUNCTION__, fd(), (intmax_t)t->offset(), t->size());
+        "%s(): fd = %d, offset = %jd, size = %zu\n", __FUNCTION__, fd(),
+        (intmax_t)t->offset(), t->size()
+    );
 
-    std::shared_ptr<SessionOpWrite> op =
-        std::make_shared<SessionOpWrite>(
-            _o, _context, _cid_counter++, std::move(t));
+    std::shared_ptr<SessionOpWrite> op = std::make_shared<SessionOpWrite>(
+        _o, _context, _cid_counter++, std::move(t)
+    );
     _context->register_op(op);
 
     std::unique_ptr<RequestCmdWrite> req =
@@ -1195,16 +1042,16 @@ void Session::write(std::unique_ptr<rawstor::TaskScalar> t) {
         read_response_head(*io_queue);
     }
 }
-
 
 void Session::write(std::unique_ptr<rawstor::TaskVector> t) {
     rawstor_debug(
-        "%s(): fd = %d, offset = %jd, niov = %u, size = %zu\n",
-        __FUNCTION__, fd(), (intmax_t)t->offset(), t->niov(), t->size());
+        "%s(): fd = %d, offset = %jd, niov = %u, size = %zu\n", __FUNCTION__,
+        fd(), (intmax_t)t->offset(), t->niov(), t->size()
+    );
 
-    std::shared_ptr<SessionOpWriteV> op =
-        std::make_shared<SessionOpWriteV>(
-            _o, _context, _cid_counter++, std::move(t));
+    std::shared_ptr<SessionOpWriteV> op = std::make_shared<SessionOpWriteV>(
+        _o, _context, _cid_counter++, std::move(t)
+    );
     _context->register_op(op);
 
     std::unique_ptr<RequestCmdWrite> req =
@@ -1216,5 +1063,5 @@ void Session::write(std::unique_ptr<rawstor::TaskVector> t) {
     }
 }
 
-
-}} // rawstor::ost
+} // namespace ost
+} // namespace rawstor

--- a/src/ost_session.hpp
+++ b/src/ost_session.hpp
@@ -1,8 +1,8 @@
 #ifndef RAWSTOR_OST_SESSION_HPP
 #define RAWSTOR_OST_SESSION_HPP
 
-#include "session.hpp"
 #include "ost_protocol.h"
+#include "session.hpp"
 
 #include <rawstorstd/ringbuf.hpp>
 #include <rawstorstd/uri.hpp>
@@ -21,61 +21,60 @@
 namespace rawstor {
 namespace ost {
 
-
 class Context;
 
+class Session final : public rawstor::Session {
+private:
+    RawstorObject* _o;
+    uint16_t _cid_counter;
 
-class Session final: public rawstor::Session {
-    private:
-        RawstorObject *_o;
-        uint16_t _cid_counter;
+    std::shared_ptr<Context> _context;
 
-        std::shared_ptr<Context> _context;
+    int _connect();
 
-        int _connect();
+public:
+    Session(const URI& uri, unsigned int depth);
+    ~Session();
 
-    public:
-        Session(const URI &uri, unsigned int depth);
-        ~Session();
+    void read_response_head(rawstor::io::Queue& queue);
+    void read_response_body(
+        rawstor::io::Queue& queue, uint16_t cid, void* buf, size_t size
+    );
+    void read_response_body(
+        rawstor::io::Queue& queue, uint16_t cid, iovec* iov, unsigned int niov,
+        size_t size
+    );
 
-        void read_response_head(rawstor::io::Queue &queue);
-        void read_response_body(
-            rawstor::io::Queue &queue, uint16_t cid,
-            void *buf, size_t size);
-        void read_response_body(
-            rawstor::io::Queue &queue, uint16_t cid,
-            iovec *iov, unsigned int niov, size_t size);
+    void create(
+        rawstor::io::Queue& queue, const RawstorUUID& id,
+        const RawstorObjectSpec& sp, std::unique_ptr<rawstor::Task> t
+    ) override;
 
-        void create(
-            rawstor::io::Queue &queue,
-            const RawstorUUID &id, const RawstorObjectSpec &sp,
-            std::unique_ptr<rawstor::Task> t) override;
+    void remove(
+        rawstor::io::Queue& queue, const RawstorUUID& id,
+        std::unique_ptr<rawstor::Task> t
+    ) override;
 
-        void remove(
-            rawstor::io::Queue &queue,
-            const RawstorUUID &id,
-            std::unique_ptr<rawstor::Task> t) override;
+    void spec(
+        rawstor::io::Queue& queue, const RawstorUUID& id, RawstorObjectSpec* sp,
+        std::unique_ptr<rawstor::Task> t
+    ) override;
 
-        void spec(
-            rawstor::io::Queue &queue,
-            const RawstorUUID &id, RawstorObjectSpec *sp,
-            std::unique_ptr<rawstor::Task> t) override;
+    void set_object(
+        rawstor::io::Queue& queue, RawstorObject* object,
+        std::unique_ptr<rawstor::Task> t
+    ) override;
 
-        void set_object(
-            rawstor::io::Queue &queue,
-            RawstorObject *object,
-            std::unique_ptr<rawstor::Task> t) override;
+    void read(std::unique_ptr<rawstor::TaskScalar> t) override;
 
-        void read(std::unique_ptr<rawstor::TaskScalar> t) override;
+    void read(std::unique_ptr<rawstor::TaskVector> t) override;
 
-        void read(std::unique_ptr<rawstor::TaskVector> t) override;
+    void write(std::unique_ptr<rawstor::TaskScalar> t) override;
 
-        void write(std::unique_ptr<rawstor::TaskScalar> t) override;
-
-        void write(std::unique_ptr<rawstor::TaskVector> t) override;
+    void write(std::unique_ptr<rawstor::TaskVector> t) override;
 };
 
-
-}} // rawstor::ost
+} // namespace ost
+} // namespace rawstor
 
 #endif // RAWSTOR_OST_SESSION_HPP

--- a/src/rawstor.cpp
+++ b/src/rawstor.cpp
@@ -7,8 +7,8 @@
 #include <rawstorstd/logging.h>
 #include <rawstorstd/uri.hpp>
 
-#include <rawstorio/task.hpp>
 #include <rawstorio/queue.hpp>
+#include <rawstorio/task.hpp>
 
 #include <sys/types.h>
 #include <sys/uio.h>
@@ -24,194 +24,158 @@
 #include <cstdlib>
 #include <cstring>
 
-
 #define QUEUE_DEPTH 256
-
 
 namespace {
 
+class TaskScalar final : public rawstor::io::TaskScalar {
+private:
+    void* _buf;
+    size_t _size;
 
-class TaskScalar final: public rawstor::io::TaskScalar {
-    private:
-        void *_buf;
-        size_t _size;
+    RawstorIOCallback* _cb;
+    void* _data;
 
-        RawstorIOCallback *_cb;
-        void *_data;
+public:
+    TaskScalar(
+        int fd, void* buf, size_t size, RawstorIOCallback* cb, void* data
+    ) :
+        rawstor::io::TaskScalar(fd),
+        _buf(buf),
+        _size(size),
+        _cb(cb),
+        _data(data) {}
 
-    public:
-        TaskScalar(
-            int fd, void *buf, size_t size,
-            RawstorIOCallback *cb, void *data):
-            rawstor::io::TaskScalar(fd),
-            _buf(buf),
-            _size(size),
-            _cb(cb),
-            _data(data)
-        {}
-
-        void operator()(size_t result, int error) override {
-            int res = _cb(result, error, _data);
-            if (res) {
-                RAWSTOR_THROW_SYSTEM_ERROR(-res);
-            }
+    void operator()(size_t result, int error) override {
+        int res = _cb(result, error, _data);
+        if (res) {
+            RAWSTOR_THROW_SYSTEM_ERROR(-res);
         }
+    }
 
-        void* buf() noexcept override {
-            return _buf;
-        }
+    void* buf() noexcept override { return _buf; }
 
-        size_t size() const noexcept override {
-            return _size;
-        }
+    size_t size() const noexcept override { return _size; }
 };
 
+class TaskVector final : public rawstor::io::TaskVector {
+private:
+    iovec* _iov;
+    unsigned int _niov;
+    size_t _size;
 
-class TaskVector final: public rawstor::io::TaskVector {
-    private:
-        iovec *_iov;
-        unsigned int _niov;
-        size_t _size;
+    RawstorIOCallback* _cb;
+    void* _data;
 
-        RawstorIOCallback *_cb;
-        void *_data;
+public:
+    TaskVector(
+        int fd, iovec* iov, unsigned int niov, size_t size,
+        RawstorIOCallback* cb, void* data
+    ) :
+        rawstor::io::TaskVector(fd),
+        _iov(iov),
+        _niov(niov),
+        _size(size),
+        _cb(cb),
+        _data(data) {}
 
-    public:
-        TaskVector(
-            int fd, iovec *iov, unsigned int niov, size_t size,
-            RawstorIOCallback *cb, void *data):
-            rawstor::io::TaskVector(fd),
-            _iov(iov),
-            _niov(niov),
-            _size(size),
-            _cb(cb),
-            _data(data)
-        {}
-
-        void operator()(size_t result, int error) override {
-            int res = _cb(result, error, _data);
-            if (res) {
-                RAWSTOR_THROW_SYSTEM_ERROR(-res);
-            }
+    void operator()(size_t result, int error) override {
+        int res = _cb(result, error, _data);
+        if (res) {
+            RAWSTOR_THROW_SYSTEM_ERROR(-res);
         }
+    }
 
-        iovec* iov() noexcept override {
-            return _iov;
-        }
+    iovec* iov() noexcept override { return _iov; }
 
-        unsigned int niov() const noexcept override {
-            return _niov;
-        }
+    unsigned int niov() const noexcept override { return _niov; }
 
-        size_t size() const noexcept override {
-            return _size;
-        }
+    size_t size() const noexcept override { return _size; }
 };
 
+class TaskScalarPositional final : public rawstor::io::TaskScalarPositional {
+private:
+    void* _buf;
+    size_t _size;
+    off_t _offset;
 
-class TaskScalarPositional final: public rawstor::io::TaskScalarPositional {
-    private:
-        void *_buf;
-        size_t _size;
-        off_t _offset;
+    RawstorIOCallback* _cb;
+    void* _data;
 
-        RawstorIOCallback *_cb;
-        void *_data;
+public:
+    TaskScalarPositional(
+        int fd, void* buf, size_t size, off_t offset, RawstorIOCallback* cb,
+        void* data
+    ) :
+        rawstor::io::TaskScalarPositional(fd),
+        _buf(buf),
+        _size(size),
+        _offset(offset),
+        _cb(cb),
+        _data(data) {}
 
-    public:
-        TaskScalarPositional(
-            int fd, void *buf, size_t size, off_t offset,
-            RawstorIOCallback *cb, void *data):
-            rawstor::io::TaskScalarPositional(fd),
-            _buf(buf),
-            _size(size),
-            _offset(offset),
-            _cb(cb),
-            _data(data)
-        {}
-
-        void operator()(size_t result, int error) override {
-            int res = _cb(result, error, _data);
-            if (res) {
-                RAWSTOR_THROW_SYSTEM_ERROR(-res);
-            }
+    void operator()(size_t result, int error) override {
+        int res = _cb(result, error, _data);
+        if (res) {
+            RAWSTOR_THROW_SYSTEM_ERROR(-res);
         }
+    }
 
-        void* buf() noexcept override {
-            return _buf;
-        }
+    void* buf() noexcept override { return _buf; }
 
-        size_t size() const noexcept override {
-            return _size;
-        }
+    size_t size() const noexcept override { return _size; }
 
-        off_t offset() const noexcept override {
-            return _offset;
-        }
+    off_t offset() const noexcept override { return _offset; }
 };
 
+class TaskVectorPositional final : public rawstor::io::TaskVectorPositional {
+private:
+    iovec* _iov;
+    unsigned int _niov;
+    size_t _size;
+    off_t _offset;
 
-class TaskVectorPositional final: public rawstor::io::TaskVectorPositional {
-    private:
-        iovec *_iov;
-        unsigned int _niov;
-        size_t _size;
-        off_t _offset;
+    RawstorIOCallback* _cb;
+    void* _data;
 
-        RawstorIOCallback *_cb;
-        void *_data;
+public:
+    TaskVectorPositional(
+        int fd, iovec* iov, unsigned int niov, size_t size, off_t offset,
+        RawstorIOCallback* cb, void* data
+    ) :
+        rawstor::io::TaskVectorPositional(fd),
+        _iov(iov),
+        _niov(niov),
+        _size(size),
+        _offset(offset),
+        _cb(cb),
+        _data(data) {}
 
-    public:
-        TaskVectorPositional(
-            int fd, iovec *iov, unsigned int niov, size_t size, off_t offset,
-            RawstorIOCallback *cb, void *data):
-            rawstor::io::TaskVectorPositional(fd),
-            _iov(iov),
-            _niov(niov),
-            _size(size),
-            _offset(offset),
-            _cb(cb),
-            _data(data)
-        {}
-
-        void operator()(size_t result, int error) override {
-            int res = _cb(result, error, _data);
-            if (res) {
-                RAWSTOR_THROW_SYSTEM_ERROR(-res);
-            }
+    void operator()(size_t result, int error) override {
+        int res = _cb(result, error, _data);
+        if (res) {
+            RAWSTOR_THROW_SYSTEM_ERROR(-res);
         }
+    }
 
-        iovec* iov() noexcept override {
-            return _iov;
-        }
+    iovec* iov() noexcept override { return _iov; }
 
-        unsigned int niov() const noexcept override {
-            return _niov;
-        }
+    unsigned int niov() const noexcept override { return _niov; }
 
-        size_t size() const noexcept override {
-            return _size;
-        }
+    size_t size() const noexcept override { return _size; }
 
-        off_t offset() const noexcept override {
-            return _offset;
-        }
+    off_t offset() const noexcept override { return _offset; }
 };
 
-
-} // unnamed
-
+} // namespace
 
 namespace rawstor {
 
+rawstor::io::Queue* io_queue;
 
-rawstor::io::Queue *io_queue;
+} // namespace rawstor
 
-
-} // rawstor
-
-
-int rawstor_initialize(const RawstorOpts *opts) {
+int rawstor_initialize(const RawstorOpts* opts) {
     int res = 0;
 
     assert(rawstor::io_queue == nullptr);
@@ -223,7 +187,8 @@ int rawstor_initialize(const RawstorOpts *opts) {
 
     rawstor_info(
         "Rawstor compiled with IO queue engine: %s\n",
-        rawstor::io::Queue::engine_name().c_str());
+        rawstor::io::Queue::engine_name().c_str()
+    );
 
     res = rawstor_opts_initialize(opts);
     if (res) {
@@ -231,11 +196,11 @@ int rawstor_initialize(const RawstorOpts *opts) {
     }
 
     try {
-        std::unique_ptr<rawstor::io::Queue> q = rawstor::io::Queue::create(
-            QUEUE_DEPTH);
+        std::unique_ptr<rawstor::io::Queue> q =
+            rawstor::io::Queue::create(QUEUE_DEPTH);
         rawstor::io_queue = q.get();
         q.release();
-    } catch (std::bad_alloc &) {
+    } catch (const std::bad_alloc&) {
         res = -ENOMEM;
         goto err_io_queue;
     }
@@ -250,152 +215,139 @@ err_logging_initialize:
     return res;
 }
 
-
 void rawstor_terminate() {
     delete rawstor::io_queue;
     rawstor_opts_terminate();
     rawstor_logging_terminate();
 }
 
-
 int rawstor_empty() {
     return rawstor::io_queue->empty();
 }
 
-
 int rawstor_wait() {
     try {
         rawstor::io_queue->wait(rawstor_opts_wait_timeout());
-    } catch (std::system_error &e) {
+    } catch (const std::system_error& e) {
         return -e.code().value();
     }
     return 0;
 }
 
-
 int rawstor_fd_read(
-    int fd, void *buf, size_t size,
-    RawstorIOCallback *cb, void *data)
-{
+    int fd, void* buf, size_t size, RawstorIOCallback* cb, void* data
+) {
     try {
         std::unique_ptr<rawstor::io::TaskScalar> t =
-            std::make_unique<TaskScalar>(
-                fd, buf, size, cb, data);
+            std::make_unique<TaskScalar>(fd, buf, size, cb, data);
         rawstor::io_queue->read(std::move(t));
         return 0;
-    } catch (std::system_error &e) {
+    } catch (const std::system_error& e) {
         return -e.code().value();
     }
 }
-
 
 int rawstor_fd_readv(
-    int fd, iovec *iov, unsigned int niov, size_t size,
-    RawstorIOCallback *cb, void *data)
-{
+    int fd, iovec* iov, unsigned int niov, size_t size, RawstorIOCallback* cb,
+    void* data
+) {
     try {
         std::unique_ptr<rawstor::io::TaskVector> t =
-            std::make_unique<TaskVector>(
-                fd, iov, niov, size, cb, data);
+            std::make_unique<TaskVector>(fd, iov, niov, size, cb, data);
         rawstor::io_queue->read(std::move(t));
         return 0;
-    } catch (std::system_error &e) {
+    } catch (const std::system_error& e) {
         return -e.code().value();
     }
 }
-
 
 int rawstor_fd_pread(
-    int fd, void *buf, size_t size, off_t offset,
-    RawstorIOCallback *cb, void *data)
-{
+    int fd, void* buf, size_t size, off_t offset, RawstorIOCallback* cb,
+    void* data
+) {
     try {
         std::unique_ptr<rawstor::io::TaskScalarPositional> t =
             std::make_unique<TaskScalarPositional>(
-                fd, buf, size, offset, cb, data);
+                fd, buf, size, offset, cb, data
+            );
         rawstor::io_queue->read(std::move(t));
         return 0;
-    } catch (std::system_error &e) {
+    } catch (const std::system_error& e) {
         return -e.code().value();
     }
 }
-
 
 int rawstor_fd_preadv(
-    int fd, iovec *iov, unsigned int niov, size_t size, off_t offset,
-    RawstorIOCallback *cb, void *data)
-{
+    int fd, iovec* iov, unsigned int niov, size_t size, off_t offset,
+    RawstorIOCallback* cb, void* data
+) {
     try {
         std::unique_ptr<rawstor::io::TaskVectorPositional> t =
             std::make_unique<TaskVectorPositional>(
-                fd, iov, niov, size, offset, cb, data);
+                fd, iov, niov, size, offset, cb, data
+            );
         rawstor::io_queue->read(std::move(t));
         return 0;
-    } catch (std::system_error &e) {
+    } catch (const std::system_error& e) {
         return -e.code().value();
     }
 }
-
 
 int rawstor_fd_write(
-    int fd, void *buf, size_t size,
-    RawstorIOCallback *cb, void *data)
-{
+    int fd, void* buf, size_t size, RawstorIOCallback* cb, void* data
+) {
     try {
         std::unique_ptr<rawstor::io::TaskScalar> t =
-            std::make_unique<TaskScalar>(
-                fd, buf, size, cb, data);
+            std::make_unique<TaskScalar>(fd, buf, size, cb, data);
         rawstor::io_queue->write(std::move(t));
         return 0;
-    } catch (std::system_error &e) {
+    } catch (const std::system_error& e) {
         return -e.code().value();
     }
 }
-
 
 int rawstor_fd_writev(
-    int fd, iovec *iov, unsigned int niov, size_t size,
-    RawstorIOCallback *cb, void *data)
-{
+    int fd, iovec* iov, unsigned int niov, size_t size, RawstorIOCallback* cb,
+    void* data
+) {
     try {
         std::unique_ptr<rawstor::io::TaskVector> t =
-            std::make_unique<TaskVector>(
-                fd, iov, niov, size, cb, data);
+            std::make_unique<TaskVector>(fd, iov, niov, size, cb, data);
         rawstor::io_queue->write(std::move(t));
         return 0;
-    } catch (std::system_error &e) {
+    } catch (const std::system_error& e) {
         return -e.code().value();
     }
 }
 
-
 int rawstor_fd_pwrite(
-    int fd, void *buf, size_t size, off_t offset,
-    RawstorIOCallback *cb, void *data)
-{
+    int fd, void* buf, size_t size, off_t offset, RawstorIOCallback* cb,
+    void* data
+) {
     try {
         std::unique_ptr<rawstor::io::TaskScalarPositional> t =
             std::make_unique<TaskScalarPositional>(
-                fd, buf, size, offset, cb, data);
+                fd, buf, size, offset, cb, data
+            );
         rawstor::io_queue->write(std::move(t));
         return 0;
-    } catch (std::system_error &e) {
+    } catch (const std::system_error& e) {
         return -e.code().value();
     }
 }
 
-
 int rawstor_fd_pwritev(
-    int fd, iovec *iov, unsigned int niov, size_t size, off_t offset,
-    RawstorIOCallback *cb, void *data)
-{
+    int fd, iovec* iov, unsigned int niov, size_t size, off_t offset,
+    RawstorIOCallback* cb, void* data
+) {
     try {
         std::unique_ptr<rawstor::io::TaskVectorPositional> t =
             std::make_unique<TaskVectorPositional>(
-                fd, iov, niov, size, offset, cb, data);
+                fd, iov, niov, size, offset, cb, data
+            );
         rawstor::io_queue->write(std::move(t));
         return 0;
-    } catch (std::system_error &e) {
+    } catch (const std::system_error& e) {
         return -e.code().value();
     }
 }

--- a/src/rawstor_internals.hpp
+++ b/src/rawstor_internals.hpp
@@ -7,14 +7,10 @@
 
 #include <memory>
 
-
 namespace rawstor {
 
+extern rawstor::io::Queue* io_queue;
 
-extern rawstor::io::Queue *io_queue;
-
-
-} // rawstor
-
+} // namespace rawstor
 
 #endif // RAWSTOR_INTERNALS_HPP

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -7,25 +7,22 @@
 #include <rawstorstd/logging.h>
 #include <rawstorstd/uri.hpp>
 
-#include <string>
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
+#include <string>
 #include <utility>
 
 #include <unistd.h>
 
 #include <cstring>
 
-
 namespace rawstor {
 
-
-Session::Session(const URI &uri, unsigned int depth):
+Session::Session(const URI& uri, unsigned int depth) :
     _depth(depth),
     _uri(uri),
-    _fd(-1)
-{}
-
+    _fd(-1) {
+}
 
 Session::~Session() {
     if (_fd != -1) {
@@ -34,13 +31,13 @@ Session::~Session() {
             int error = errno;
             errno = 0;
             rawstor_error(
-                "Session::~Session(): Close failed: %s\n", strerror(error));
+                "Session::~Session(): Close failed: %s\n", strerror(error)
+            );
         }
     }
 }
 
-
-std::unique_ptr<Session> Session::create(const URI &uri, unsigned int depth) {
+std::unique_ptr<Session> Session::create(const URI& uri, unsigned int depth) {
     if (uri.scheme() == "ost") {
         return std::make_unique<rawstor::ost::Session>(uri, depth);
     }
@@ -52,12 +49,10 @@ std::unique_ptr<Session> Session::create(const URI &uri, unsigned int depth) {
     throw std::runtime_error(oss.str());
 }
 
-
 std::string Session::str() const {
     std::ostringstream oss;
     oss << "fd " << _fd;
     return oss.str();
 }
 
-
-} // rawstor
+} // namespace rawstor

--- a/src/session.hpp
+++ b/src/session.hpp
@@ -12,9 +12,7 @@
 #include <memory>
 #include <sstream>
 
-
 namespace rawstor {
-
 
 class Task;
 
@@ -22,73 +20,62 @@ class TaskScalar;
 
 class TaskVector;
 
-
 class Session {
-    private:
-        unsigned int _depth;
-        URI _uri;
-        int _fd;
+private:
+    unsigned int _depth;
+    URI _uri;
+    int _fd;
 
-    protected:
-        inline void set_fd(int fd) noexcept {
-            _fd = fd;
-        }
+protected:
+    inline void set_fd(int fd) noexcept { _fd = fd; }
 
-    public:
-        static std::unique_ptr<Session> create(
-            const URI &uri, unsigned int depth);
+public:
+    static std::unique_ptr<Session> create(const URI& uri, unsigned int depth);
 
-        Session(const URI &uri, unsigned int depth);
-        Session(const Session &) = delete;
-        Session(Session &&) noexcept = delete;
-        virtual ~Session();
-        Session& operator=(const Session &) = delete;
-        Session& operator=(Session &&) = delete;
+    Session(const URI& uri, unsigned int depth);
+    Session(const Session&) = delete;
+    Session(Session&&) noexcept = delete;
+    virtual ~Session();
+    Session& operator=(const Session&) = delete;
+    Session& operator=(Session&&) = delete;
 
-        std::string str() const;
+    std::string str() const;
 
-        inline const URI& uri() const noexcept {
-            return _uri;
-        }
+    inline const URI& uri() const noexcept { return _uri; }
 
-        inline unsigned int depth() const noexcept {
-            return _depth;
-        }
+    inline unsigned int depth() const noexcept { return _depth; }
 
-        inline int fd() const noexcept {
-            return _fd;
-        }
+    inline int fd() const noexcept { return _fd; }
 
-        virtual void create(
-            rawstor::io::Queue &queue,
-            const RawstorUUID &id, const RawstorObjectSpec &sp,
-            std::unique_ptr<Task> t) = 0;
+    virtual void create(
+        rawstor::io::Queue& queue, const RawstorUUID& id,
+        const RawstorObjectSpec& sp, std::unique_ptr<Task> t
+    ) = 0;
 
-        virtual void remove(
-            rawstor::io::Queue &queue,
-            const RawstorUUID &id,
-            std::unique_ptr<Task> t) = 0;
+    virtual void remove(
+        rawstor::io::Queue& queue, const RawstorUUID& id,
+        std::unique_ptr<Task> t
+    ) = 0;
 
-        virtual void spec(
-            rawstor::io::Queue &queue,
-            const RawstorUUID &id, RawstorObjectSpec *sp,
-            std::unique_ptr<Task> t) = 0;
+    virtual void spec(
+        rawstor::io::Queue& queue, const RawstorUUID& id, RawstorObjectSpec* sp,
+        std::unique_ptr<Task> t
+    ) = 0;
 
-        virtual void set_object(
-            rawstor::io::Queue &queue,
-            RawstorObject *object,
-            std::unique_ptr<Task> t) = 0;
+    virtual void set_object(
+        rawstor::io::Queue& queue, RawstorObject* object,
+        std::unique_ptr<Task> t
+    ) = 0;
 
-        virtual void read(std::unique_ptr<TaskScalar> t) = 0;
+    virtual void read(std::unique_ptr<TaskScalar> t) = 0;
 
-        virtual void read(std::unique_ptr<TaskVector> t) = 0;
+    virtual void read(std::unique_ptr<TaskVector> t) = 0;
 
-        virtual void write(std::unique_ptr<TaskScalar> t) = 0;
+    virtual void write(std::unique_ptr<TaskScalar> t) = 0;
 
-        virtual void write(std::unique_ptr<TaskVector> t) = 0;
+    virtual void write(std::unique_ptr<TaskVector> t) = 0;
 };
 
-
-} //rawstor
+} // namespace rawstor
 
 #endif // RAWSTOR_SESSION_HPP

--- a/src/task.hpp
+++ b/src/task.hpp
@@ -8,79 +8,75 @@
 
 #include <sys/uio.h>
 
-
 namespace rawstor {
 
-
 class Task {
-    private:
+private:
 #ifdef RAWSTOR_TRACE_EVENTS
-        size_t _trace_id;
+    size_t _trace_id;
 #endif
 
-    public:
-        Task()
+public:
+    Task()
 #ifdef RAWSTOR_TRACE_EVENTS
-            : _trace_id(rawstor_trace_event_begin(
-                'I', __FILE__, __LINE__, __FUNCTION__,
-                "\n"))
+        :
+        _trace_id(rawstor_trace_event_begin(
+            'I', __FILE__, __LINE__, __FUNCTION__, "\n"
+        ))
 #endif
-        {}
-        Task(const Task &) = delete;
-        Task(Task &&) = delete;
-        virtual ~Task() {
+    {
+    }
+    Task(const Task&) = delete;
+    Task(Task&&) = delete;
+    virtual ~Task() {
 #ifdef RAWSTOR_TRACE_EVENTS
-            rawstor_trace_event_end(
-                _trace_id, __FILE__, __LINE__, __FUNCTION__,
-                "\n");
+        rawstor_trace_event_end(
+            _trace_id, __FILE__, __LINE__, __FUNCTION__, "\n"
+        );
 #endif
-        }
+    }
 
-        Task& operator=(const Task &) = delete;
-        Task& operator=(Task &&) = delete;
+    Task& operator=(const Task&) = delete;
+    Task& operator=(Task&&) = delete;
 
-        virtual void operator()(
-            RawstorObject *o, size_t result, int error) = 0;
+    virtual void operator()(RawstorObject* o, size_t result, int error) = 0;
 
 #ifdef RAWSTOR_TRACE_EVENTS
-        void trace(
-            const char *file, int line, const char *function,
-            const std::string &message)
-        {
-            rawstor_trace_event_message(
-                _trace_id, file, line, function,
-                "%s\n", message.c_str());
-        }
+    void trace(
+        const char* file, int line, const char* function,
+        const std::string& message
+    ) {
+        rawstor_trace_event_message(
+            _trace_id, file, line, function, "%s\n", message.c_str()
+        );
+    }
 #endif
 };
 
+class TaskScalar : public Task {
+public:
+    TaskScalar() : Task() {}
 
-class TaskScalar: public Task {
-    public:
-        TaskScalar(): Task() {}
+    virtual void* buf() noexcept = 0;
 
-        virtual void* buf() noexcept = 0;
+    virtual size_t size() const noexcept = 0;
 
-        virtual size_t size() const noexcept = 0;
-
-        virtual off_t offset() const noexcept = 0;
+    virtual off_t offset() const noexcept = 0;
 };
 
+class TaskVector : public Task {
+public:
+    TaskVector() : Task() {}
 
-class TaskVector: public Task {
-    public:
-        TaskVector(): Task() {}
+    virtual iovec* iov() noexcept = 0;
 
-        virtual iovec* iov() noexcept = 0;
+    virtual unsigned int niov() const noexcept = 0;
 
-        virtual unsigned int niov() const noexcept = 0;
+    virtual size_t size() const noexcept = 0;
 
-        virtual size_t size() const noexcept = 0;
-
-        virtual off_t offset() const noexcept = 0;
+    virtual off_t offset() const noexcept = 0;
 };
 
-
-} // rawstor
+} // namespace rawstor
 
 #endif // RAWSTOR_TASK_HPP

--- a/tests/test_dummy.c
+++ b/tests/test_dummy.c
@@ -2,7 +2,6 @@
 
 #include <stdlib.h>
 
-
 int main() {
     return EXIT_SUCCESS;
 }

--- a/tests/unittest.h
+++ b/tests/unittest.h
@@ -1,28 +1,25 @@
 #ifndef RAWSTOR_TEST_UNITTEST_H
 #define RAWSTOR_TEST_UNITTEST_H
 
-
 #include <stdio.h>
-
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
-#define assertTrue(expr) do { \
-    if (!(expr)) { \
-        fprintf( \
-            stderr, "%s:%d Assertion failed: %s\n", \
-            __FILE__, __LINE__, #expr); \
-        return 1; \
-    } \
-} while (0)
-
+#define assertTrue(expr)                                                       \
+    do {                                                                       \
+        if (!(expr)) {                                                         \
+            fprintf(                                                           \
+                stderr, "%s:%d Assertion failed: %s\n", __FILE__, __LINE__,    \
+                #expr                                                          \
+            );                                                                 \
+            return 1;                                                          \
+        }                                                                      \
+    } while (0)
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // RAWSTOR_TEST_UNITTEST_H

--- a/tests/unittest.hpp
+++ b/tests/unittest.hpp
@@ -1,19 +1,17 @@
 #ifndef RAWSTOR_TEST_UNITTEST_HPP
 #define RAWSTOR_TEST_UNITTEST_HPP
 
-
 #include "unittest.h"
 
-
-#define assertThrow(expr, exc) do { \
-    int caught = 0; \
-    try { \
-        expr; \
-    } catch (const exc &) { \
-        caught = 1; \
-    } \
-    assertTrue(caught == 1); \
-} while (0)
-
+#define assertThrow(expr, exc)                                                 \
+    do {                                                                       \
+        int caught = 0;                                                        \
+        try {                                                                  \
+            expr;                                                              \
+        } catch (const exc&) {                                                 \
+            caught = 1;                                                        \
+        }                                                                      \
+        assertTrue(caught == 1);                                               \
+    } while (0)
 
 #endif // RAWSTOR_TEST_UNITTEST_HPP

--- a/vu/main.c
+++ b/vu/main.c
@@ -8,7 +8,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-
 void usage() {
     fprintf(
         stderr,
@@ -28,19 +27,14 @@ void usage() {
     );
 }
 
-
 void sact_handler(int s) {
     printf("Caught signal: %d\n", s);
 }
 
+static struct sigaction sact = {.sa_handler = sact_handler};
 
-static struct sigaction sact = {
-    .sa_handler = sact_handler
-};
-
-
-int main(int argc, char **argv) {
-    const char *optstring = "ho:s:";
+int main(int argc, char** argv) {
+    const char* optstring = "ho:s:";
     struct option longopts[] = {
         {"help", no_argument, NULL, 'h'},
         {"object-id", required_argument, NULL, 'o'},
@@ -49,9 +43,9 @@ int main(int argc, char **argv) {
         {},
     };
 
-    const char *object_id_arg = NULL;
-    const char *socket_path_arg = NULL;
-    const char *uri_arg = NULL;
+    const char* object_id_arg = NULL;
+    const char* socket_path_arg = NULL;
+    const char* uri_arg = NULL;
     while (1) {
         int c = getopt_long(argc, argv, optstring, longopts, NULL);
         if (c == -1) {
@@ -59,25 +53,25 @@ int main(int argc, char **argv) {
         }
 
         switch (c) {
-            case 'h':
-                usage();
-                return EXIT_SUCCESS;
-                break;
+        case 'h':
+            usage();
+            return EXIT_SUCCESS;
+            break;
 
-            case 'o':
-                object_id_arg = optarg;
-                break;
+        case 'o':
+            object_id_arg = optarg;
+            break;
 
-            case 's':
-                socket_path_arg = optarg;
-                break;
+        case 's':
+            socket_path_arg = optarg;
+            break;
 
-            case 'u':
-                uri_arg = optarg;
-                break;
+        case 'u':
+            uri_arg = optarg;
+            break;
 
-            default:
-                return EXIT_FAILURE;
+        default:
+            return EXIT_FAILURE;
         }
     }
 

--- a/vu/protocol.h
+++ b/vu/protocol.h
@@ -6,15 +6,13 @@
 #else
 #include <stdint.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
 /* Do we get callbacks when the ring is completely used, even if we've
  * suppressed them? */
-#define VIRTIO_F_NOTIFY_ON_EMPTY    24
+#define VIRTIO_F_NOTIFY_ON_EMPTY 24
 
 /* We support indirect buffer descriptors */
 #define VIRTIO_RING_F_INDIRECT_DESC 28
@@ -23,10 +21,10 @@ extern "C" {
  * at the end of the avail ring. Host should ignore the avail->flags field. */
 /* The Host publishes the avail index for which it expects a kick
  * at the end of the used ring. Guest should ignore the used->flags field. */
-#define VIRTIO_RING_F_EVENT_IDX     29
+#define VIRTIO_RING_F_EVENT_IDX 29
 
 /* v1.0 compliant. */
-#define VIRTIO_F_VERSION_1      32
+#define VIRTIO_F_VERSION_1 32
 
 /* Log all write descriptors. Can be changed while device is active. */
 #define VHOST_F_LOG_ALL 26
@@ -59,7 +57,6 @@ struct vhost_vring_addr {
 
 #include <stdint.h>
 
-
 #define RAWSTOR_VU_PACKED __attribute__((packed))
 
 /* Based on qemu/hw/virtio/vhost-user.c */
@@ -76,7 +73,6 @@ struct vhost_vring_addr {
 
 #define VHOST_USER_HDR_SIZE offsetof(VhostUserMsg, payload)
 
-
 typedef struct VhostUserMemoryRegion {
     uint64_t guest_phys_addr;
     uint64_t memory_size;
@@ -84,25 +80,21 @@ typedef struct VhostUserMemoryRegion {
     uint64_t mmap_offset;
 } VhostUserMemoryRegion;
 
-
 typedef struct VhostUserMemory {
     uint32_t nregions;
     uint32_t padding;
     VhostUserMemoryRegion regions[VHOST_MEMORY_BASELINE_NREGIONS];
 } VhostUserMemory;
 
-
 typedef struct VhostUserMemRegMsg {
     uint64_t padding;
     VhostUserMemoryRegion region;
 } VhostUserMemRegMsg;
 
-
 typedef struct VhostUserLog {
     uint64_t mmap_size;
     uint64_t mmap_offset;
 } VhostUserLog;
-
 
 typedef struct VhostUserConfig {
     uint32_t offset;
@@ -111,13 +103,11 @@ typedef struct VhostUserConfig {
     uint8_t region[VHOST_USER_MAX_CONFIG_SIZE];
 } VhostUserConfig;
 
-
 typedef struct VhostUserVringArea {
     uint64_t u64;
     uint64_t size;
     uint64_t offset;
 } VhostUserVringArea;
-
 
 typedef struct VhostUserInflight {
     uint64_t mmap_size;
@@ -126,11 +116,9 @@ typedef struct VhostUserInflight {
     uint16_t queue_size;
 } VhostUserInflight;
 
-
 typedef struct VhostUserShared {
     unsigned char uuid[UUID_LEN];
 } VhostUserShared;
-
 
 enum VhostUserProtocolFeature {
     VHOST_USER_PROTOCOL_F_MQ = 0,
@@ -153,7 +141,6 @@ enum VhostUserProtocolFeature {
     VHOST_USER_PROTOCOL_F_SHARED_OBJECT = 18,
     VHOST_USER_PROTOCOL_F_MAX
 };
-
 
 typedef enum VhostUserRequest {
     VHOST_USER_NONE = 0,
@@ -184,9 +171,9 @@ typedef enum VhostUserRequest {
     VHOST_USER_SET_CONFIG = 25,
     VHOST_USER_CREATE_CRYPTO_SESSION = 26,
     VHOST_USER_CLOSE_CRYPTO_SESSION = 27,
-    VHOST_USER_POSTCOPY_ADVISE  = 28,
-    VHOST_USER_POSTCOPY_LISTEN  = 29,
-    VHOST_USER_POSTCOPY_END     = 30,
+    VHOST_USER_POSTCOPY_ADVISE = 28,
+    VHOST_USER_POSTCOPY_LISTEN = 29,
+    VHOST_USER_POSTCOPY_END = 30,
     VHOST_USER_GET_INFLIGHT_FD = 31,
     VHOST_USER_SET_INFLIGHT_FD = 32,
     VHOST_USER_GPU_SET_SOCKET = 33,
@@ -203,18 +190,17 @@ typedef enum VhostUserRequest {
     VHOST_USER_MAX
 } VhostUserRequest;
 
-
 typedef struct VhostUserMsg {
     VhostUserRequest request;
 
-#define VHOST_USER_VERSION_MASK     (0x3)
-#define VHOST_USER_REPLY_MASK       (0x1 << 2)
-#define VHOST_USER_NEED_REPLY_MASK  (0x1 << 3)
+#define VHOST_USER_VERSION_MASK (0x3)
+#define VHOST_USER_REPLY_MASK (0x1 << 2)
+#define VHOST_USER_NEED_REPLY_MASK (0x1 << 3)
     uint32_t flags;
     uint32_t size; /* the following payload size */
     union {
-#define VHOST_USER_VRING_IDX_MASK   (0xff)
-#define VHOST_USER_VRING_NOFD_MASK  (0x1 << 8)
+#define VHOST_USER_VRING_IDX_MASK (0xff)
+#define VHOST_USER_VRING_NOFD_MASK (0x1 << 8)
         uint64_t u64;
         struct vhost_vring_state state;
         struct vhost_vring_addr addr;
@@ -229,13 +215,11 @@ typedef struct VhostUserMsg {
 
     int fds[VHOST_MEMORY_BASELINE_NREGIONS];
     int fd_num;
-    uint8_t *data;
+    uint8_t* data;
 } RAWSTOR_VU_PACKED VhostUserMsg;
-
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // RAWSTOR_VHOST_SERVER_H

--- a/vu/server.h
+++ b/vu/server.h
@@ -1,24 +1,19 @@
 #ifndef RAWSTOR_VU_SERVER_H
 #define RAWSTOR_VU_SERVER_H
 
-
 #include <rawstorstd/gcc.h>
-
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
 int rawstor_vu_server(
-    const char RAWSTOR_UNUSED *uri,
-    int RAWSTOR_UNUSED object_id,
-    const char *socket_path);
-
+    const char RAWSTOR_UNUSED* uri, int RAWSTOR_UNUSED object_id,
+    const char* socket_path
+);
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // RAWSTOR_VU_SERVER_H


### PR DESCRIPTION
This pull request integrates "clang-format" into the project to establish and enforce a consistent code style across all C/C++ source files. This initiative aims to improve code readability, reduce cognitive load for developers, and streamline future contributions by automating style checks and providing clear guidance for formatting issues.

* **Code Style Enforcement**: Introduced ".clang-format" to define code style based on LLVM with 4-space indentation, ensuring consistency across the codebase.
* **Automated Formatting Script**: Added ".github/tools/clang-format.sh" to automatically check and suggest fixes for code style compliance, streamlining the development workflow.
* **Widespread Formatting Application**: Applied "clang-format" across numerous C/C++ source and header files, standardizing whitespace, pointer alignment, and indentation.

(cherry picked from commit 417eaa2809c6604b26e37d8b448a66a25dac9ce6)