### PR TITLE
add: locations and targets page (#338)

### DIFF
--- a/docs/locations_and_targets.md
+++ b/docs/locations_and_targets.md
@@ -1,0 +1,79 @@
+# Locations and Targets
+
+## Overview
+
+Rawstor client library and OST backend use two core concepts to address and access data: **Location** and **Target**.
+
+---
+
+## Location
+
+A **location** specifies the address of a backend data store (or a list of backends). It is expressed as a comma-separated list of URIs. The URI format follows the standard scheme `<scheme>://<endpoint>`.
+
+Currently, two URI schemes are supported:
+
+| Scheme | Description |
+|--------|-------------|
+| `ost`  | Backend server speaking the OST protocol (see [Protocol.md](https://github.com/rawstor/rawstor_docs/blob/main/Protocol.md)) |
+| `file` | Local filesystem backend (a folder path) |
+
+### Single backend examples
+
+- `ost://<host>:<port>` – an OST server at the given host and port.
+- `file://<path_to_folder>` – a folder on the local filesystem.
+
+### Multiple backends (comma‑separated)
+
+When multiple URIs are listed, the client interprets the list according to specific policies:
+
+| Example | Behavior |
+|---------|----------|
+| `ost://host1:port1,ost://host2:port2` | **Mirroring** – both backends contain identical data. |
+| `file:///data/folder,ost://host:port` | **Data locality** – the file backend serves as a local cache or fast access path, while the OST backend is the primary remote store. |
+
+**Syntax rules:**
+- Do not add spaces between URIs – use a single comma: `uri1,uri2`
+- To include a literal comma within a URI, escape it with a backslash: `\,`
+- Each URI must be a valid location (scheme + endpoint).
+- All URIs in the list must be unique – duplicates are not allowed.
+
+---
+
+## Target
+
+A **target** identifies a specific data object. For a single target, the format is `<scheme>://<endpoint>/<uuid>`. For multiple targets, the UUID must be appended to each URI: `<scheme1>://<endpoint1>/<uuid>,<scheme2>://<endpoint2>/<uuid>,...`
+
+Where:
+- `<scheme>` and `<endpoint>` are the same as for location.
+- `<uuid>` is the unique identifier of the object (rawstor uses UUID v7).
+
+### Single backend target examples
+
+- `ost://<host>:<port>/<uuid>` – an object stored on a single OST server.
+- `file://<path_to_folder>/<uuid>` – an object stored as a file in a local folder.
+
+### Multiple backend target (mirroring / locality)
+
+The client uses the same policies as for locations (mirroring, locality, etc.).
+
+Example: `ost://127.0.0.1:9090/019cbfad-a389-7d42-a0f6-c29993ac8c00,file:///var/rawstor/019cbfad-a389-7d42-a0f6-c29993ac8c00`
+
+This target references the same object (UUID `019cbfad-a389-7d42-a0f6-c29993ac8c00`) on two different backends.
+
+**Important:** All URIs in a target list must point to the same UUID. Mixing different UUIDs in one target is not allowed.
+
+---
+
+## Summary table
+
+| Concept | Format | Purpose | Example |
+|---------|--------|---------|---------|
+| **Location** | `<scheme>://<endpoint>` or `uri1,uri2,...` | Address of a backend data store (or a set of stores) | `ost://127.0.0.1:9090`<br>`file:///var/rawstor` |
+| **Target** | `<scheme>://<endpoint>/<uuid>` or `uri1,uri2,...` | Address of a specific data object | `ost://127.0.0.1:9090/019cbfad-a389-7d42-a0f6-c29993ac8c00`<br>`ost://127.0.0.1:9090/019cbfad-a389-7d42-a0f6-c29993ac8c00,file:///var/rawstor/019cbfad-a389-7d42-a0f6-c29993ac8c00` |
+
+---
+
+## Notes
+
+- When using the `file://` scheme, the path must be absolute. Relative paths are not allowed.
+- The OST protocol details, including authentication, error handling, and streaming, are defined in the [protocol specification](https://github.com/rawstor/rawstor_docs/blob/main/Protocol.md).

--- a/librawstorstd/src/uri.cpp
+++ b/librawstorstd/src/uri.cpp
@@ -129,6 +129,37 @@ void parse_path(
     }
 }
 
+std::string escape(const std::string& s, const char ch) {
+    std::string ret;
+    ret.reserve(s.size());
+
+    for (const char i : s) {
+        if (i == ch || i == '\\') {
+            ret.push_back('\\');
+        }
+        ret.push_back(i);
+    }
+
+    return ret;
+}
+
+std::string unescape(const std::string& s) {
+    std::string ret;
+    ret.reserve(s.size());
+    bool escaped = false;
+
+    for (const char ch : s) {
+        if (!escaped && ch == '\\') {
+            escaped = true;
+            continue;
+        }
+        ret.push_back(ch);
+        escaped = false;
+    }
+
+    return ret;
+}
+
 } // namespace
 
 namespace rawstor {
@@ -173,15 +204,17 @@ std::vector<rawstor::URI> URI::uriv(const char* uris) {
     std::vector<rawstor::URI> ret;
     const char* start = uris;
     const char* p = uris;
+    bool escaped = false;
     while (true) {
         if (*p == '\0') {
-            ret.emplace_back(std::string(start));
+            ret.emplace_back(unescape(std::string(start)));
             break;
         }
-        if (*p == ',' && (p == uris || *(p - 1) != '\\')) {
-            ret.emplace_back(std::string(start, p - start));
+        if (*p == ',' && !escaped) {
+            ret.emplace_back(unescape(std::string(start, p - start)));
             start = p + 1;
         }
+        escaped = *p == '\\' && !escaped;
         ++p;
     }
     return ret;
@@ -194,7 +227,7 @@ std::string URI::uris(const std::vector<rawstor::URI>& uriv) {
         if (comma) {
             oss << ',';
         }
-        oss << uri.str();
+        oss << escape(uri.str(), ',');
         comma = true;
     }
     return oss.str();

--- a/librawstorstd/tests/test_uri.cpp
+++ b/librawstorstd/tests/test_uri.cpp
@@ -174,7 +174,7 @@ TEST(URIsTest, basics) {
     {
         std::vector<rawstor::URI> uris = rawstor::URI::uriv("a\\,b,c");
         EXPECT_EQ(uris.size(), (size_t)2);
-        EXPECT_EQ(uris[0].str(), "a\\,b");
+        EXPECT_EQ(uris[0].str(), "a,b");
         EXPECT_EQ(uris[1].str(), "c");
 
         std::string s = rawstor::URI::uris(uris);
@@ -234,10 +234,30 @@ TEST(URIsTest, basics) {
     {
         std::vector<rawstor::URI> uris = rawstor::URI::uriv("\\,a");
         EXPECT_EQ(uris.size(), (size_t)1);
-        EXPECT_EQ(uris[0].str(), "\\,a");
+        EXPECT_EQ(uris[0].str(), ",a");
 
         std::string s = rawstor::URI::uris(uris);
         EXPECT_EQ(s, "\\,a");
+    }
+
+    {
+        std::vector<rawstor::URI> uris = rawstor::URI::uriv("a,b\\\\c");
+        EXPECT_EQ(uris.size(), (size_t)2);
+        EXPECT_EQ(uris[0].str(), "a");
+        EXPECT_EQ(uris[1].str(), "b\\c");
+
+        std::string s = rawstor::URI::uris(uris);
+        EXPECT_EQ(s, "a,b\\\\c");
+    }
+
+    {
+        std::vector<rawstor::URI> uris = rawstor::URI::uriv("\\\\,a");
+        EXPECT_EQ(uris.size(), (size_t)2);
+        EXPECT_EQ(uris[0].str(), "\\");
+        EXPECT_EQ(uris[1].str(), "a");
+
+        std::string s = rawstor::URI::uris(uris);
+        EXPECT_EQ(s, "\\\\,a");
     }
 }
 


### PR DESCRIPTION
This pull request introduces comprehensive documentation for the 'Location' and 'Target' concepts used in the Rawstor client library and OST backend. Alongside the documentation, it improves the underlying URI parsing logic to support escaping special characters, specifically commas, which allows for more flexible and reliable URI handling in various backend configurations.

### Highlights

* **Documentation Addition**: Added a new documentation file 'docs/locations_and_targets.md' to define and explain the concepts of Locations and Targets within the Rawstor ecosystem.
* **URI Parsing Improvements**: Implemented robust escaping and unescaping logic in 'librawstorstd/src/uri.cpp' to correctly handle commas within URI strings, ensuring they are not misinterpreted as delimiters.
* **Test Coverage**: Updated 'librawstorstd/tests/test_uri.cpp' with additional test cases to verify the new escaping/unescaping functionality and ensure correct parsing of complex URI strings.

(cherry picked from commit 2fd284ce8738624103ef720b72d8437c6fb03684)