### PR TITLE
ref: split OST frame to head and body parts (#316)

### DIFF
--- a/librawstorstd/include/rawstorstd/gcc.h
+++ b/librawstorstd/include/rawstorstd/gcc.h
@@ -11,8 +11,6 @@ extern "C" {
 #define RAWSTOR_UNUSED
 #endif
 
-#define RAWSTOR_PACKED __attribute__((packed))
-
 #ifdef __APPLE__
 #define RAWSTOR_ON_MACOS
 #endif

--- a/src/ost_protocol.h
+++ b/src/ost_protocol.h
@@ -1,8 +1,6 @@
 #ifndef RAWSTOR_OST_PROTOCOL_H
 #define RAWSTOR_OST_PROTOCOL_H
 
-#include <rawstorstd/gcc.h>
-
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -11,25 +9,23 @@
 extern "C" {
 #endif
 
+#define RAWSTOR_PACKED __attribute__((packed))
+
 #define RAWSTOR_MAGIC 0x72737472 // "rstr" as ascii
 
-enum RawstorOSTCommandType {
-    RAWSTOR_CMD_SET_OBJECT,
-    RAWSTOR_CMD_READ,
-    RAWSTOR_CMD_WRITE,
-    RAWSTOR_CMD_DISCARD,
-};
+#define RAWSTOR_CMD_SET_OBJECT 0
+#define RAWSTOR_CMD_READ 1
+#define RAWSTOR_CMD_WRITE 2
+#define RAWSTOR_CMD_DISCARD 3
+typedef uint32_t RawstorOSTCommandType;
 
-/* Just for basic validation only */
-struct RawstorOSTFrameCmdOnly {
+struct RawstorOSTFrameHead {
     uint32_t magic;
-    enum RawstorOSTCommandType cmd;
+    RawstorOSTCommandType cmd; // RawstorOSTCommandType
 } RAWSTOR_PACKED;
 
 /* Minimalistic protocol frame */
-struct RawstorOSTFrameBasic {
-    uint32_t magic;
-    enum RawstorOSTCommandType cmd;
+struct RawstorOSTFrameBasicBody {
     // var is for minimal commands only,
     // will be overridden in other command structs
     uint8_t obj_id[16];
@@ -37,20 +33,27 @@ struct RawstorOSTFrameBasic {
     uint64_t val;
 } RAWSTOR_PACKED;
 
-struct RawstorOSTFrameIO {
-    uint32_t magic;
-    enum RawstorOSTCommandType cmd;
+struct RawstorOSTFrameBasic {
+    struct RawstorOSTFrameHead head;
+    struct RawstorOSTFrameBasicBody body;
+} RAWSTOR_PACKED;
+
+struct RawstorOSTFrameIOBody {
     uint16_t cid;
     uint64_t offset;
     uint32_t len;
     uint64_t hash;
-    bool sync;
+    uint8_t sync;
+} RAWSTOR_PACKED;
+
+struct RawstorOSTFrameIO {
+    struct RawstorOSTFrameHead head;
+    struct RawstorOSTFrameIOBody body;
 } RAWSTOR_PACKED;
 
 /* response frames */
 struct RawstorOSTFrameResponse {
-    uint32_t magic;
-    enum RawstorOSTCommandType cmd;
+    struct RawstorOSTFrameHead head;
     uint16_t cid;
     // TODO: if we send length in res - it should be the same type
     // (signed-unsigned too)

--- a/src/ost_session.cpp
+++ b/src/ost_session.cpp
@@ -56,10 +56,10 @@ int validate_response(
 ) noexcept {
     assert(response != nullptr);
 
-    if (response->magic != RAWSTOR_MAGIC) {
+    if (response->head.magic != RAWSTOR_MAGIC) {
         rawstor_error(
             "%s: Unexpected magic number: %x != %x\n", s.str().c_str(),
-            response->magic, RAWSTOR_MAGIC
+            response->head.magic, RAWSTOR_MAGIC
         );
         return EPROTO;
     }
@@ -75,8 +75,8 @@ int validate_response(
 }
 
 int validate_cmd(
-    const rawstor::ost::Session& s, enum RawstorOSTCommandType cmd,
-    enum RawstorOSTCommandType expected
+    const rawstor::ost::Session& s, RawstorOSTCommandType cmd,
+    RawstorOSTCommandType expected
 ) noexcept {
     if (cmd == expected) {
         return 0;
@@ -245,13 +245,18 @@ public:
     ) :
         SessionOp(context, cid, trace_event, std::move(cb)),
         _request({
-            .magic = RAWSTOR_MAGIC,
-            .cmd = RAWSTOR_CMD_SET_OBJECT,
-            .obj_id = {},
-            .offset = 0,
-            .val = 0,
+            .head =
+                {
+                    .magic = RAWSTOR_MAGIC,
+                    .cmd = RAWSTOR_CMD_SET_OBJECT,
+                },
+            .body = {
+                .obj_id = {},
+                .offset = 0,
+                .val = 0,
+            },
         }) {
-        memcpy(_request.obj_id, id.bytes, sizeof(_request.obj_id));
+        memcpy(_request.body.obj_id, id.bytes, sizeof(_request.body.obj_id));
         rawstor::ost::Session& s = _context->session();
         rawstor_info("%s: Setting object id\n", s.str().c_str());
     }
@@ -271,7 +276,7 @@ public:
         }
 
         if (!error) {
-            error = validate_cmd(s, response->cmd, RAWSTOR_CMD_SET_OBJECT);
+            error = validate_cmd(s, response->head.cmd, RAWSTOR_CMD_SET_OBJECT);
         }
 
         if (!error) {
@@ -301,13 +306,19 @@ public:
         _buf(buf),
         _size(size),
         _request({
-            .magic = RAWSTOR_MAGIC,
-            .cmd = RAWSTOR_CMD_READ,
-            .cid = cid,
-            .offset = (uint64_t)offset,
-            .len = (uint32_t)_size,
-            .hash = 0,
-            .sync = 0,
+            .head =
+                {
+                    .magic = RAWSTOR_MAGIC,
+                    .cmd = RAWSTOR_CMD_READ,
+                },
+            .body =
+                {
+                    .cid = cid,
+                    .offset = (uint64_t)offset,
+                    .len = (uint32_t)_size,
+                    .hash = 0,
+                    .sync = 0,
+                },
         }),
         _hash(0) {}
 
@@ -326,7 +337,7 @@ public:
         }
 
         if (!error) {
-            error = validate_cmd(s, response->cmd, RAWSTOR_CMD_READ);
+            error = validate_cmd(s, response->head.cmd, RAWSTOR_CMD_READ);
         }
 
         if (!error) {
@@ -372,13 +383,19 @@ public:
         _niov(niov),
         _size(size),
         _request({
-            .magic = RAWSTOR_MAGIC,
-            .cmd = RAWSTOR_CMD_READ,
-            .cid = cid,
-            .offset = (uint64_t)offset,
-            .len = (uint32_t)_size,
-            .hash = 0,
-            .sync = 0,
+            .head =
+                {
+                    .magic = RAWSTOR_MAGIC,
+                    .cmd = RAWSTOR_CMD_READ,
+                },
+            .body =
+                {
+                    .cid = cid,
+                    .offset = (uint64_t)offset,
+                    .len = (uint32_t)_size,
+                    .hash = 0,
+                    .sync = 0,
+                },
         }),
         _hash(0) {}
 
@@ -397,7 +414,7 @@ public:
         }
 
         if (!error) {
-            error = validate_cmd(s, response->cmd, RAWSTOR_CMD_READ);
+            error = validate_cmd(s, response->head.cmd, RAWSTOR_CMD_READ);
         }
 
         if (!error) {
@@ -436,13 +453,18 @@ public:
     ) :
         SessionOp(context, cid, trace_event, std::move(cb)),
         _request({
-            .magic = RAWSTOR_MAGIC,
-            .cmd = RAWSTOR_CMD_WRITE,
-            .cid = cid,
-            .offset = (uint64_t)offset,
-            .len = (uint32_t)size,
-            .hash = hash(buf, size),
-            .sync = 0,
+            .head =
+                {
+                    .magic = RAWSTOR_MAGIC,
+                    .cmd = RAWSTOR_CMD_WRITE,
+                },
+            .body = {
+                .cid = cid,
+                .offset = (uint64_t)offset,
+                .len = (uint32_t)size,
+                .hash = hash(buf, size),
+                .sync = 0,
+            },
         }) {
         _iov.reserve(2);
         _iov.push_back({
@@ -460,7 +482,7 @@ public:
     unsigned int request_niov() const noexcept { return _iov.size(); }
 
     size_t request_size() const noexcept override {
-        return sizeof(_request) + _request.len;
+        return sizeof(_request) + _request.body.len;
     }
 
     void
@@ -474,7 +496,7 @@ public:
         }
 
         if (!error) {
-            error = validate_cmd(s, response->cmd, RAWSTOR_CMD_WRITE);
+            error = validate_cmd(s, response->head.cmd, RAWSTOR_CMD_WRITE);
         }
 
         _dispatch(response != nullptr ? response->res : 0, error);
@@ -495,13 +517,18 @@ public:
     ) :
         SessionOp(context, cid, trace_event, std::move(cb)),
         _request({
-            .magic = RAWSTOR_MAGIC,
-            .cmd = RAWSTOR_CMD_WRITE,
-            .cid = cid,
-            .offset = (uint64_t)offset,
-            .len = (uint32_t)size,
-            .hash = hash(iov, niov),
-            .sync = 0,
+            .head =
+                {
+                    .magic = RAWSTOR_MAGIC,
+                    .cmd = RAWSTOR_CMD_WRITE,
+                },
+            .body = {
+                .cid = cid,
+                .offset = (uint64_t)offset,
+                .len = (uint32_t)size,
+                .hash = hash(iov, niov),
+                .sync = 0,
+            },
         }) {
         _iov.reserve(1 + niov);
         _iov.push_back({
@@ -518,7 +545,7 @@ public:
     unsigned int request_niov() const noexcept { return _iov.size(); }
 
     size_t request_size() const noexcept override {
-        return sizeof(_request) + _request.len;
+        return sizeof(_request) + _request.body.len;
     }
 
     void
@@ -532,7 +559,7 @@ public:
         }
 
         if (!error) {
-            error = validate_cmd(s, response->cmd, RAWSTOR_CMD_WRITE);
+            error = validate_cmd(s, response->head.cmd, RAWSTOR_CMD_WRITE);
         }
 
         _dispatch(response != nullptr ? response->res : 0, error);
@@ -772,13 +799,20 @@ void Session::set_object(RawstorObject* object) {
     std::unique_ptr<rawstor::io::Queue> queue = rawstor::io::Queue::create(2);
 
     RawstorOSTFrameBasic request = {
-        .magic = RAWSTOR_MAGIC,
-        .cmd = RAWSTOR_CMD_SET_OBJECT,
-        .obj_id = {},
-        .offset = 0,
-        .val = 0,
+        .head =
+            {
+                .magic = RAWSTOR_MAGIC,
+                .cmd = RAWSTOR_CMD_SET_OBJECT,
+            },
+        .body = {
+            .obj_id = {},
+            .offset = 0,
+            .val = 0,
+        },
     };
-    memcpy(request.obj_id, object->id().bytes, sizeof(request.obj_id));
+    memcpy(
+        request.body.obj_id, object->id().bytes, sizeof(request.body.obj_id)
+    );
     rawstor_info("%s: Setting object id\n", str().c_str());
     queue->write(
         fd(), &request, sizeof(request),
@@ -824,8 +858,9 @@ void Session::set_object(RawstorObject* object) {
             }
 
             if (!error) {
-                error =
-                    validate_cmd(*this, response.cmd, RAWSTOR_CMD_SET_OBJECT);
+                error = validate_cmd(
+                    *this, response.head.cmd, RAWSTOR_CMD_SET_OBJECT
+                );
             }
 
             if (error) {


### PR DESCRIPTION
This pull request refactors the OST protocol frame definitions to improve cross-platform binary compatibility and structure clarity. By separating the frame headers from their bodies and enforcing fixed-width types for protocol fields, the changes ensure more predictable memory layouts. The implementation also updates the associated session logic to correctly interface with these new structured frames.

* **Protocol Structure Refactoring**: Split the OST frame structures into separate 'head' and 'body' components to improve protocol clarity and maintainability.
* **Type Safety and Portability**: Replaced enum-based command types with fixed-width uint32_t types and changed the 'sync' boolean field to uint8_t to ensure consistent binary representation across platforms.
* **Codebase Adjustments**: Updated all session operations and validation logic to accommodate the new nested structure of the OST frames.

(cherry picked from commit 29bc99dbdd1dce041872ec8c01912d63e18c960e)

Conflicts:
	src/ost_session.cpp