### PR TITLE
add: uris routine (#327)

### DIFF
--- a/librawstorstd/include/rawstorstd/uri.hpp
+++ b/librawstorstd/include/rawstorstd/uri.hpp
@@ -42,6 +42,7 @@ private:
 
 public:
     static std::vector<rawstor::URI> uriv(const char* uris);
+    static std::string uris(const std::vector<rawstor::URI>& uriv);
 
     explicit URI(const std::string& uri);
     URI(const URI& parent, const std::string& child);

--- a/librawstorstd/src/uri.cpp
+++ b/librawstorstd/src/uri.cpp
@@ -181,6 +181,19 @@ std::vector<rawstor::URI> URI::uriv(const char* uris) {
     return ret;
 }
 
+std::string URI::uris(const std::vector<rawstor::URI>& uriv) {
+    std::ostringstream oss;
+    bool comma = false;
+    for (const auto& uri : uriv) {
+        if (comma) {
+            oss << ',';
+        }
+        oss << uri.str();
+        comma = true;
+    }
+    return oss.str();
+}
+
 URI::URI(const std::string& uri) : _uri(uri) {
     std::string path;
     parse_uri(

--- a/librawstorstd/tests/test_uri.cpp
+++ b/librawstorstd/tests/test_uri.cpp
@@ -166,6 +166,9 @@ TEST(URIsTest, basics) {
         EXPECT_EQ(uris[0].str(), "a");
         EXPECT_EQ(uris[1].str(), "b");
         EXPECT_EQ(uris[2].str(), "c");
+
+        std::string s = rawstor::URI::uris(uris);
+        EXPECT_EQ(s, "a,b,c");
     }
 
     {
@@ -173,6 +176,9 @@ TEST(URIsTest, basics) {
         EXPECT_EQ(uris.size(), (size_t)2);
         EXPECT_EQ(uris[0].str(), "a\\,b");
         EXPECT_EQ(uris[1].str(), "c");
+
+        std::string s = rawstor::URI::uris(uris);
+        EXPECT_EQ(s, "a\\,b,c");
     }
 
     {
@@ -181,12 +187,18 @@ TEST(URIsTest, basics) {
         EXPECT_EQ(uris[0].str(), "a");
         EXPECT_EQ(uris[1].str(), "b");
         EXPECT_EQ(uris[2].str(), "");
+
+        std::string s = rawstor::URI::uris(uris);
+        EXPECT_EQ(s, "a,b,");
     }
 
     {
         std::vector<rawstor::URI> uris = rawstor::URI::uriv("");
         EXPECT_EQ(uris.size(), (size_t)1);
         EXPECT_EQ(uris[0].str(), "");
+
+        std::string s = rawstor::URI::uris(uris);
+        EXPECT_EQ(s, "");
     }
 
     {
@@ -194,6 +206,9 @@ TEST(URIsTest, basics) {
         EXPECT_EQ(uris.size(), (size_t)2);
         EXPECT_EQ(uris[0].str(), "");
         EXPECT_EQ(uris[1].str(), "");
+
+        std::string s = rawstor::URI::uris(uris);
+        EXPECT_EQ(s, ",");
     }
 
     {
@@ -201,6 +216,9 @@ TEST(URIsTest, basics) {
         EXPECT_EQ(uris.size(), (size_t)2);
         EXPECT_EQ(uris[0].str(), "");
         EXPECT_EQ(uris[1].str(), "a");
+
+        std::string s = rawstor::URI::uris(uris);
+        EXPECT_EQ(s, ",a");
     }
 
     {
@@ -208,12 +226,18 @@ TEST(URIsTest, basics) {
         EXPECT_EQ(uris.size(), (size_t)2);
         EXPECT_EQ(uris[0].str(), "a");
         EXPECT_EQ(uris[1].str(), "");
+
+        std::string s = rawstor::URI::uris(uris);
+        EXPECT_EQ(s, "a,");
     }
 
     {
         std::vector<rawstor::URI> uris = rawstor::URI::uriv("\\,a");
         EXPECT_EQ(uris.size(), (size_t)1);
         EXPECT_EQ(uris[0].str(), "\\,a");
+
+        std::string s = rawstor::URI::uris(uris);
+        EXPECT_EQ(s, "\\,a");
     }
 }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -35,16 +35,8 @@
 namespace {
 
 int uris(const std::vector<rawstor::URI>& uriv, char* buf, size_t size) {
-    std::ostringstream oss;
-    bool comma = false;
-    for (const auto& uri : uriv) {
-        if (comma) {
-            oss << ',';
-        }
-        oss << uri.str();
-        comma = true;
-    }
-    int res = snprintf(buf, size, "%s", oss.str().c_str());
+    std::string s = rawstor::URI::uris(uriv);
+    int res = snprintf(buf, size, "%s", s.c_str());
     if (res < 0) {
         RAWSTOR_THROW_ERRNO();
     }


### PR DESCRIPTION
This pull request introduces a standardized way to serialize a collection of URI objects into a single comma-separated string. By centralizing this logic within the `URI` class, the codebase becomes more maintainable and consistent. The changes also include updated unit tests to verify the correctness of the serialization process across different edge cases.

### Highlights

* **New URI Serialization Routine**: Added a static `uris` method to the `URI` class to serialize a vector of `URI` objects into a comma-separated string.
* **Code Refactoring**: Refactored existing logic in `src/object.cpp` to utilize the new centralized `URI::uris` method, reducing code duplication.
* **Enhanced Test Coverage**: Updated `test_uri.cpp` to include comprehensive test cases for the new serialization routine, ensuring correct handling of various input scenarios.

(cherry picked from commit 9cb18ca88aa10abf7517265e0f875dac63858c9c)