### PR TITLE
fix: signal handler (#352)

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -5,12 +5,18 @@
 
 #include "config.h"
 
+#include <rawstorstd/gcc.h>
+
 #include <rawstor.h>
 
+#include <errno.h>
 #include <getopt.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+static struct sigaction sact = {};
 
 static void usage(void) {
     fprintf(
@@ -37,6 +43,9 @@ static void usage(void) {
 
 static void version(void) {
     fprintf(stdout, "Rawstor CLI " PACKAGE_VERSION "\n");
+}
+
+static void sact_handler(int RAWSTOR_UNUSED s) {
 }
 
 static void command_create_usage(void) {
@@ -440,6 +449,25 @@ int main(int argc, char** argv) {
             fprintf(stderr, "wait-timeout argument must be unsigned integer\n");
             return EXIT_FAILURE;
         }
+    }
+
+    sact.sa_handler = sact_handler;
+    sigemptyset(&sact.sa_mask);
+    if (sigaction(SIGINT, &sact, NULL) == -1) {
+        int errsv = errno;
+        errno = 0;
+        fprintf(
+            stderr, "Failed to register SIGINT handler: %s\n", strerror(errsv)
+        );
+        return EXIT_FAILURE;
+    }
+    if (sigaction(SIGTERM, &sact, NULL) == -1) {
+        int errsv = errno;
+        errno = 0;
+        fprintf(
+            stderr, "Failed to register SIGTERM handler: %s\n", strerror(errsv)
+        );
+        return EXIT_FAILURE;
     }
 
     int ret = run_command(argv[optind], &opts, argc - optind, &argv[optind]);


### PR DESCRIPTION
This pull request introduces improved signal handling for the CLI application by registering handlers for SIGINT and SIGTERM. It also cleans up existing signal handling logic in the vhost component to reduce verbosity, ensuring more consistent behavior across the codebase.

* **Signal Handling Implementation**: Added robust signal handling for SIGINT and SIGTERM in the CLI tool to ensure graceful termination.
* **Code Cleanup**: Simplified the signal handler in the vhost component by removing unnecessary console output.

(cherry picked from commit 9dfa3496b95984325068aedf365013a7255d59be)

Conflicts:
	vhost/main.cpp