### PR TITLE
ref: introduce target and location conception (#337)

### DIFF
--- a/cli/create.c
+++ b/cli/create.c
@@ -6,7 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-int rawstor_cli_create(const char* uris, size_t size) {
+int rawstor_cli_create(const char* location, size_t size) {
     struct RawstorObjectSpec spec = {
         .size = size << 30,
     };
@@ -14,16 +14,15 @@ int rawstor_cli_create(const char* uris, size_t size) {
     fprintf(stderr, "Creating object with specification:\n");
     fprintf(stderr, "  size: %zu Gb\n", size);
 
-    char object_uris[65536];
-    int res =
-        rawstor_object_create(uris, &spec, object_uris, sizeof(object_uris));
+    char target[65536];
+    int res = rawstor_object_create(location, &spec, target, sizeof(target));
     if (res < 0) {
         fprintf(stderr, "rawstor_object_create() failed: %s\n", strerror(-res));
         return EXIT_FAILURE;
     }
 
     fprintf(stderr, "Object created\n");
-    fprintf(stdout, "%s\n", object_uris);
+    fprintf(stdout, "%s\n", target);
 
     return EXIT_SUCCESS;
 }

--- a/cli/create.h
+++ b/cli/create.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-int rawstor_cli_create(const char* uris, size_t size);
+int rawstor_cli_create(const char* location, size_t size);
 
 #ifdef __cplusplus
 }

--- a/cli/main.c
+++ b/cli/main.c
@@ -63,7 +63,7 @@ static int command_create(int argc, char** argv) {
     };
 
     char* size_arg = NULL;
-    char* uri_arg = NULL;
+    char* location_arg = NULL;
     optind = 1;
     while (1) {
         int c = getopt_long(argc, argv, optstring, longopts, NULL);
@@ -82,7 +82,7 @@ static int command_create(int argc, char** argv) {
             break;
 
         case 'u':
-            uri_arg = optarg;
+            location_arg = optarg;
             break;
 
         default:
@@ -100,7 +100,7 @@ static int command_create(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    if (uri_arg == NULL) {
+    if (location_arg == NULL) {
         fprintf(stderr, "uri required\n");
         return EXIT_FAILURE;
     }
@@ -111,7 +111,7 @@ static int command_create(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    return rawstor_cli_create(uri_arg, size);
+    return rawstor_cli_create(location_arg, size);
 }
 
 static void command_remove_usage(void) {
@@ -135,7 +135,7 @@ static int command_remove(int argc, char** argv) {
         {},
     };
 
-    char* object_uri_arg = NULL;
+    char* target_arg = NULL;
     optind = 1;
     while (1) {
         int c = getopt_long(argc, argv, optstring, longopts, NULL);
@@ -150,7 +150,7 @@ static int command_remove(int argc, char** argv) {
             break;
 
         case 'o':
-            object_uri_arg = optarg;
+            target_arg = optarg;
             break;
 
         default:
@@ -163,12 +163,12 @@ static int command_remove(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    if (object_uri_arg == NULL) {
+    if (target_arg == NULL) {
         fprintf(stderr, "object-uri required\n");
         return EXIT_FAILURE;
     }
 
-    return rawstor_cli_remove(object_uri_arg);
+    return rawstor_cli_remove(target_arg);
 }
 
 static void command_show_usage(void) {
@@ -192,7 +192,7 @@ static int command_show(int argc, char** argv) {
         {},
     };
 
-    char* object_uri_arg = NULL;
+    char* target_arg = NULL;
     optind = 1;
     while (1) {
         int c = getopt_long(argc, argv, optstring, longopts, NULL);
@@ -207,7 +207,7 @@ static int command_show(int argc, char** argv) {
             break;
 
         case 'o':
-            object_uri_arg = optarg;
+            target_arg = optarg;
             break;
 
         default:
@@ -220,12 +220,12 @@ static int command_show(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    if (object_uri_arg == NULL) {
+    if (target_arg == NULL) {
         fprintf(stderr, "object-uri required\n");
         return EXIT_FAILURE;
     }
 
-    return rawstor_cli_show(object_uri_arg);
+    return rawstor_cli_show(target_arg);
 }
 
 static void command_testio_usage(void) {
@@ -264,7 +264,7 @@ static int command_testio(int argc, char** argv) {
     char* block_size_arg = NULL;
     char* count_arg = NULL;
     char* io_depth_arg = NULL;
-    char* object_uri_arg = NULL;
+    char* target_arg = NULL;
     int vector_mode = 0;
     optind = 1;
     while (1) {
@@ -292,7 +292,7 @@ static int command_testio(int argc, char** argv) {
             break;
 
         case 'o':
-            object_uri_arg = optarg;
+            target_arg = optarg;
             break;
 
         case 'v':
@@ -342,13 +342,13 @@ static int command_testio(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    if (object_uri_arg == NULL) {
+    if (target_arg == NULL) {
         fprintf(stderr, "object-uri required\n");
         return EXIT_FAILURE;
     }
 
     return rawstor_cli_testio(
-        object_uri_arg, block_size, count, io_depth, vector_mode
+        target_arg, block_size, count, io_depth, vector_mode
     );
 }
 

--- a/cli/remove.c
+++ b/cli/remove.c
@@ -8,10 +8,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-int rawstor_cli_remove(const char* uris) {
-    fprintf(stderr, "Removing object: %s\n", uris);
+int rawstor_cli_remove(const char* target) {
+    fprintf(stderr, "Removing object: %s\n", target);
 
-    int res = rawstor_object_remove(uris);
+    int res = rawstor_object_remove(target);
     if (res) {
         fprintf(stderr, "rawstor_object_remove() failed: %s\n", strerror(-res));
         return EXIT_FAILURE;

--- a/cli/remove.h
+++ b/cli/remove.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-int rawstor_cli_remove(const char* uris);
+int rawstor_cli_remove(const char* target);
 
 #ifdef __cplusplus
 }

--- a/cli/show.c
+++ b/cli/show.c
@@ -8,15 +8,15 @@
 #include <stdlib.h>
 #include <string.h>
 
-int rawstor_cli_show(const char* uris) {
+int rawstor_cli_show(const char* target) {
     struct RawstorObjectSpec spec;
-    int res = rawstor_object_spec(uris, &spec);
+    int res = rawstor_object_spec(target, &spec);
     if (res) {
         fprintf(stderr, "rawstor_object_spec() failed: %s\n", strerror(-res));
         return EXIT_FAILURE;
     }
 
-    printf("uri: %s\n", uris);
+    printf("uri: %s\n", target);
     printf("size: %zu Gb\n", spec.size >> 30);
 
     return EXIT_SUCCESS;

--- a/cli/show.h
+++ b/cli/show.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-int rawstor_cli_show(const char* uris);
+int rawstor_cli_show(const char* target);
 
 #ifdef __cplusplus
 }

--- a/cli/testio.c
+++ b/cli/testio.c
@@ -256,12 +256,12 @@ static int srcv_data_sent(
 }
 
 int rawstor_cli_testio(
-    const char* uris, size_t block_size, unsigned int count,
+    const char* target, size_t block_size, unsigned int count,
     unsigned int io_depth, int vector_mode
 ) {
     int res;
     RawstorObject* object;
-    res = rawstor_object_open(uris, &object);
+    res = rawstor_object_open(target, &object);
     if (res < 0) {
         fprintf(stderr, "rawstor_object_open() failed: %s\n", strerror(-res));
         goto err_open;

--- a/cli/testio.h
+++ b/cli/testio.h
@@ -8,7 +8,7 @@ extern "C" {
 #endif
 
 int rawstor_cli_testio(
-    const char* uris, size_t block_size, unsigned int count,
+    const char* target, size_t block_size, unsigned int count,
     unsigned int io_depth, int vector_mode
 );
 

--- a/include/rawstor/object.h
+++ b/include/rawstor/object.h
@@ -21,35 +21,254 @@ extern "C" {
 
 typedef struct RawstorObject RawstorObject;
 
+/**
+ * @brief Object metadata structure.
+ *
+ * Contains information about a stored object. This structure is used both for
+ * retrieving existing object metadata (via rawstor_object_spec()) and for
+ * specifying parameters when creating a new object (via
+ * rawstor_object_create()).
+ *
+ * When used with rawstor_object_create(), the size field must be set to the
+ * desired size of the object to be created.
+ *
+ * When used with rawstor_object_spec(), the size field is filled with the
+ * actual size of the existing object in bytes.
+ *
+ * @see rawstor_object_spec
+ * @see rawstor_object_create
+ */
 struct RawstorObjectSpec {
-    size_t size;
+    size_t size; /**< Size of the object in bytes. */
 };
 
 typedef int(RawstorCallback)(
     RawstorObject* object, size_t size, size_t result, int error, void* data
 );
 
+/**
+ * @brief Retrieve metadata about a stored object.
+ *
+ * Given a target string (as defined in the Rawstor location/target syntax),
+ * this function fills a RawstorObjectSpec structure with information about the
+ * object, such as its size.
+ *
+ * The target may be a single location‑UUID pair or a comma‑separated list of
+ * such pairs (mirroring / data locality). All UUIDs in a list must be
+ * identical. The function queries backends in the order they appear until one
+ * successfully returns the metadata.
+ *
+ * @param target  Target string, e.g.:
+ *                - "ost://127.0.0.1:9090/019cbfad-a389-7d42-a0f6-c29993ac8c00"
+ *                - "file:///var/rawstor/019cbfad-a389-7d42-a0f6-c29993ac8c00"
+ *                - "ost://host1:9090/abc,ost://host2:9090/abc"  (mirroring)
+ *                - "file:///data/abc,ost://host1:9090/abc"      (locality)
+ * @param spec    Pointer to a RawstorObjectSpec structure that will be
+ *                filled with the object's metadata on success.
+ *
+ * @return 0 on success, negative errno on error.
+ * @retval 0        Object metadata successfully retrieved.
+ * @retval -EINVAL  Invalid target syntax (e.g., malformed URI, empty list,
+ *                  duplicate URIs, mismatched UUIDs).
+ * @retval -ENOENT  Object not found on any of the specified backends.
+ * @retval -EIO     I/O error (network or filesystem).
+ * @retval -EACCES  Permission denied.
+ *
+ * @see RawstorObjectSpec
+ * @see Location and Target documentation in Rawstor user guide:
+ * https://github.com/rawstor/librawstor/blob/main/docs/locations_and_targets.md
+ */
 int rawstor_object_spec(
-    const char* object_uris, struct RawstorObjectSpec* spec
+    const char* target, struct RawstorObjectSpec* spec
 ) RAWSTOR_NOEXCEPT;
 
+/**
+ * @brief Create a new empty object at the specified location.
+ *
+ * This function creates an object at the given location with the specified
+ * metadata (e.g., size). Upon success, the target string of the newly created
+ * object is written into the provided buffer. The target string follows the
+ * format described in Locations and Targets documentation.
+ *
+ * @param location  Location string (e.g., "ost://host:port" or a
+ *                  comma‑separated list). Specifies which backend(s) should
+ *                  store the object.
+ * @param spec      Pointer to a RawstorObjectSpec structure containing the
+ *                  desired object metadata (e.g., size in bytes). The size
+ *                  field must be set to the expected size of the object.
+ * @param target    Output buffer that will receive the target string of the
+ *                  created object (e.g., "ost://host:port/<uuid>").
+ *                  Can not be NULL.
+ * @param size      Size of the target buffer in bytes (including space for
+ *                  the null terminator).
+ *
+ * @return On success, returns the number of characters that would have been
+ *         written to target (excluding the terminating null byte), as with
+ *         snprintf(). If this value is non‑negative but greater than or equal
+ *         to size, the output was truncated.
+ * @retval Negative value on error (e.g., -EINVAL for invalid location or spec,
+ *         -ENOMEM, -EIO, etc.). The specific negative errno codes are
+ *         implementation‑defined.
+ *
+ * @see RawstorObjectSpec
+ * @see Locations and Targets:
+ * https://github.com/rawstor/librawstor/blob/main/docs/locations_and_targets.md
+ */
 int rawstor_object_create(
-    const char* uris, const struct RawstorObjectSpec* spec, char* object_uris,
+    const char* location, const struct RawstorObjectSpec* spec, char* target,
     size_t size
 ) RAWSTOR_NOEXCEPT;
 
-int rawstor_object_remove(const char* object_uris) RAWSTOR_NOEXCEPT;
+/**
+ * @brief Remove an object from the storage system.
+ *
+ * Given a target string (as defined in the Rawstor location/target syntax),
+ * this function deletes the specified object from all backends listed in the
+ * target. If the target contains multiple URIs (mirroring or locality),
+ * the object is removed from every backend in the list.
+ *
+ * @param target  Target string identifying the object to remove, e.g.:
+ *                - "ost://127.0.0.1:9090/019cbfad-a389-7d42-a0f6-c29993ac8c00"
+ *                - "file:///var/rawstor/019cbfad-a389-7d42-a0f6-c29993ac8c00"
+ *                - "ost://host1:9090/abc,ost://host2:9090/abc"  (mirroring)
+ *                - "file:///data/abc,ost://host1:9090/abc"      (locality)
+ *
+ * @return 0 on success, negative errno on error.
+ * @retval 0        Object successfully removed from all backends.
+ * @retval -EINVAL  Invalid target syntax (malformed URI, empty list, duplicate
+ *                  URIs, mismatched UUIDs).
+ * @retval -ENOENT  Object not found on one or more backends.
+ * @retval -EIO     I/O error (network or filesystem).
+ * @retval -EACCES  Permission denied.
+ *
+ * @see RawstorObjectSpec
+ * @see Locations and Targets:
+ * https://github.com/rawstor/librawstor/blob/main/docs/locations_and_targets.md
+ */
+int rawstor_object_remove(const char* target) RAWSTOR_NOEXCEPT;
 
+/**
+ * @brief Open an existing object for reading and/or writing.
+ *
+ * Given a target string (as defined in the Rawstor location/target syntax),
+ * this function opens the specified object and returns an opaque handle that
+ * can be used for subsequent read/write operations. The object must already
+ * exist; otherwise, the function returns an error.
+ *
+ * If the target contains multiple URIs (mirroring or data locality), the
+ * library selects the appropriate backend(s) according to the location
+ * policy defined for that target.
+ *
+ * The returned RawstorObject handle must be closed with rawstor_object_close()
+ * to release resources.
+ *
+ * @param target  Target string identifying the object to open, e.g.:
+ *                - "ost://127.0.0.1:9090/019cbfad-a389-7d42-a0f6-c29993ac8c00"
+ *                - "file:///var/rawstor/019cbfad-a389-7d42-a0f6-c29993ac8c00"
+ *                - "ost://host1:9090/abc,ost://host2:9090/abc"  (mirroring)
+ *                - "file:///data/abc,ost://host1:9090/abc"      (locality)
+ * @param object  Pointer to a RawstorObject pointer that will receive the
+ *                opaque handle on success. The caller must not modify the
+ *                pointed-to memory directly. On error, *object is set to NULL.
+ *
+ * @return 0 on success, negative errno on error.
+ * @retval 0        Object successfully opened.
+ * @retval -EINVAL  Invalid target syntax (malformed URI, empty list, duplicate
+ *                  URIs, mismatched UUIDs).
+ * @retval -ENOENT  Object does not exist on any of the specified backends.
+ * @retval -EIO     I/O error (network or filesystem).
+ * @retval -EACCES  Permission denied.
+ *
+ * @see RawstorObject
+ * @see rawstor_object_close
+ * @see Locations and Targets:
+ * https://github.com/rawstor/librawstor/blob/main/docs/locations_and_targets.md
+ */
 int rawstor_object_open(
-    const char* object_uris, RawstorObject** object
+    const char* target, RawstorObject** object
 ) RAWSTOR_NOEXCEPT;
 
+/**
+ * @brief Close an opened object and release associated resources.
+ *
+ * This function closes a RawstorObject handle previously obtained via
+ * rawstor_object_open(). After closing, the handle becomes invalid and should
+ * not be used further. Any pending write buffers are flushed to the backend(s)
+ * before the handle is closed.
+ *
+ * @param object  Pointer to the RawstorObject handle to close. Can not be NULL.
+ *
+ * @return 0 on success, negative errno on error.
+ * @retval 0        Object successfully closed.
+ * @retval -EIO     I/O error while flushing writes or finalizing metadata.
+ *
+ * @see rawstor_object_open
+ */
 int rawstor_object_close(RawstorObject* object) RAWSTOR_NOEXCEPT;
 
+/**
+ * @brief Retrieve the UUID of an open object.
+ *
+ * Given an open RawstorObject handle, this function writes the object's
+ * unique identifier (UUID) into the provided buffer. The UUID is the part
+ * after the last slash in a target string (e.g., for target
+ * "ost://host:9090/019cbfad-a389-7d42-a0f6-c29993ac8c00", the UUID is
+ * "019cbfad-a389-7d42-a0f6-c29993ac8c00").
+ *
+ * If the buffer size is insufficient, the output is truncated but the
+ * return value indicates the required buffer length (excluding the null
+ * terminator), similar to snprintf().
+ *
+ * @param object  Open object handle obtained from rawstor_object_open().
+ * @param buf     Output buffer that will receive the UUID string. Can not be
+ *                NULL.
+ * @param size    Size of the output buffer in bytes (including space for the
+ *                terminating null byte). If size is 0, no data is written, but
+ *                the required length is still returned.
+ *
+ * @return On success, returns the number of characters that would have been
+ *         written to buf (excluding the terminating null byte). If this value
+ *         is non‑negative but greater than or equal to size, the output was
+ *         truncated.
+ *
+ * @see rawstor_object_open
+ */
 int rawstor_object_id(
     const RawstorObject* object, char* buf, size_t size
 ) RAWSTOR_NOEXCEPT;
 
+/**
+ * @brief Retrieve the list of location URIs for an open object.
+ *
+ * Given an open RawstorObject handle, this function writes a comma‑separated
+ * list of location URIs (as defined in the Locations and Targets documentation)
+ * into the provided buffer. These URIs represent the backend(s) where the
+ * object is physically stored (e.g., OST servers, file system paths).
+ *
+ * The format is the same as the location part of a target string, for example:
+ * - "ost://host1:9090/abc,ost://host2:9090/abc"  (mirroring)
+ * - "file:///data/abc,ost://host1:9090/abc"      (locality)
+ *
+ * If the buffer size is insufficient, the output is truncated but the return
+ * value indicates the required buffer length (excluding the null terminator),
+ * similar to snprintf().
+ *
+ * @param object  Open object handle obtained from rawstor_object_open().
+ * @param buf     Output buffer that will receive the comma‑separated list of
+ *                location URIs. Can not be NULL.
+ * @param size    Size of the output buffer in bytes (including space for the
+ *                terminating null byte). If size is 0, no data is written,
+ *                but the required length is still returned.
+ *
+ * @return On success, returns the number of characters that would have been
+ *         written to buf (excluding the terminating null byte). If this value
+ *         is non‑negative but greater than or equal to size, the output was
+ *         truncated.
+ *
+ * @see rawstor_object_id
+ * @see Locations and Targets:
+ * https://github.com/rawstor/librawstor/blob/main/docs/locations_and_targets.md
+ */
 int rawstor_object_uris(
     const RawstorObject* object, char* buf, size_t size
 ) RAWSTOR_NOEXCEPT;

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -67,8 +67,9 @@ Connection::~Connection() {
     }
 }
 
-std::vector<std::shared_ptr<Session>>
-Connection::_open(const URI& uri, RawstorObject* object, size_t nsessions) {
+std::vector<std::shared_ptr<Session>> Connection::_open(
+    const URI& location, RawstorObject* object, size_t nsessions
+) {
     std::vector<std::shared_ptr<Session>> sessions;
 
     for (unsigned int attempt = 1; attempt <= rawstor_opts_io_attempts();
@@ -77,7 +78,9 @@ Connection::_open(const URI& uri, RawstorObject* object, size_t nsessions) {
             sessions.clear();
             sessions.reserve(nsessions);
             for (size_t i = 0; i < nsessions; ++i) {
-                sessions.push_back(Session::create(*io_queue, uri, _depth));
+                sessions.push_back(
+                    Session::create(*io_queue, location, _depth)
+                );
             }
 
             for (std::shared_ptr<Session> s : sessions) {
@@ -205,23 +208,23 @@ void Connection::invalidate_session(const std::shared_ptr<Session>& s) {
         _sessions.erase(it);
 
         std::vector<std::shared_ptr<Session>> new_sessions =
-            _open(s->uri(), _object, 1);
+            _open(s->location(), _object, 1);
 
         _sessions.push_back(new_sessions.front());
     }
 }
 
-const URI* Connection::uri() const noexcept {
+const URI* Connection::location() const noexcept {
     if (_sessions.empty()) {
         return nullptr;
     }
 
-    return &_sessions.front()->uri();
+    return &_sessions.front()->location();
 }
 
-void Connection::create(const URI& uri, const RawstorObjectSpec& sp) {
+void Connection::create(const URI& target, const RawstorObjectSpec& sp) {
     RawstorUUID id;
-    int res = rawstor_uuid_from_string(&id, uri.path().filename().c_str());
+    int res = rawstor_uuid_from_string(&id, target.path().filename().c_str());
     if (res) {
         RAWSTOR_THROW_SYSTEM_ERROR(-res);
     }
@@ -229,7 +232,7 @@ void Connection::create(const URI& uri, const RawstorObjectSpec& sp) {
     Queue q(1, _depth);
 
     std::unique_ptr<Session> s =
-        Session::create(q.queue(), uri.parent(), _depth);
+        Session::create(q.queue(), target.parent(), _depth);
     s->create(id, sp, [&q](int error) {
         q.sub_operation();
 
@@ -241,9 +244,9 @@ void Connection::create(const URI& uri, const RawstorObjectSpec& sp) {
     q.wait();
 }
 
-void Connection::remove(const URI& uri) {
+void Connection::remove(const URI& target) {
     RawstorUUID id;
-    int res = rawstor_uuid_from_string(&id, uri.path().filename().c_str());
+    int res = rawstor_uuid_from_string(&id, target.path().filename().c_str());
     if (res) {
         RAWSTOR_THROW_SYSTEM_ERROR(-res);
     }
@@ -251,7 +254,7 @@ void Connection::remove(const URI& uri) {
     Queue q(1, _depth);
 
     std::unique_ptr<Session> s =
-        Session::create(q.queue(), uri.parent(), _depth);
+        Session::create(q.queue(), target.parent(), _depth);
     s->remove(id, [&q](int error) {
         q.sub_operation();
 
@@ -263,9 +266,9 @@ void Connection::remove(const URI& uri) {
     q.wait();
 }
 
-void Connection::spec(const URI& uri, RawstorObjectSpec* sp) {
+void Connection::spec(const URI& target, RawstorObjectSpec* sp) {
     RawstorUUID id;
-    int res = rawstor_uuid_from_string(&id, uri.path().filename().c_str());
+    int res = rawstor_uuid_from_string(&id, target.path().filename().c_str());
     if (res) {
         RAWSTOR_THROW_SYSTEM_ERROR(-res);
     }
@@ -273,7 +276,7 @@ void Connection::spec(const URI& uri, RawstorObjectSpec* sp) {
     Queue q(1, _depth);
 
     std::unique_ptr<Session> s =
-        Session::create(q.queue(), uri.parent(), _depth);
+        Session::create(q.queue(), target.parent(), _depth);
     s->spec(id, [&q, sp](const RawstorObjectSpec& spec, int error) {
         q.sub_operation();
 
@@ -287,8 +290,10 @@ void Connection::spec(const URI& uri, RawstorObjectSpec* sp) {
     q.wait();
 }
 
-void Connection::open(const URI& uri, RawstorObject* object, size_t nsessions) {
-    _sessions = _open(uri, object, nsessions);
+void Connection::open(
+    const URI& location, RawstorObject* object, size_t nsessions
+) {
+    _sessions = _open(location, object, nsessions);
     _object = object;
 }
 

--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -25,7 +25,7 @@ private:
     size_t _session_index;
 
     std::vector<std::shared_ptr<Session>>
-    _open(const URI& uri, RawstorObject* object, size_t nsessions);
+    _open(const URI& location, RawstorObject* object, size_t nsessions);
 
     void
     _op(const char* func_name, size_t size, off_t offset,
@@ -45,15 +45,15 @@ public:
     std::shared_ptr<Session> get_next_session();
     void invalidate_session(const std::shared_ptr<Session>& s);
 
-    const URI* uri() const noexcept;
+    const URI* location() const noexcept;
 
-    void create(const URI& uri, const RawstorObjectSpec& sp);
+    void create(const URI& target, const RawstorObjectSpec& sp);
 
-    void remove(const URI& uri);
+    void remove(const URI& target);
 
-    void spec(const URI& uri, RawstorObjectSpec* sp);
+    void spec(const URI& target, RawstorObjectSpec* sp);
 
-    void open(const URI& uri, RawstorObject* object, size_t nsessions);
+    void open(const URI& location, RawstorObject* object, size_t nsessions);
 
     void close();
 

--- a/src/file_session.cpp
+++ b/src/file_session.cpp
@@ -29,16 +29,16 @@
 
 namespace {
 
-std::string get_ost_path(const rawstor::URI& uri) {
-    if (uri.scheme() != "file") {
-        rawstor_error("Unexpected URI scheme: %s\n", uri.str().c_str());
+std::string get_ost_path(const rawstor::URI& location) {
+    if (location.scheme() != "file") {
+        rawstor_error("Unexpected URI scheme: %s\n", location.str().c_str());
         RAWSTOR_THROW_SYSTEM_ERROR(EINVAL);
     }
-    if (!uri.host().empty()) {
-        rawstor_error("Empty host expected: %s\n", uri.str().c_str());
+    if (!location.host().empty()) {
+        rawstor_error("Empty host expected: %s\n", location.str().c_str());
         RAWSTOR_THROW_SYSTEM_ERROR(EINVAL);
     }
-    return uri.path().str();
+    return location.path().str();
 }
 
 std::string get_object_spec_path(
@@ -96,19 +96,19 @@ namespace rawstor {
 namespace file {
 
 Session::Session(
-    rawstor::io::Queue& queue, const URI& uri, unsigned int depth
+    rawstor::io::Queue& queue, const URI& location, unsigned int depth
 ) :
-    rawstor::Session(queue, uri, depth) {
+    rawstor::Session(queue, location, depth) {
 }
 
 int Session::_connect(const RawstorUUID& id) {
-    std::string ost_path = get_ost_path(uri());
+    std::string ost_path = get_ost_path(location());
 
-    RawstorUUIDString uuid_string;
-    rawstor_uuid_to_string(&id, &uuid_string);
-    std::string dat_path = get_object_dat_path(ost_path, uuid_string);
+    RawstorUUIDString id_string;
+    rawstor_uuid_to_string(&id, &id_string);
+    std::string dat_path = get_object_dat_path(ost_path, id_string);
 
-    rawstor_info("Connecting to %s...\n", uri().str().c_str());
+    rawstor_info("Connecting to %s...\n", location().str().c_str());
     int fd = open(dat_path.c_str(), O_RDWR | O_NONBLOCK);
     if (fd == -1) {
         RAWSTOR_THROW_ERRNO();
@@ -121,7 +121,7 @@ void Session::create(
     const RawstorUUID& id, const RawstorObjectSpec& sp,
     std::function<void(int)>&& cb
 ) {
-    std::string ost_path = get_ost_path(uri());
+    std::string ost_path = get_ost_path(location());
     if (mkdir(ost_path.c_str(), 0755) == -1) {
         if (errno == EEXIST) {
             errno = 0;
@@ -164,7 +164,7 @@ void Session::create(
 }
 
 void Session::remove(const RawstorUUID& id, std::function<void(int)>&& cb) {
-    std::string ost_path = get_ost_path(uri());
+    std::string ost_path = get_ost_path(location());
 
     RawstorUUIDString uuid_string;
     rawstor_uuid_to_string(&id, &uuid_string);
@@ -194,7 +194,7 @@ void Session::spec(
     const RawstorUUID& id,
     std::function<void(const RawstorObjectSpec&, int)>&& cb
 ) {
-    std::string ost_path = get_ost_path(uri());
+    std::string ost_path = get_ost_path(location());
 
     RawstorUUIDString uuid_string;
     rawstor_uuid_to_string(&id, &uuid_string);

--- a/src/file_session.hpp
+++ b/src/file_session.hpp
@@ -18,7 +18,7 @@ private:
     int _connect(const RawstorUUID& id);
 
 public:
-    Session(rawstor::io::Queue& queue, const URI& uri, unsigned int depth);
+    Session(rawstor::io::Queue& queue, const URI& location, unsigned int depth);
 
     void create(
         const RawstorUUID& id, const RawstorObjectSpec& sp,

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -52,14 +52,14 @@ void validate_not_empty(const std::vector<rawstor::URI>& uris) {
     RAWSTOR_THROW_SYSTEM_ERROR(EINVAL);
 }
 
-void validate_same_uuid(const std::vector<rawstor::URI>& uris) {
-    if (uris.empty()) {
+void validate_same_uuid(const std::vector<rawstor::URI>& targets) {
+    if (targets.empty()) {
         return;
     }
 
-    std::string uuid = uris.front().path().filename();
-    for (const auto& uri : uris) {
-        if (uri.path().filename() != uuid) {
+    std::string uuid = targets.front().path().filename();
+    for (const auto& target : targets) {
+        if (target.path().filename() != uuid) {
             rawstor_error("Equal UUID expected\n");
             RAWSTOR_THROW_SYSTEM_ERROR(EINVAL);
         }
@@ -71,59 +71,59 @@ void validate_different_uris(const std::vector<rawstor::URI>& uris) {
         return;
     }
 
-    std::set<rawstor::URI> targets;
+    std::set<rawstor::URI> seen;
     for (const auto& uri : uris) {
-        if (targets.find(uri) != targets.end()) {
+        if (seen.find(uri) != seen.end()) {
             rawstor_error("Different uris expected\n");
             RAWSTOR_THROW_SYSTEM_ERROR(EINVAL);
         }
-        targets.insert(uri);
+        seen.insert(uri);
     }
 }
 
 } // namespace
 
-RawstorObject::RawstorObject(const std::vector<rawstor::URI>& uris) : _id() {
-    validate_not_empty(uris);
-    validate_different_uris(uris);
-    validate_same_uuid(uris);
+RawstorObject::RawstorObject(const std::vector<rawstor::URI>& targets) : _id() {
+    validate_not_empty(targets);
+    validate_different_uris(targets);
+    validate_same_uuid(targets);
 
-    std::string uuid = uris.front().path().filename();
-    int res = rawstor_uuid_from_string(&_id, uuid.c_str());
+    std::string id = targets.front().path().filename();
+    int res = rawstor_uuid_from_string(&_id, id.c_str());
     if (res) {
         RAWSTOR_THROW_SYSTEM_ERROR(-res);
     }
 
-    _cns.reserve(uris.size());
-    for (const auto& uri : uris) {
+    _cns.reserve(targets.size());
+    for (const auto& target : targets) {
         std::unique_ptr<rawstor::Connection> cn =
             std::make_unique<rawstor::Connection>(QUEUE_DEPTH);
-        cn->open(uri.parent(), this, rawstor_opts_sessions());
+        cn->open(target.parent(), this, rawstor_opts_sessions());
         _cns.push_back(std::move(cn));
     }
 }
 
 void RawstorObject::create(
-    const std::vector<rawstor::URI>& uris, const RawstorObjectSpec& sp,
-    std::vector<rawstor::URI>* object_uris
+    const std::vector<rawstor::URI>& locations, const RawstorObjectSpec& sp,
+    std::vector<rawstor::URI>* targets
 ) {
-    validate_not_empty(uris);
-    validate_different_uris(uris);
+    validate_not_empty(locations);
+    validate_different_uris(locations);
 
-    RawstorUUIDString uuid_string;
-    RawstorUUID uuid;
-    int res = rawstor_uuid7_init(&uuid);
+    RawstorUUIDString id_string;
+    RawstorUUID id;
+    int res = rawstor_uuid7_init(&id);
     if (res) {
         RAWSTOR_THROW_SYSTEM_ERROR(-res);
     }
-    rawstor_uuid_to_string(&uuid, &uuid_string);
+    rawstor_uuid_to_string(&id, &id_string);
 
     std::vector<rawstor::URI> ret;
     try {
-        for (const auto& uri : uris) {
-            rawstor::URI object_uri = rawstor::URI(uri, uuid_string);
-            rawstor::Connection(QUEUE_DEPTH).create(object_uri, sp);
-            ret.push_back(object_uri);
+        for (const auto& location : locations) {
+            rawstor::URI target = rawstor::URI(location, id_string);
+            rawstor::Connection(QUEUE_DEPTH).create(target, sp);
+            ret.push_back(target);
         }
     } catch (...) {
         if (!ret.empty()) {
@@ -137,18 +137,18 @@ void RawstorObject::create(
         }
         throw;
     }
-    *object_uris = ret;
+    *targets = ret;
 }
 
-void RawstorObject::remove(const std::vector<rawstor::URI>& uris) {
-    validate_not_empty(uris);
-    validate_different_uris(uris);
-    validate_same_uuid(uris);
+void RawstorObject::remove(const std::vector<rawstor::URI>& targets) {
+    validate_not_empty(targets);
+    validate_different_uris(targets);
+    validate_same_uuid(targets);
 
     std::exception_ptr eptr;
-    for (const auto& uri : uris) {
+    for (const auto& target : targets) {
         try {
-            rawstor::Connection(QUEUE_DEPTH).remove(uri);
+            rawstor::Connection(QUEUE_DEPTH).remove(target);
         } catch (const std::exception& e) {
             rawstor_error("%s\n", e.what());
 
@@ -163,27 +163,27 @@ void RawstorObject::remove(const std::vector<rawstor::URI>& uris) {
 }
 
 void RawstorObject::spec(
-    const std::vector<rawstor::URI>& uris, RawstorObjectSpec* sp
+    const std::vector<rawstor::URI>& targets, RawstorObjectSpec* sp
 ) {
     /**
      * TODO: Should we read all specs and compare them here?
      */
-    validate_not_empty(uris);
-    validate_different_uris(uris);
-    validate_same_uuid(uris);
+    validate_not_empty(targets);
+    validate_different_uris(targets);
+    validate_same_uuid(targets);
 
-    rawstor::Connection(QUEUE_DEPTH).spec(uris.front(), sp);
+    rawstor::Connection(QUEUE_DEPTH).spec(targets.front(), sp);
 }
 
-std::vector<rawstor::URI> RawstorObject::uris() const {
+std::vector<rawstor::URI> RawstorObject::locations() const {
     std::vector<rawstor::URI> ret;
     ret.reserve(_cns.size());
     for (const auto& cn : _cns) {
-        const rawstor::URI* uri = cn->uri();
-        if (uri == nullptr) {
+        const rawstor::URI* location = cn->location();
+        if (location == nullptr) {
             continue;
         }
-        ret.push_back(*uri);
+        ret.push_back(*location);
     }
     return ret;
 }
@@ -329,13 +329,12 @@ void RawstorObject::pwritev(
 }
 
 int rawstor_object_create(
-    const char* uris, const RawstorObjectSpec* sp, char* object_uris,
-    size_t size
+    const char* location, const RawstorObjectSpec* sp, char* target, size_t size
 ) noexcept {
     try {
-        std::vector<rawstor::URI> object_uriv;
-        RawstorObject::create(rawstor::URI::uriv(uris), *sp, &object_uriv);
-        return ::uris(object_uriv, object_uris, size);
+        std::vector<rawstor::URI> targets;
+        RawstorObject::create(rawstor::URI::uriv(location), *sp, &targets);
+        return ::uris(targets, target, size);
     } catch (const std::system_error& e) {
         return -e.code().value();
     } catch (const std::bad_alloc& e) {
@@ -349,9 +348,9 @@ int rawstor_object_create(
     }
 }
 
-int rawstor_object_remove(const char* object_uris) noexcept {
+int rawstor_object_remove(const char* target) noexcept {
     try {
-        RawstorObject::remove(rawstor::URI::uriv(object_uris));
+        RawstorObject::remove(rawstor::URI::uriv(target));
         return 0;
     } catch (const std::system_error& e) {
         return -e.code().value();
@@ -366,11 +365,9 @@ int rawstor_object_remove(const char* object_uris) noexcept {
     }
 }
 
-int rawstor_object_spec(
-    const char* object_uris, RawstorObjectSpec* sp
-) noexcept {
+int rawstor_object_spec(const char* target, RawstorObjectSpec* sp) noexcept {
     try {
-        RawstorObject::spec(rawstor::URI::uriv(object_uris), sp);
+        RawstorObject::spec(rawstor::URI::uriv(target), sp);
         return 0;
     } catch (const std::system_error& e) {
         return -e.code().value();
@@ -385,12 +382,10 @@ int rawstor_object_spec(
     }
 }
 
-int rawstor_object_open(
-    const char* object_uris, RawstorObject** object
-) noexcept {
+int rawstor_object_open(const char* target, RawstorObject** object) noexcept {
     try {
         std::unique_ptr<RawstorObject> ret =
-            std::make_unique<RawstorObject>(rawstor::URI::uriv(object_uris));
+            std::make_unique<RawstorObject>(rawstor::URI::uriv(target));
 
         *object = ret.get();
 
@@ -455,7 +450,7 @@ int rawstor_object_uris(
     const RawstorObject* object, char* buf, size_t size
 ) noexcept {
     try {
-        return uris(object->uris(), buf, size);
+        return uris(object->locations(), buf, size);
     } catch (const std::system_error& e) {
         return -e.code().value();
     } catch (const std::bad_alloc& e) {

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -23,20 +23,20 @@ private:
 
 public:
     static void create(
-        const std::vector<rawstor::URI>& uris, const RawstorObjectSpec& sp,
-        std::vector<rawstor::URI>* object_uris
+        const std::vector<rawstor::URI>& locations, const RawstorObjectSpec& sp,
+        std::vector<rawstor::URI>* targets
     );
-    static void remove(const std::vector<rawstor::URI>& uris);
+    static void remove(const std::vector<rawstor::URI>& targets);
     static void
-    spec(const std::vector<rawstor::URI>& uris, RawstorObjectSpec* sp);
+    spec(const std::vector<rawstor::URI>& targets, RawstorObjectSpec* sp);
 
-    explicit RawstorObject(const std::vector<rawstor::URI>& uris);
+    explicit RawstorObject(const std::vector<rawstor::URI>& targets);
     RawstorObject(const RawstorObject&) = delete;
     RawstorObject(RawstorObject&&) = delete;
     RawstorObject& operator=(const RawstorObject&) = delete;
     RawstorObject& operator=(RawstorObject&&) = delete;
 
-    std::vector<rawstor::URI> uris() const;
+    std::vector<rawstor::URI> locations() const;
 
     inline const RawstorUUID& id() const noexcept { return _id; }
 

--- a/src/ost_session.cpp
+++ b/src/ost_session.cpp
@@ -596,9 +596,9 @@ void Context::fail_in_flight(int error) {
 }
 
 Session::Session(
-    rawstor::io::Queue& queue, const URI& uri, unsigned int depth
+    rawstor::io::Queue& queue, const URI& location, unsigned int depth
 ) :
-    rawstor::Session(queue, uri, depth),
+    rawstor::Session(queue, location, depth),
     _cid_counter(0),
     _context(std::make_shared<Context>(*this)) {
     int fd = _connect();
@@ -610,8 +610,8 @@ Session::~Session() {
 }
 
 int Session::_connect() {
-    if (!uri().path().str().empty() && uri().path().str() != "/") {
-        rawstor_error("Empty path expected: %s\n", uri().str().c_str());
+    if (!location().path().str().empty() && location().path().str() != "/") {
+        rawstor_error("Empty path expected: %s\n", location().str().c_str());
         RAWSTOR_THROW_SYSTEM_ERROR(EINVAL);
     }
 
@@ -649,16 +649,20 @@ int Session::_connect() {
 
         sockaddr_in servaddr = {};
         servaddr.sin_family = AF_INET;
-        servaddr.sin_port = htons(uri().port());
+        servaddr.sin_port = htons(location().port());
 
-        res = inet_pton(AF_INET, uri().hostname().c_str(), &servaddr.sin_addr);
+        res = inet_pton(
+            AF_INET, location().hostname().c_str(), &servaddr.sin_addr
+        );
         if (res == 0) {
             RAWSTOR_THROW_SYSTEM_ERROR(EINVAL);
         } else if (res == -1) {
             RAWSTOR_THROW_ERRNO();
         }
 
-        rawstor_info("fd %d: Connecting to %s...\n", fd, uri().str().c_str());
+        rawstor_info(
+            "fd %d: Connecting to %s...\n", fd, location().str().c_str()
+        );
         if (connect(fd, (sockaddr*)&servaddr, sizeof(servaddr)) == -1) {
             RAWSTOR_THROW_ERRNO();
         }

--- a/src/ost_session.hpp
+++ b/src/ost_session.hpp
@@ -33,7 +33,7 @@ private:
     int _connect();
 
 public:
-    Session(rawstor::io::Queue& queue, const URI& uri, unsigned int depth);
+    Session(rawstor::io::Queue& queue, const URI& location, unsigned int depth);
     ~Session();
 
     void read_response_head();

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -19,10 +19,10 @@
 namespace rawstor {
 
 Session::Session(
-    rawstor::io::Queue& queue, const URI& uri, unsigned int depth
+    rawstor::io::Queue& queue, const URI& location, unsigned int depth
 ) :
     _depth(depth),
-    _uri(uri),
+    _location(location),
     _fd(-1),
     _queue(queue) {
 }
@@ -40,15 +40,16 @@ Session::~Session() {
     }
 }
 
-std::unique_ptr<Session>
-Session::create(rawstor::io::Queue& queue, const URI& uri, unsigned int depth) {
-    if (uri.scheme() == "ost") {
-        return std::make_unique<rawstor::ost::Session>(queue, uri, depth);
+std::unique_ptr<Session> Session::create(
+    rawstor::io::Queue& queue, const URI& location, unsigned int depth
+) {
+    if (location.scheme() == "ost") {
+        return std::make_unique<rawstor::ost::Session>(queue, location, depth);
     }
-    if (uri.scheme() == "file") {
-        return std::make_unique<rawstor::file::Session>(queue, uri, depth);
+    if (location.scheme() == "file") {
+        return std::make_unique<rawstor::file::Session>(queue, location, depth);
     }
-    rawstor_error("Unexpected URI: %s\n", uri.str().c_str());
+    rawstor_error("Unexpected URI scheme: %s\n", location.str().c_str());
     RAWSTOR_THROW_SYSTEM_ERROR(EINVAL);
 }
 

--- a/src/session.hpp
+++ b/src/session.hpp
@@ -20,7 +20,7 @@ class Task;
 class Session {
 private:
     unsigned int _depth;
-    URI _uri;
+    URI _location;
     int _fd;
 
 protected:
@@ -30,9 +30,9 @@ protected:
 
 public:
     static std::unique_ptr<Session>
-    create(rawstor::io::Queue& queue, const URI& uri, unsigned int depth);
+    create(rawstor::io::Queue& queue, const URI& location, unsigned int depth);
 
-    Session(rawstor::io::Queue& queue, const URI& uri, unsigned int depth);
+    Session(rawstor::io::Queue& queue, const URI& location, unsigned int depth);
     Session(const Session&) = delete;
     Session(Session&&) noexcept = delete;
     virtual ~Session();
@@ -41,7 +41,7 @@ public:
 
     std::string str() const;
 
-    inline const URI& uri() const noexcept { return _uri; }
+    inline const URI& location() const noexcept { return _location; }
 
     inline unsigned int depth() const noexcept { return _depth; }
 


### PR DESCRIPTION
This pull request introduces a conceptual separation between 'location' and 'target' within the Rawstor library. By renaming internal variables and parameters, the codebase now clearly distinguishes between the storage backend location and the full object target (which includes the object ID). This change enhances the API's semantic accuracy and aligns the implementation with the intended design, while also providing improved documentation for public-facing functions.

* **Terminology Refinement**: Renamed 'uri' to 'target' and 'location' across the codebase to better distinguish between storage locations and full object targets, improving API clarity.
* **API Documentation**: Added comprehensive Doxygen documentation to the public API in `include/rawstor/object.h` to clarify usage and behavior of object operations.
* **Codebase Consistency**: Standardized parameter naming conventions across internal and public interfaces to improve maintainability and readability.

(cherry picked from commit 884f35a5cc85fcac969692e5c573281002d9064c)

Conflicts:
	cli/show.c
	src/ost_session.cpp