### PR TITLE
add: license to public headers (#364)

### DIFF
--- a/include/rawstor.h
+++ b/include/rawstor.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2025, Vasily Stepanov (vasily.stepanov@gmail.com)
+ * Copyright (C) 2025-2026, Vasily Stepanov (vasily.stepanov@gmail.com)
  *
  * SPDX-License-Identifier: LGPL-3.0
  */

--- a/include/rawstor/object.h
+++ b/include/rawstor/object.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2025, Vasily Stepanov (vasily.stepanov@gmail.com)
+ * Copyright (C) 2025-2026, Vasily Stepanov (vasily.stepanov@gmail.com)
  *
  * SPDX-License-Identifier: LGPL-3.0
  */

--- a/src/ost_protocol.h
+++ b/src/ost_protocol.h
@@ -1,3 +1,9 @@
+/**
+ * Copyright (C) 2025-2026, Vasily Stepanov (vasily.stepanov@gmail.com)
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+ */
+
 #ifndef RAWSTOR_OST_PROTOCOL_H
 #define RAWSTOR_OST_PROTOCOL_H
 


### PR DESCRIPTION
This pull request ensures that all public header files contain the correct copyright information and license identifiers, maintaining consistency and legal compliance across the project's codebase.

### Highlights

* **Copyright Update**: Updated the copyright year ranges in existing header files to include 2026.
* **License Header Addition**: Added missing license headers and copyright information to the ost_protocol.h file.

(cherry picked from commit 103d2dbba281f562be32e7f662e371f89a26df37)