### PR TITLE
ref: redefine RawstorObject (#371)

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1,5 +1,6 @@
 #include "connection.hpp"
 
+#include "object.hpp"
 #include "opts.h"
 #include "rawstor_internals.hpp"
 #include "session.hpp"
@@ -68,7 +69,7 @@ Connection::~Connection() {
 }
 
 std::vector<std::shared_ptr<Session>> Connection::_open(
-    const rawstd::URI& location, RawstorObject* object, size_t nsessions
+    const rawstd::URI& location, Object* object, size_t nsessions
 ) {
     std::vector<std::shared_ptr<Session>> sessions;
 
@@ -293,7 +294,7 @@ void Connection::spec(const rawstd::URI& target, RawstorObjectSpec* sp) {
 }
 
 void Connection::open(
-    const rawstd::URI& location, RawstorObject* object, size_t nsessions
+    const rawstd::URI& location, Object* object, size_t nsessions
 ) {
     _sessions = _open(location, object, nsessions);
     _object = object;

--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -1,9 +1,10 @@
 #ifndef RAWSTOR_CONNECTION_HPP
 #define RAWSTOR_CONNECTION_HPP
 
+#include "object.hpp"
+
 #include <rawstd/uri.hpp>
 
-#include <rawstor/object.h>
 #include <rawstor/rawstor.h>
 
 #include <functional>
@@ -18,14 +19,14 @@ class Session;
 
 class Connection final {
 private:
-    RawstorObject* _object;
+    Object* _object;
     unsigned int _depth;
 
     std::vector<std::shared_ptr<Session>> _sessions;
     size_t _session_index;
 
     std::vector<std::shared_ptr<Session>>
-    _open(const rawstd::URI& location, RawstorObject* object, size_t nsessions);
+    _open(const rawstd::URI& location, Object* object, size_t nsessions);
 
     void
     _op(const char* func_name, size_t size, off_t offset,
@@ -53,8 +54,7 @@ public:
 
     void spec(const rawstd::URI& target, RawstorObjectSpec* sp);
 
-    void
-    open(const rawstd::URI& location, RawstorObject* object, size_t nsessions);
+    void open(const rawstd::URI& location, Object* object, size_t nsessions);
 
     void close();
 

--- a/src/file_session.cpp
+++ b/src/file_session.cpp
@@ -223,7 +223,7 @@ void Session::spec(
     cb(ret, 0);
 }
 
-void Session::set_object(RawstorObject* object) {
+void Session::set_object(Object* object) {
     if (fd() != -1) {
         throw std::runtime_error("Object already set");
     }

--- a/src/file_session.hpp
+++ b/src/file_session.hpp
@@ -34,7 +34,7 @@ public:
         std::function<void(const RawstorObjectSpec&, int)>&& cb
     ) override;
 
-    void set_object(RawstorObject* object) override;
+    void set_object(Object* object) override;
 
     void pread(
         void* buf, size_t size, off_t offset,

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -83,7 +83,9 @@ void validate_different_uris(const std::vector<rawstd::URI>& uris) {
 
 } // namespace
 
-RawstorObject::RawstorObject(const std::vector<rawstd::URI>& targets) : _id() {
+namespace rawstor {
+
+Object::Object(const std::vector<rawstd::URI>& targets) : _id() {
     validate_not_empty(targets);
     validate_different_uris(targets);
     validate_same_uuid(targets);
@@ -103,7 +105,7 @@ RawstorObject::RawstorObject(const std::vector<rawstd::URI>& targets) : _id() {
     }
 }
 
-void RawstorObject::create(
+void Object::create(
     const std::vector<rawstd::URI>& locations, const RawstorObjectSpec& sp,
     std::vector<rawstd::URI>* targets
 ) {
@@ -140,7 +142,7 @@ void RawstorObject::create(
     *targets = ret;
 }
 
-void RawstorObject::remove(const std::vector<rawstd::URI>& targets) {
+void Object::remove(const std::vector<rawstd::URI>& targets) {
     validate_not_empty(targets);
     validate_different_uris(targets);
     validate_same_uuid(targets);
@@ -162,7 +164,7 @@ void RawstorObject::remove(const std::vector<rawstd::URI>& targets) {
     }
 }
 
-void RawstorObject::spec(
+void Object::spec(
     const std::vector<rawstd::URI>& targets, RawstorObjectSpec* sp
 ) {
     /**
@@ -175,7 +177,7 @@ void RawstorObject::spec(
     rawstor::Connection(QUEUE_DEPTH).spec(targets.front(), sp);
 }
 
-std::vector<rawstd::URI> RawstorObject::locations() const {
+std::vector<rawstd::URI> Object::locations() const {
     std::vector<rawstd::URI> ret;
     ret.reserve(_cns.size());
     for (const auto& cn : _cns) {
@@ -188,7 +190,7 @@ std::vector<rawstd::URI> RawstorObject::locations() const {
     return ret;
 }
 
-void RawstorObject::pread(
+void Object::pread(
     void* buf, size_t size, off_t offset, std::function<void(size_t, int)>&& cb
 ) {
     rawstd::TraceEvent trace_event = RAWSTD_TRACE_EVENT(
@@ -209,7 +211,7 @@ void RawstorObject::pread(
     );
 }
 
-void RawstorObject::preadv(
+void Object::preadv(
     iovec* iov, unsigned int niov, size_t size, off_t offset,
     std::function<void(size_t, int)>&& cb
 ) {
@@ -231,7 +233,7 @@ void RawstorObject::preadv(
     );
 }
 
-void RawstorObject::pwrite(
+void Object::pwrite(
     const void* buf, size_t size, off_t offset,
     std::function<void(size_t, int)>&& cb
 ) {
@@ -279,7 +281,7 @@ void RawstorObject::pwrite(
     }
 }
 
-void RawstorObject::pwritev(
+void Object::pwritev(
     const iovec* iov, unsigned int niov, size_t size, off_t offset,
     std::function<void(size_t, int)>&& cb
 ) {
@@ -328,12 +330,14 @@ void RawstorObject::pwritev(
     }
 }
 
+} // namespace rawstor
+
 int rawstor_object_create(
     const char* location, const RawstorObjectSpec* sp, char* target, size_t size
 ) noexcept {
     try {
         std::vector<rawstd::URI> targets;
-        RawstorObject::create(rawstd::URI::uriv(location), *sp, &targets);
+        rawstor::Object::create(rawstd::URI::uriv(location), *sp, &targets);
         return ::uris(targets, target, size);
     } catch (const std::system_error& e) {
         return -e.code().value();
@@ -350,7 +354,7 @@ int rawstor_object_create(
 
 int rawstor_object_remove(const char* target) noexcept {
     try {
-        RawstorObject::remove(rawstd::URI::uriv(target));
+        rawstor::Object::remove(rawstd::URI::uriv(target));
         return 0;
     } catch (const std::system_error& e) {
         return -e.code().value();
@@ -367,7 +371,7 @@ int rawstor_object_remove(const char* target) noexcept {
 
 int rawstor_object_spec(const char* target, RawstorObjectSpec* sp) noexcept {
     try {
-        RawstorObject::spec(rawstd::URI::uriv(target), sp);
+        rawstor::Object::spec(rawstd::URI::uriv(target), sp);
         return 0;
     } catch (const std::system_error& e) {
         return -e.code().value();
@@ -384,8 +388,8 @@ int rawstor_object_spec(const char* target, RawstorObjectSpec* sp) noexcept {
 
 int rawstor_object_open(const char* target, RawstorObject** object) noexcept {
     try {
-        std::unique_ptr<RawstorObject> ret =
-            std::make_unique<RawstorObject>(rawstd::URI::uriv(target));
+        std::unique_ptr<rawstor::Object> ret =
+            std::make_unique<rawstor::Object>(rawstd::URI::uriv(target));
 
         *object = ret.get();
 
@@ -407,7 +411,7 @@ int rawstor_object_open(const char* target, RawstorObject** object) noexcept {
 
 int rawstor_object_close(RawstorObject* object) noexcept {
     try {
-        delete object;
+        delete static_cast<rawstor::Object*>(object);
         return 0;
     } catch (const std::system_error& e) {
         return -e.code().value();
@@ -427,7 +431,9 @@ int rawstor_object_id(
 ) noexcept {
     try {
         RawstdUUIDString uuid;
-        rawstd_uuid_to_string(&object->id(), &uuid);
+        rawstd_uuid_to_string(
+            &static_cast<const rawstor::Object*>(object)->id(), &uuid
+        );
         int res = snprintf(buf, size, "%s", uuid);
         if (res < 0) {
             RAWSTD_THROW_ERRNO();
@@ -450,7 +456,9 @@ int rawstor_object_uris(
     const RawstorObject* object, char* buf, size_t size
 ) noexcept {
     try {
-        return uris(object->locations(), buf, size);
+        return uris(
+            static_cast<const rawstor::Object*>(object)->locations(), buf, size
+        );
     } catch (const std::system_error& e) {
         return -e.code().value();
     } catch (const std::bad_alloc& e) {
@@ -469,7 +477,7 @@ int rawstor_object_pread(
     RawstorCallback* cb, void* data
 ) noexcept {
     try {
-        object->pread(
+        static_cast<rawstor::Object*>(object)->pread(
             buf, size, offset,
             [object, size, cb, data](size_t result, int error) {
                 cb(object, size, result, error, data);
@@ -494,7 +502,7 @@ int rawstor_object_preadv(
     off_t offset, RawstorCallback* cb, void* data
 ) noexcept {
     try {
-        object->preadv(
+        static_cast<rawstor::Object*>(object)->preadv(
             iov, niov, size, offset,
             [object, size, cb, data](size_t result, int error) {
                 cb(object, size, result, error, data);
@@ -519,7 +527,7 @@ int rawstor_object_pwrite(
     RawstorCallback* cb, void* data
 ) noexcept {
     try {
-        object->pwrite(
+        static_cast<rawstor::Object*>(object)->pwrite(
             buf, size, offset,
             [object, size, cb, data](size_t result, int error) {
                 cb(object, size, result, error, data);
@@ -544,7 +552,7 @@ int rawstor_object_pwritev(
     off_t offset, RawstorCallback* cb, void* data
 ) noexcept {
     try {
-        object->pwritev(
+        static_cast<rawstor::Object*>(object)->pwritev(
             iov, niov, size, offset,
             [object, size, cb, data](size_t result, int error) {
                 cb(object, size, result, error, data);

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -10,13 +10,13 @@
 #include <memory>
 #include <vector>
 
+struct RawstorObject {};
+
 namespace rawstor {
 
 class Connection;
 
-} // namespace rawstor
-
-struct RawstorObject final {
+class Object final : public RawstorObject {
 private:
     RawstdUUID _id;
     std::vector<std::unique_ptr<rawstor::Connection>> _cns;
@@ -30,11 +30,11 @@ public:
     static void
     spec(const std::vector<rawstd::URI>& targets, RawstorObjectSpec* sp);
 
-    explicit RawstorObject(const std::vector<rawstd::URI>& targets);
-    RawstorObject(const RawstorObject&) = delete;
-    RawstorObject(RawstorObject&&) = delete;
-    RawstorObject& operator=(const RawstorObject&) = delete;
-    RawstorObject& operator=(RawstorObject&&) = delete;
+    explicit Object(const std::vector<rawstd::URI>& targets);
+    Object(const Object&) = delete;
+    Object(Object&&) = delete;
+    Object& operator=(const Object&) = delete;
+    Object& operator=(Object&&) = delete;
 
     std::vector<rawstd::URI> locations() const;
 
@@ -60,5 +60,7 @@ public:
         std::function<void(size_t, int)>&& cb
     );
 };
+
+} // namespace rawstor
 
 #endif // RAWSTOR_OBJECT_HPP

--- a/src/ost_session.cpp
+++ b/src/ost_session.cpp
@@ -802,7 +802,7 @@ void Session::spec(
     cb(ret, 0);
 }
 
-void Session::set_object(RawstorObject* object) {
+void Session::set_object(rawstor::Object* object) {
     rawstd::TraceEvent trace_event =
         RAWSTD_TRACE_EVENT('s', "%s\n", "set object");
 

--- a/src/ost_session.hpp
+++ b/src/ost_session.hpp
@@ -54,7 +54,7 @@ public:
         std::function<void(const RawstorObjectSpec&, int)>&& cb
     ) override;
 
-    void set_object(RawstorObject* object) override;
+    void set_object(Object* object) override;
 
     void pread(
         void* buf, size_t size, off_t offset,

--- a/src/session.hpp
+++ b/src/session.hpp
@@ -63,7 +63,7 @@ public:
         std::function<void(const RawstorObjectSpec&, int)>&& cb
     ) = 0;
 
-    virtual void set_object(RawstorObject* object) = 0;
+    virtual void set_object(Object* object) = 0;
 
     virtual void pread(
         void* buf, size_t size, off_t offset,


### PR DESCRIPTION
This pull request refactors the internal object representation by separating the public C-compatible struct from the internal C++ implementation. By redefining `RawstorObject` as an empty struct and introducing `rawstor::Object`, the codebase gains better encapsulation and clearer separation between the C API and the internal C++ logic. This change impacts several core components, including connection handling, session management, and file operations, ensuring they now interact with the appropriate internal class.

* **Refactoring RawstorObject**: Redefined `RawstorObject` as an empty struct and introduced a new `rawstor::Object` class to encapsulate the core logic, improving type safety and structure.
* **API Updates**: Updated internal connection, session, and object management methods to utilize the new `rawstor::Object` class instead of the original `RawstorObject` struct.

(cherry picked from commit d45d8ac21ff75dd9377ddab9aca89241d6fcacea)

Conflicts:
	src/ost_session.cpp
	src/ost_session.hpp