### PR TITLE
fix: handle URI port parsing error (#332)

### DIFF
--- a/librawstorstd/src/uri.cpp
+++ b/librawstorstd/src/uri.cpp
@@ -61,7 +61,13 @@ void parse_uri(
         std::istringstream iss(
             uri.substr(colon_delim, path_delim - colon_delim)
         );
-        iss >> *port;
+        if (iss.peek() < '0' || iss.peek() > '9') {
+            *port = 0;
+        } else {
+            if (!(iss >> *port) || !iss.eof() || *port > 65535) {
+                *port = 0;
+            }
+        }
     } else {
         *hostname = uri.substr(at_delim, path_delim - at_delim);
         *port = 0;


### PR DESCRIPTION
This pull request improves the reliability of URI port parsing by replacing a lenient extraction method with a more rigorous validation process. The changes ensure that the port component of a URI is correctly identified and validated against standard constraints, preventing malformed input from causing unexpected behavior.

### Highlights

* **Robust Port Validation**: Implemented strict validation for URI port parsing to ensure only numeric values within the valid 0-65535 range are accepted.
* **Improved Error Handling**: Added checks to prevent partial parsing, negative numbers, and non-numeric characters from being processed as valid ports.

(cherry picked from commit deb91b530a09471ac00d0b5797c9b9f27f44d8c0)