### PR TITLE
fix: call setup_fd on accept (#319)

### DIFF
--- a/librawstorio/src/poll_event.cpp
+++ b/librawstorio/src/poll_event.cpp
@@ -1,8 +1,11 @@
 #include "poll_event.hpp"
 
+#include "poll_queue.hpp"
+
 #include <rawstorstd/iovec.h>
 #include <rawstorstd/logging.h>
 
+#include <system_error>
 #include <vector>
 
 #include <sys/types.h>
@@ -106,10 +109,28 @@ ssize_t EventSimplexAcceptOneshot::process() noexcept {
     RAWSTOR_TRACE_EVENT_MESSAGE(trace_event, "%s\n", "accept()");
     ssize_t res = ::accept(_fd, _addr, _addrlen);
     if (res >= 0) {
-        _result = res;
+        try {
+            rawstor::io::poll::Queue::setup_fd(res);
+            _result = res;
 #ifdef RAWSTOR_TRACE_EVENTS
-        RAWSTOR_TRACE_EVENT_MESSAGE(trace_event, "%s\n", "completed");
+            RAWSTOR_TRACE_EVENT_MESSAGE(trace_event, "%s\n", "completed");
 #endif
+        } catch (const std::system_error& e) {
+            rawstor_error("Failed to setup fd %zd: %s\n", res, e.what());
+            ::close(res);
+            res = -e.code().value();
+            set_error(e.code().value());
+        } catch (const std::exception& e) {
+            rawstor_error("Failed to setup fd %zd: %s\n", res, e.what());
+            ::close(res);
+            res = -EIO;
+            set_error(EIO);
+        } catch (...) {
+            rawstor_error("Failed to setup fd %zd\n", res);
+            ::close(res);
+            res = -EIO;
+            set_error(EIO);
+        }
     } else {
         int error = errno;
         errno = 0;
@@ -126,10 +147,28 @@ ssize_t EventSimplexAcceptMultishot::process() noexcept {
     RAWSTOR_TRACE_EVENT_MESSAGE(trace_event, "%s\n", "accept()");
     ssize_t res = ::accept(_fd, nullptr, nullptr);
     if (res >= 0) {
-        _result = res;
+        try {
+            rawstor::io::poll::Queue::setup_fd(res);
+            _result = res;
 #ifdef RAWSTOR_TRACE_EVENTS
-        RAWSTOR_TRACE_EVENT_MESSAGE(trace_event, "%s\n", "completed");
+            RAWSTOR_TRACE_EVENT_MESSAGE(trace_event, "%s\n", "completed");
 #endif
+        } catch (const std::system_error& e) {
+            rawstor_error("Failed to setup fd %zd: %s\n", res, e.what());
+            ::close(res);
+            res = -e.code().value();
+            set_error(e.code().value());
+        } catch (const std::exception& e) {
+            rawstor_error("Failed to setup fd %zd: %s\n", res, e.what());
+            ::close(res);
+            res = -EIO;
+            set_error(EIO);
+        } catch (...) {
+            rawstor_error("Failed to setup fd %zd\n", res);
+            ::close(res);
+            res = -EIO;
+            set_error(EIO);
+        }
     } else {
         int error = errno;
         errno = 0;

--- a/librawstorio/src/uring_queue.cpp
+++ b/librawstorio/src/uring_queue.cpp
@@ -158,6 +158,30 @@ rawstor::io::Event* Queue::accept(
                 RAWSTOR_TRACE_EVENT_MESSAGE(
                     trace_event, "result = %zu, error = %d\n", result, error
                 );
+                if (!error) {
+                    try {
+                        rawstor::io::uring::Queue::setup_fd(result);
+                    } catch (const std::system_error& e) {
+                        rawstor_error(
+                            "Failed to setup fd %zu: %s\n", result, e.what()
+                        );
+                        ::close(result);
+                        result = 0;
+                        error = e.code().value();
+                    } catch (const std::exception& e) {
+                        rawstor_error(
+                            "Failed to setup fd %zu: %s\n", result, e.what()
+                        );
+                        ::close(result);
+                        result = 0;
+                        error = EIO;
+                    } catch (...) {
+                        rawstor_error("Failed to setup fd %zu\n", result);
+                        ::close(result);
+                        result = 0;
+                        error = EIO;
+                    }
+                }
                 cb(result, error);
             }
         );
@@ -183,6 +207,30 @@ Queue::accept_multishot(int fd, std::function<void(size_t, int)>&& cb) {
                 RAWSTOR_TRACE_EVENT_MESSAGE(
                     trace_event, "result = %zu, error = %d\n", result, error
                 );
+                if (!error) {
+                    try {
+                        rawstor::io::uring::Queue::setup_fd(result);
+                    } catch (const std::system_error& e) {
+                        rawstor_error(
+                            "Failed to setup fd %zu: %s\n", result, e.what()
+                        );
+                        ::close(result);
+                        result = 0;
+                        error = e.code().value();
+                    } catch (const std::exception& e) {
+                        rawstor_error(
+                            "Failed to setup fd %zu: %s\n", result, e.what()
+                        );
+                        ::close(result);
+                        result = 0;
+                        error = EIO;
+                    } catch (...) {
+                        rawstor_error("Failed to setup fd %zu\n", result);
+                        ::close(result);
+                        result = 0;
+                        error = EIO;
+                    }
+                }
                 cb(result, error);
             }
         );


### PR DESCRIPTION
This pull request improves the robustness of the socket acceptance process by ensuring that file descriptors are correctly configured and managed. It addresses potential crashes and resource leaks by introducing structured exception handling around the `setup_fd` calls in both poll and uring queue implementations, ensuring that failures are logged and resources are released appropriately.

### Highlights

* **Exception Safety**: Wrapped calls to `setup_fd` in try-catch blocks to prevent crashes in `noexcept` methods and ensure proper resource cleanup.
* **Resource Management**: Added logic to close file descriptors upon `setup_fd` failure to prevent resource leaks.
* **Error Handling**: Implemented comprehensive error handling for `setup_fd` failures, including logging and setting appropriate error codes.

(cherry picked from commit dcaa37c58470d59f5482f04b08aa52c06d84788c)