### PR TITLE
fix: doc formatting (#348)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,36 @@
 
 ## TL;DR
 ```
+PREFIX=${HOME}/local
+
 ./autogen.sh
-./configure
-make
+./configure --prefix=${PREFIX}
+make -j$(nproc)
 make install
-rawstor-vhost \
-    --socket-path=/run/rawstor1.sock \
-    --object-uri=ost://${OST_HOST}:${OST_PORT}/${OBJECT_UUID}
+
+OST_ADDR=192.168.0.1:8080
+
+##
+# Client
+#
+OBJECT_ID=...
+VHOST_RUNDIR=${PREFIX}/var/run/rawstor
+
+mkdir -p ${VHOST_RUNDIR}
+
+./vhost/rawstor-vhost \
+    --socket-path=${VHOST_RUNDIR}/rawstor1.sock \
+    --object-uri=ost://${OST_ADDR}/${OBJECT_ID}
+
+qemu-system-x86_64 \
+    -enable-kvm \
+    -m 4G \
+    -machine accel=kvm,memory-backend=mem \
+    -drive file=image.qcow2,if=none,id=drive1 \
+    -device virtio-blk-pci,drive=drive1 \
+    -object memory-backend-memfd,id=mem,size=4G,share=on \
+    -chardev socket,id=rawstor1,reconnect=1,path=${VHOST_RUNDIR}/rawstor1.sock \
+    -device vhost-user-blk-pci,chardev=rawstor1,num-queues=1,disable-legacy=on
 ```
 
 ## Configure
@@ -28,9 +51,14 @@ This will replace liburing with poll.
 rawstor-vhost is a userspace VirtIO block device backend that implements the vhost-user protocol. It allows virtual machines to access block storage via shared memory, bypassing the host kernel for improved performance.
 
 ```
+PREFIX=${HOME}/local
+OST_ADDR=192.168.0.1:8080
+OBJECT_ID=...
+VHOST_RUNDIR=${PREFIX}/var/run/rawstor
+
 rawstor-vhost \
-    --socket-path=/run/rawstor1.sock \
-    --object-uri=ost://${OST_HOST}:${OST_PORT}/${OBJECT_UUID}
+    --socket-path=${VHOST_RUNDIR}/rawstor1.sock \
+    --object-uri=ost://${OST_ADDR}/${OBJECT_ID}
 
 qemu-system-x86_64 \
     -enable-kvm \
@@ -39,7 +67,7 @@ qemu-system-x86_64 \
     -drive file=image.qcow2,if=none,id=drive1 \
     -device virtio-blk-pci,drive=drive1 \
     -object memory-backend-memfd,id=mem,size=4G,share=on \
-    -chardev socket,id=rawstor1,reconnect=1,path=/run/rawstor1.sock \
+    -chardev socket,id=rawstor1,reconnect=1,path=${VHOST_RUNDIR}/rawstor1.sock \
     -device vhost-user-blk-pci,chardev=rawstor1,num-queues=1,disable-legacy=on
 ```
 

--- a/include/rawstor/object.h
+++ b/include/rawstor/object.h
@@ -246,7 +246,9 @@ int rawstor_object_id(
  * object is physically stored (e.g., OST servers, file system paths).
  *
  * The format is the same as the location part of a target string, for example:
+ *
  * - "ost://host1:9090/abc,ost://host2:9090/abc"  (mirroring)
+ *
  * - "file:///data/abc,ost://host1:9090/abc"      (locality)
  *
  * If the buffer size is insufficient, the output is truncated but the return


### PR DESCRIPTION
This pull request focuses on improving the project's documentation and usability. It standardizes Doxygen-style comments across core header files for better readability and updates the README to provide a more robust and practical guide for building and running the rawstor-vhost service.

* **Documentation Updates**: Improved formatting and consistency in header files, including the addition of @brief tags and standardized spacing for documentation lists.
* **README Enhancements**: Updated the README with more detailed installation and usage instructions, including prefix configuration and a complete QEMU execution example.

(cherry picked from commit f52b88a9b19ee7048c71539c6fe902209e763155)

Conflicts:
	README.md
	include/rawstor/rawstor.h