### PR TITLE
ref: add explicit response body (#329)

### DIFF
--- a/src/ost_protocol.h
+++ b/src/ost_protocol.h
@@ -52,13 +52,17 @@ struct RawstorOSTFrameIO {
 } RAWSTOR_PACKED;
 
 /* response frames */
-struct RawstorOSTFrameResponse {
-    struct RawstorOSTFrameHead head;
+struct RawstorOSTFrameResponseBody {
     uint16_t cid;
     // TODO: if we send length in res - it should be the same type
     // (signed-unsigned too)
     int32_t res;
     uint64_t hash;
+} RAWSTOR_PACKED;
+
+struct RawstorOSTFrameResponse {
+    struct RawstorOSTFrameHead head;
+    struct RawstorOSTFrameResponseBody body;
 } RAWSTOR_PACKED;
 
 #ifdef __cplusplus

--- a/src/ost_session.cpp
+++ b/src/ost_session.cpp
@@ -64,9 +64,10 @@ int validate_response(
         return EPROTO;
     }
 
-    if (response->res < 0) {
+    if (response->body.res < 0) {
         rawstor_error(
-            "%s: Server error: %s\n", s.str().c_str(), strerror(-response->res)
+            "%s: Server error: %s\n", s.str().c_str(),
+            strerror(-response->body.res)
         );
         return EPROTO;
     }
@@ -139,9 +140,9 @@ public:
     inline RawstorOSTFrameResponse* response() noexcept { return &_response; }
 
     SessionOp& find_op() {
-        auto it = _ops.find(_response.cid);
+        auto it = _ops.find(_response.body.cid);
         if (it == _ops.end()) {
-            rawstor_error("Unexpected cid: %u\n", _response.cid);
+            rawstor_error("Unexpected cid: %u\n", _response.body.cid);
             RAWSTOR_THROW_SYSTEM_ERROR(EPROTO);
         }
 
@@ -341,7 +342,7 @@ public:
         }
 
         if (!error) {
-            _hash = response->hash;
+            _hash = response->body.hash;
             s.read_response_body(_buf, _size);
         } else {
             _dispatch(0, error);
@@ -418,7 +419,7 @@ public:
         }
 
         if (!error) {
-            _hash = response->hash;
+            _hash = response->body.hash;
             s.read_response_body(_iov, _niov, _size);
         } else {
             _dispatch(0, error);
@@ -499,7 +500,9 @@ public:
             error = validate_cmd(s, response->head.cmd, RAWSTOR_CMD_WRITE);
         }
 
-        _dispatch(response != nullptr ? response->res : 0, error);
+        _dispatch(
+            !error && response != nullptr ? response->body.res : 0, error
+        );
     }
 };
 
@@ -562,7 +565,9 @@ public:
             error = validate_cmd(s, response->head.cmd, RAWSTOR_CMD_WRITE);
         }
 
-        _dispatch(response != nullptr ? response->res : 0, error);
+        _dispatch(
+            !error && response != nullptr ? response->body.res : 0, error
+        );
     }
 };
 


### PR DESCRIPTION
This pull request refactors the Rawstor protocol response structure by introducing an explicit body struct for response frames. This change improves the clarity and maintainability of the protocol definition. Additionally, the implementation includes necessary updates to session operations to accommodate this structural change and enhances error handling logic to prevent potential integer casting issues during dispatch operations.

* **Protocol Structure Refactoring**: Extracted the response fields into a dedicated `RawstorOSTFrameResponseBody` struct, separating them from the frame header.
* **Codebase Adaptation**: Updated all references to response fields across the session management logic to access them through the new `body` member.
* **Error Handling Improvement**: Refined the `_dispatch` calls to ensure that negative error codes are not incorrectly cast to large positive values when an error state is present.

(cherry picked from commit 10dae628fe1117d7abf828f8dc473e1e309931ff)

Conflicts:
	src/ost_session.cpp