### PR TITLE
fix: handle linux case for setsockopt (#324)

### DIFF
--- a/librawstorstd/src/socket.c
+++ b/librawstorstd/src/socket.c
@@ -119,7 +119,7 @@ int rawstor_socket_set_user_timeout(int fd, unsigned int timeout) {
 #if defined(RAWSTOR_ON_LINUX)
     if (setsockopt(
             fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &timeout, sizeof(timeout)
-        )) {
+        ) == -1) {
         error = errno;
         errno = 0;
         return -error;


### PR DESCRIPTION
This pull request improves the reliability of socket configuration on Linux systems by ensuring that the return value of setsockopt is properly validated against -1, preventing potential misinterpretation of successful operations as errors.

### Highlights

* **Socket Configuration Fix**: Updated the setsockopt call for Linux to explicitly check for a return value of -1 to correctly identify errors.

(cherry picked from commit 21974c7d39b6f1d3f98d12c953deab9f509f89fe)