### PR TITLE
ref: replace object_uri with target (#343)

### DIFF
--- a/vhost/device.cpp
+++ b/vhost/device.cpp
@@ -495,7 +495,7 @@ namespace vhost {
 
 std::unordered_map<int, Device*> Device::_devices;
 
-Device::Device(const std::string& object_uris, int fd) :
+Device::Device(const std::string& target, int fd) :
     _object(nullptr),
     _iface{
         .get_features = ::get_features,
@@ -523,12 +523,12 @@ Device::Device(const std::string& object_uris, int fd) :
     _blk_config(std::make_unique<virtio_blk_config>()) {
     memset(_blk_config.get(), 0, sizeof(*_blk_config.get()));
 
-    int ires = rawstor_object_spec(object_uris.c_str(), &_spec);
+    int ires = rawstor_object_spec(target.c_str(), &_spec);
     if (ires) {
         RAWSTOR_THROW_SYSTEM_ERROR(-ires);
     }
 
-    ires = rawstor_object_open(object_uris.c_str(), &_object);
+    ires = rawstor_object_open(target.c_str(), &_object);
     if (ires) {
         RAWSTOR_THROW_SYSTEM_ERROR(-ires);
     }

--- a/vhost/device.hpp
+++ b/vhost/device.hpp
@@ -36,7 +36,7 @@ public:
     static Device& get(int fd);
     static Device* find(int fd);
 
-    Device(const std::string& object_uris, int fd);
+    Device(const std::string& target, int fd);
     Device(const Device&) = delete;
     Device(Device&&) = delete;
     ~Device();

--- a/vhost/main.cpp
+++ b/vhost/main.cpp
@@ -43,8 +43,8 @@ void sact_handler(int s) {
     std::cout << "Caught signal:" << s << std::endl;
 }
 
-void server(const std::string& object_uri, const std::string& socket_path) {
-    rawstor::vhost::Server s(object_uri, socket_path);
+void server(const std::string& target, const std::string& socket_path) {
+    rawstor::vhost::Server s(target, socket_path);
     s.loop();
 }
 
@@ -59,7 +59,7 @@ int main(int argc, char** argv) {
         {},
     };
 
-    const char* object_uri_arg = nullptr;
+    const char* target_arg = nullptr;
     const char* socket_path_arg = nullptr;
     while (1) {
         int c = getopt_long(argc, argv, optstring, longopts, nullptr);
@@ -74,7 +74,7 @@ int main(int argc, char** argv) {
             break;
 
         case 'o':
-            object_uri_arg = optarg;
+            target_arg = optarg;
             break;
 
         case 's':
@@ -91,7 +91,7 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    if (object_uri_arg == nullptr) {
+    if (target_arg == nullptr) {
         std::cerr << "object-uri argument required" << std::endl;
         return EXIT_FAILURE;
     }
@@ -119,7 +119,7 @@ int main(int argc, char** argv) {
     }
 
     try {
-        server(object_uri_arg, socket_path_arg);
+        server(target_arg, socket_path_arg);
     } catch (const std::exception& e) {
         std::cerr << e.what() << std::endl;
         return EXIT_FAILURE;

--- a/vhost/server.cpp
+++ b/vhost/server.cpp
@@ -81,8 +81,8 @@ void close_unix_socket(const std::string& socket_path, int fd) {
 namespace rawstor {
 namespace vhost {
 
-Server::Server(const std::string& object_uris, const std::string& socket_path) :
-    _object_uris(object_uris),
+Server::Server(const std::string& target, const std::string& socket_path) :
+    _target(target),
     _socket_path(socket_path),
     _fd(open_unix_socket(_socket_path)) {
     int res = rawstor_initialize(NULL);
@@ -111,7 +111,7 @@ void Server::loop() {
         RAWSTOR_THROW_ERRNO();
     }
 
-    Device d(_object_uris, fd);
+    Device d(_target, fd);
     d.loop();
 }
 

--- a/vhost/server.hpp
+++ b/vhost/server.hpp
@@ -8,12 +8,12 @@ namespace vhost {
 
 class Server final {
 private:
-    std::string _object_uris;
+    std::string _target;
     std::string _socket_path;
     int _fd;
 
 public:
-    Server(const std::string& object_uris, const std::string& socket_path);
+    Server(const std::string& target, const std::string& socket_path);
     Server(const Server&) = delete;
     Server(Server&&) = delete;
     ~Server();


### PR DESCRIPTION
This pull request standardizes the terminology used for object specifications by renaming 'object_uri' and its variants to 'target'. This change ensures consistency across the vhost implementation, including class constructors, internal storage, and command-line argument handling.

### Highlights

* **Variable Renaming**: Renamed variables and parameters previously named 'object_uri' or 'object_uris' to 'target' across the codebase to improve naming consistency.
* **Codebase Alignment**: Updated the Device and Server classes, as well as the main entry point, to reflect the new 'target' terminology for object specification.

(cherry picked from commit 4c4b981acc4e815a4dc299da5e714c339e526249)