### PR TITLE
add: version command line argument (#358)

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -28,7 +28,7 @@ static void usage(void) {
         "options:\n"
         "  -h, --help            Show this help message and exit\n"
         "  --sessions            Number of opened sessions per object\n"
-        "  -v, --version         Rawstor client version\n"
+        "  -v, --version         Rawstor version\n"
         "  --wait-timeout        IO wait timeout\n"
         "\n"
         "command:\n"
@@ -84,7 +84,6 @@ static int command_create(int argc, char** argv) {
         case 'h':
             command_create_usage();
             return EXIT_SUCCESS;
-            break;
 
         case 's':
             size_arg = optarg;
@@ -156,7 +155,6 @@ static int command_remove(int argc, char** argv) {
         case 'h':
             command_remove_usage();
             return EXIT_SUCCESS;
-            break;
 
         case 'o':
             target_arg = optarg;
@@ -213,7 +211,6 @@ static int command_show(int argc, char** argv) {
         case 'h':
             command_show_usage();
             return EXIT_SUCCESS;
-            break;
 
         case 'o':
             target_arg = optarg;
@@ -298,7 +295,6 @@ static int command_testio(int argc, char** argv) {
         case 'h':
             command_testio_usage();
             return EXIT_SUCCESS;
-            break;
 
         case 'o':
             target_arg = optarg;
@@ -410,7 +406,6 @@ int main(int argc, char** argv) {
         case 'h':
             usage();
             return EXIT_SUCCESS;
-            break;
 
         case 's':
             sessions_arg = optarg;
@@ -423,7 +418,6 @@ int main(int argc, char** argv) {
         case 'v':
             version();
             return EXIT_SUCCESS;
-            break;
 
         default:
             return EXIT_FAILURE;

--- a/vhost/main.cpp
+++ b/vhost/main.cpp
@@ -1,5 +1,7 @@
 #include "server.hpp"
 
+#include "config.h"
+
 #include <rawstor.h>
 
 #include <getopt.h>
@@ -17,9 +19,9 @@ namespace {
 struct sigaction sact = {};
 
 void usage() {
-    std::cerr << "Rawstor vhost server" << std::endl
+    std::cout << "Rawstor VHOST " << PACKAGE_VERSION << std::endl
               << std::endl
-              << "usage: rawstor-vhost [-h] -o OBJECT_URI -s SOCKET_PATH"
+              << "usage: rawstor-vhost [options] -o OBJECT_URI -s SOCKET_PATH"
               << std::endl
               << std::endl
               << "options:" << std::endl
@@ -36,7 +38,12 @@ void usage() {
               << std::endl
               << "                        "
                  "vhost-user Unix domain socket."
-              << std::endl;
+              << std::endl
+              << "  -v, --version         Rawstor version" << std::endl;
+}
+
+void version() {
+    std::cout << "Rawstor VHOST " << PACKAGE_VERSION << std::endl;
 }
 
 void sact_handler(int) {
@@ -50,11 +57,12 @@ void server(const std::string& target, const std::string& socket_path) {
 } // namespace
 
 int main(int argc, char** argv) {
-    const char* optstring = "ho:s:";
+    const char* optstring = "ho:s:v";
     struct option longopts[] = {
         {"help", no_argument, nullptr, 'h'},
         {"object-uri", required_argument, nullptr, 'o'},
         {"socket-path", required_argument, nullptr, 's'},
+        {"version", no_argument, nullptr, 'v'},
         {},
     };
 
@@ -70,7 +78,6 @@ int main(int argc, char** argv) {
         case 'h':
             usage();
             return EXIT_SUCCESS;
-            break;
 
         case 'o':
             target_arg = optarg;
@@ -79,6 +86,10 @@ int main(int argc, char** argv) {
         case 's':
             socket_path_arg = optarg;
             break;
+
+        case 'v':
+            version();
+            return EXIT_SUCCESS;
 
         default:
             return EXIT_FAILURE;


### PR DESCRIPTION
This pull request introduces a version command-line argument to the application's CLI and VHOST server components. It also includes minor refactoring to remove unreachable code and standardizes output streams for help and version information to improve consistency across the codebase.

* **Version Command Support**: Added a new '-v, --version' command-line argument to both the CLI and VHOST server components to display the current version.
* **Code Cleanup**: Removed redundant 'break' statements following 'return' calls in switch-case blocks across multiple files to improve code cleanliness.
* **Standardization**: Updated the VHOST server to use 'std::cout' for help and version output, ensuring consistency with standard CLI practices.

(cherry picked from commit aede208f017004b9a9a252b523a89884b55eb675)

Conflicts:
	vhost/main.cpp