### PR TITLE
add: cancel by fd routine (#346)

### DIFF
--- a/librawstorio/include/rawstorio/queue.hpp
+++ b/librawstorio/include/rawstorio/queue.hpp
@@ -122,6 +122,8 @@ public:
 
     virtual void cancel(Event* event) = 0;
 
+    virtual void cancel(int fd) = 0;
+
     virtual bool empty() const noexcept = 0;
 
     virtual void wait(unsigned int timeout) = 0;

--- a/librawstorio/src/poll_queue.cpp
+++ b/librawstorio/src/poll_queue.cpp
@@ -391,6 +391,14 @@ void Queue::cancel(rawstor::io::Event* e) {
     RAWSTOR_THROW_SYSTEM_ERROR(ENOENT);
 }
 
+void Queue::cancel(int fd) {
+    auto it = _sessions.find(fd);
+    if (it != _sessions.end()) {
+        it->second->cancel(_cqes);
+        _sessions.erase(it);
+    }
+}
+
 bool Queue::empty() const noexcept {
     if (!_cqes.empty()) {
         return false;

--- a/librawstorio/src/poll_queue.hpp
+++ b/librawstorio/src/poll_queue.hpp
@@ -117,6 +117,8 @@ public:
 
     void cancel(rawstor::io::Event* e) override;
 
+    void cancel(int fd) override;
+
     bool empty() const noexcept override;
 
     void wait(unsigned int timeout) override;

--- a/librawstorio/src/poll_session.cpp
+++ b/librawstorio/src/poll_session.cpp
@@ -252,6 +252,28 @@ bool Session::cancel(rawstor::io::Event* event, rawstor::RingBuf<Event>& cqes) {
     return found;
 }
 
+void Session::cancel(rawstor::RingBuf<Event>& cqes) {
+    while (!_poll_sqes.empty()) {
+        std::unique_ptr<EventSimplexPoll> e = std::move(_poll_sqes.front());
+        _poll_sqes.pop_front();
+
+        e->set_error(ECANCELED);
+        cqes.push(std::move(e));
+    }
+
+    while (!_read_sqes.empty()) {
+        std::unique_ptr<EventSimplex> e = _read_sqes.pop();
+        e->set_error(ECANCELED);
+        cqes.push(std::move(e));
+    }
+
+    while (!_write_sqes.empty()) {
+        std::unique_ptr<Event> e = _write_sqes.pop();
+        e->set_error(ECANCELED);
+        cqes.push(std::move(e));
+    }
+}
+
 void Session::process(
     rawstor::RingBuf<rawstor::io::poll::Event>& cqes, short revents
 ) {

--- a/librawstorio/src/poll_session.hpp
+++ b/librawstorio/src/poll_session.hpp
@@ -66,6 +66,8 @@ public:
 
     bool cancel(rawstor::io::Event* event, rawstor::RingBuf<Event>& cqes);
 
+    void cancel(rawstor::RingBuf<Event>& cqes);
+
     void process(RingBuf<Event>& cqes, short revents);
 };
 

--- a/librawstorio/src/uring_queue.cpp
+++ b/librawstorio/src/uring_queue.cpp
@@ -621,8 +621,21 @@ void Queue::cancel(rawstor::io::Event* event) {
 
     io_uring_sync_cancel_reg req = {};
     req.addr = (__u64)event;
-    req.fd = 0;
-    req.flags = 0;
+    res = io_uring_register_sync_cancel(&_ring, &req);
+    if (res < 0) {
+        RAWSTOR_THROW_SYSTEM_ERROR(-res);
+    }
+}
+
+void Queue::cancel(int fd) {
+    int res = io_uring_submit(&_ring);
+    if (res < 0) {
+        RAWSTOR_THROW_SYSTEM_ERROR(-res);
+    }
+
+    io_uring_sync_cancel_reg req = {};
+    req.fd = fd;
+    req.flags = IORING_ASYNC_CANCEL_ALL | IORING_ASYNC_CANCEL_FD;
     res = io_uring_register_sync_cancel(&_ring, &req);
     if (res < 0) {
         RAWSTOR_THROW_SYSTEM_ERROR(-res);

--- a/librawstorio/src/uring_queue.hpp
+++ b/librawstorio/src/uring_queue.hpp
@@ -107,6 +107,8 @@ public:
 
     void cancel(rawstor::io::Event* event);
 
+    void cancel(int fd);
+
     bool empty() const noexcept override;
 
     void wait(unsigned int timeout) override;

--- a/librawstorio/tests/test_cancel.cpp
+++ b/librawstorio/tests/test_cancel.cpp
@@ -12,11 +12,12 @@ namespace {
 
 class CancelTest : public rawstor::io::tests::QueueTest {
 protected:
-    CancelTest() : rawstor::io::tests::QueueTest(1) {}
+    CancelTest() : rawstor::io::tests::QueueTest(4) {}
 };
 
-TEST_F(CancelTest, cancel_nullptr) {
+TEST_F(CancelTest, cancel_noent) {
     EXPECT_THROW(_queue->cancel(nullptr), std::system_error);
+    EXPECT_NO_THROW(_queue->cancel(0));
 }
 
 TEST_F(CancelTest, poll) {
@@ -154,6 +155,50 @@ TEST_F(CancelTest, write_completed) {
     EXPECT_EQ(result, sizeof(client_buf));
     EXPECT_EQ(error, 0);
     EXPECT_EQ(strcmp(server_buf, client_buf), 0);
+}
+
+TEST_F(CancelTest, cancel_all) {
+    size_t result_poll = 0;
+    int error_poll = 0;
+    _queue->poll(_fd, POLLIN, [&result_poll, &error_poll](size_t r, int e) {
+        result_poll = r;
+        error_poll = e;
+    });
+
+    char client_buf_read[10];
+    size_t result_read = 0;
+    int error_read = 0;
+    _queue->read(
+        _fd, client_buf_read, sizeof(client_buf_read),
+        [&result_read, &error_read](size_t r, int e) {
+            result_read = r;
+            error_read = e;
+        }
+    );
+
+    char client_buf_write[] = "data";
+    size_t result_write = 0;
+    int error_write = 0;
+    _queue->write(
+        _fd, client_buf_write, sizeof(client_buf_write),
+        [&result_write, &error_write](size_t r, int e) {
+            result_write = r;
+            error_write = e;
+        }
+    );
+
+    _queue->cancel(_fd);
+
+    EXPECT_NO_THROW(_wait_all());
+
+    EXPECT_EQ(result_poll, (size_t)0);
+    EXPECT_EQ(error_poll, ECANCELED);
+    EXPECT_EQ(result_read, (size_t)0);
+    EXPECT_EQ(error_read, ECANCELED);
+#ifndef RAWSTOR_WITH_LIBURING
+    EXPECT_EQ(result_write, (size_t)0);
+    EXPECT_EQ(error_write, ECANCELED);
+#endif
 }
 
 } // unnamed namespace


### PR DESCRIPTION
This pull request introduces a new capability to cancel all pending I/O operations associated with a specific file descriptor. By extending the `Queue` interface and implementing the logic across the existing `poll` and `io_uring` backends, the change ensures consistent resource cleanup and improved error handling for asynchronous operations. The implementation prioritizes idempotency and aligns with existing test expectations regarding non-existent event cancellation.

* **API Expansion**: Added a new `cancel(int fd)` method to the `Queue` interface and implemented it for both `poll` and `io_uring` backends.
* **Session Management**: Implemented session-level cancellation logic to safely clear pending poll, read, and write events when a file descriptor is cancelled.
* **Test Coverage**: Introduced new test cases in `test_cancel.cpp` to verify idempotent cancellation behavior and ensure all pending events for a file descriptor are correctly cancelled.

(cherry picked from commit 0729e2900fc6d38a1c8e73200d302642ed56e917)

Conflicts:
	librawstorio/include/rawstorio/queue.hpp
	librawstorio/src/poll_queue.cpp
	librawstorio/src/poll_queue.hpp
	librawstorio/src/uring_queue.hpp