### PR TITLE
add: socket reuse routine (#321)

### DIFF
--- a/librawstorstd/include/rawstorstd/socket.h
+++ b/librawstorstd/include/rawstorstd/socket.h
@@ -9,6 +9,8 @@ int rawstor_socket_set_nonblock(int fd);
 
 int rawstor_socket_set_nodelay(int fd);
 
+int rawstor_socket_set_reuse(int fd);
+
 int rawstor_socket_set_snd_timeout(int fd, unsigned int timeout);
 
 int rawstor_socket_set_rcv_timeout(int fd, unsigned int timeout);

--- a/librawstorstd/src/socket.c
+++ b/librawstorstd/src/socket.c
@@ -51,13 +51,28 @@ int rawstor_socket_set_nodelay(int fd) {
     int error;
 
     int onoff = 1;
-    if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &onoff, sizeof(onoff))) {
+    if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &onoff, sizeof(onoff)) == -1) {
         error = errno;
         errno = 0;
         return -error;
     }
 
     rawstor_debug("fd %d: IPPROTO_TCP/TCP_NODELAY\n", fd);
+
+    return 0;
+}
+
+int rawstor_socket_set_reuse(int fd) {
+    int error;
+
+    int onoff = 1;
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &onoff, sizeof(onoff)) == -1) {
+        error = errno;
+        errno = 0;
+        return -error;
+    }
+
+    rawstor_debug("fd %d: SOL_SOCKET/SO_REUSEADDR\n", fd);
 
     return 0;
 }
@@ -69,7 +84,7 @@ int rawstor_socket_set_snd_timeout(int fd, unsigned int timeout) {
         .tv_sec = timeout / 1000,
         .tv_usec = (timeout % 1000) * 1000,
     };
-    if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeo, sizeof(timeo))) {
+    if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeo, sizeof(timeo)) == -1) {
         error = errno;
         errno = 0;
         return -error;
@@ -87,7 +102,7 @@ int rawstor_socket_set_rcv_timeout(int fd, unsigned int timeout) {
         .tv_sec = timeout / 1000,
         .tv_usec = (timeout % 1000) * 1000,
     };
-    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeo, sizeof(timeo))) {
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeo, sizeof(timeo)) == -1) {
         error = errno;
         errno = 0;
         return -error;
@@ -114,7 +129,7 @@ int rawstor_socket_set_user_timeout(int fd, unsigned int timeout) {
     timeout = (timeout + 999) / 1000;
     if (setsockopt(
             fd, IPPROTO_TCP, TCP_CONNECTIONTIMEOUT, &timeout, sizeof(timeout)
-        )) {
+        ) == -1) {
         error = errno;
         errno = 0;
         return -error;
@@ -132,7 +147,7 @@ int rawstor_socket_set_user_timeout(int fd, unsigned int timeout) {
 int rawstor_socket_set_snd_bufsize(int fd, unsigned int size) {
     int error;
 
-    if (setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &size, sizeof(size))) {
+    if (setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &size, sizeof(size)) == -1) {
         error = errno;
         errno = 0;
         return -error;
@@ -146,7 +161,7 @@ int rawstor_socket_set_snd_bufsize(int fd, unsigned int size) {
 int rawstor_socket_set_rcv_bufsize(int fd, unsigned int size) {
     int error;
 
-    if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size))) {
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size)) == -1) {
         error = errno;
         errno = 0;
         return -error;


### PR DESCRIPTION
This pull request introduces a new utility function to configure socket address reuse and standardizes error checking for socket options throughout the library. These changes improve the reliability of socket configuration by ensuring that return values from system calls are handled explicitly.

### Highlights

* **New Socket Functionality**: Added the `rawstor_socket_set_reuse` function to enable the `SO_REUSEADDR` socket option.
* **Improved Error Handling**: Updated all `setsockopt` calls across the socket utility module to explicitly check for `-1` as the error condition, ensuring more robust and portable behavior.

(cherry picked from commit 8df510407ffdf65295bfc5d1479e5df70cc4d48f)