### PR TITLE
fix: remove unused depth parameter (#373)

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -20,6 +20,11 @@
 
 #include <cstring>
 
+/**
+ * TODO: Make it global
+ */
+#define QUEUE_DEPTH 256
+
 namespace {
 
 /**
@@ -54,10 +59,7 @@ public:
 
 namespace rawstor {
 
-Connection::Connection(unsigned int depth) :
-    _object(nullptr),
-    _depth(depth),
-    _session_index(0) {
+Connection::Connection() : _object(nullptr), _session_index(0) {
 }
 
 Connection::~Connection() {
@@ -79,9 +81,7 @@ std::vector<std::shared_ptr<Session>> Connection::_open(
             sessions.clear();
             sessions.reserve(nsessions);
             for (size_t i = 0; i < nsessions; ++i) {
-                sessions.push_back(
-                    Session::create(*io_queue, location, _depth)
-                );
+                sessions.push_back(Session::create(*io_queue, location));
             }
 
             for (std::shared_ptr<Session> s : sessions) {
@@ -232,10 +232,9 @@ void Connection::create(
         RAWSTD_THROW_SYSTEM_ERROR(-res);
     }
 
-    Queue q(1, _depth);
+    Queue q(1, QUEUE_DEPTH);
 
-    std::unique_ptr<Session> s =
-        Session::create(q.queue(), target.parent(), _depth);
+    std::unique_ptr<Session> s = Session::create(q.queue(), target.parent());
     s->create(id, sp, [&q](int error) {
         q.sub_operation();
 
@@ -254,10 +253,9 @@ void Connection::remove(const rawstd::URI& target) {
         RAWSTD_THROW_SYSTEM_ERROR(-res);
     }
 
-    Queue q(1, _depth);
+    Queue q(1, QUEUE_DEPTH);
 
-    std::unique_ptr<Session> s =
-        Session::create(q.queue(), target.parent(), _depth);
+    std::unique_ptr<Session> s = Session::create(q.queue(), target.parent());
     s->remove(id, [&q](int error) {
         q.sub_operation();
 
@@ -276,10 +274,9 @@ void Connection::spec(const rawstd::URI& target, RawstorObjectSpec* sp) {
         RAWSTD_THROW_SYSTEM_ERROR(-res);
     }
 
-    Queue q(1, _depth);
+    Queue q(1, QUEUE_DEPTH);
 
-    std::unique_ptr<Session> s =
-        Session::create(q.queue(), target.parent(), _depth);
+    std::unique_ptr<Session> s = Session::create(q.queue(), target.parent());
     s->spec(id, [&q, sp](const RawstorObjectSpec& spec, int error) {
         q.sub_operation();
 

--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -20,7 +20,6 @@ class Session;
 class Connection final {
 private:
     Object* _object;
-    unsigned int _depth;
 
     std::vector<std::shared_ptr<Session>> _sessions;
     size_t _session_index;
@@ -37,7 +36,7 @@ private:
         unsigned int attempt);
 
 public:
-    Connection(unsigned int depth);
+    Connection();
     Connection(const Connection&) = delete;
     ~Connection();
 

--- a/src/file_session.cpp
+++ b/src/file_session.cpp
@@ -94,10 +94,8 @@ void write_dat(
 namespace rawstor {
 namespace file {
 
-Session::Session(
-    rawio::Queue& queue, const rawstd::URI& location, unsigned int depth
-) :
-    rawstor::Session(queue, location, depth) {
+Session::Session(rawio::Queue& queue, const rawstd::URI& location) :
+    rawstor::Session(queue, location) {
 }
 
 int Session::_connect(const RawstdUUID& id) {

--- a/src/file_session.hpp
+++ b/src/file_session.hpp
@@ -18,9 +18,7 @@ private:
     int _connect(const RawstdUUID& id);
 
 public:
-    Session(
-        rawio::Queue& queue, const rawstd::URI& location, unsigned int depth
-    );
+    Session(rawio::Queue& queue, const rawstd::URI& location);
 
     void create(
         const RawstdUUID& id, const RawstorObjectSpec& sp,

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -27,11 +27,6 @@
 #include <cstdlib>
 #include <cstring>
 
-/**
- * TODO: Make it global
- */
-#define QUEUE_DEPTH 256
-
 namespace {
 
 int uris(const std::vector<rawstd::URI>& uriv, char* buf, size_t size) {
@@ -99,7 +94,7 @@ Object::Object(const std::vector<rawstd::URI>& targets) : _id() {
     _cns.reserve(targets.size());
     for (const auto& target : targets) {
         std::unique_ptr<rawstor::Connection> cn =
-            std::make_unique<rawstor::Connection>(QUEUE_DEPTH);
+            std::make_unique<rawstor::Connection>();
         cn->open(target.parent(), this, rawstor_opts_sessions());
         _cns.push_back(std::move(cn));
     }
@@ -124,7 +119,7 @@ void Object::create(
     try {
         for (const auto& location : locations) {
             rawstd::URI target = rawstd::URI(location, id_string);
-            rawstor::Connection(QUEUE_DEPTH).create(target, sp);
+            rawstor::Connection().create(target, sp);
             ret.push_back(target);
         }
     } catch (...) {
@@ -150,7 +145,7 @@ void Object::remove(const std::vector<rawstd::URI>& targets) {
     std::exception_ptr eptr;
     for (const auto& target : targets) {
         try {
-            rawstor::Connection(QUEUE_DEPTH).remove(target);
+            rawstor::Connection().remove(target);
         } catch (const std::exception& e) {
             rawstd_error("%s\n", e.what());
 
@@ -174,7 +169,7 @@ void Object::spec(
     validate_different_uris(targets);
     validate_same_uuid(targets);
 
-    rawstor::Connection(QUEUE_DEPTH).spec(targets.front(), sp);
+    rawstor::Connection().spec(targets.front(), sp);
 }
 
 std::vector<rawstd::URI> Object::locations() const {

--- a/src/ost_session.cpp
+++ b/src/ost_session.cpp
@@ -595,10 +595,8 @@ void Context::fail_in_flight(int error) {
     }
 }
 
-Session::Session(
-    rawio::Queue& queue, const rawstd::URI& location, unsigned int depth
-) :
-    rawstor::Session(queue, location, depth),
+Session::Session(rawio::Queue& queue, const rawstd::URI& location) :
+    rawstor::Session(queue, location),
     _cid_counter(0),
     _context(std::make_shared<Context>(*this)) {
     int fd = _connect();

--- a/src/ost_session.hpp
+++ b/src/ost_session.hpp
@@ -33,9 +33,7 @@ private:
     int _connect();
 
 public:
-    Session(
-        rawio::Queue& queue, const rawstd::URI& location, unsigned int depth
-    );
+    Session(rawio::Queue& queue, const rawstd::URI& location);
     ~Session();
 
     void read_response_head();

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -18,10 +18,7 @@
 
 namespace rawstor {
 
-Session::Session(
-    rawio::Queue& queue, const rawstd::URI& location, unsigned int depth
-) :
-    _depth(depth),
+Session::Session(rawio::Queue& queue, const rawstd::URI& location) :
     _location(location),
     _fd(-1),
     _queue(queue) {
@@ -40,14 +37,13 @@ Session::~Session() {
     }
 }
 
-std::unique_ptr<Session> Session::create(
-    rawio::Queue& queue, const rawstd::URI& location, unsigned int depth
-) {
+std::unique_ptr<Session>
+Session::create(rawio::Queue& queue, const rawstd::URI& location) {
     if (location.scheme() == "ost") {
-        return std::make_unique<rawstor::ost::Session>(queue, location, depth);
+        return std::make_unique<rawstor::ost::Session>(queue, location);
     }
     if (location.scheme() == "file") {
-        return std::make_unique<rawstor::file::Session>(queue, location, depth);
+        return std::make_unique<rawstor::file::Session>(queue, location);
     }
     rawstd_error("Unexpected URI scheme: %s\n", location.str().c_str());
     RAWSTD_THROW_SYSTEM_ERROR(EINVAL);

--- a/src/session.hpp
+++ b/src/session.hpp
@@ -19,7 +19,6 @@ class Task;
 
 class Session {
 private:
-    unsigned int _depth;
     rawstd::URI _location;
     int _fd;
 
@@ -29,13 +28,10 @@ protected:
     inline void set_fd(int fd) noexcept { _fd = fd; }
 
 public:
-    static std::unique_ptr<Session> create(
-        rawio::Queue& queue, const rawstd::URI& location, unsigned int depth
-    );
+    static std::unique_ptr<Session>
+    create(rawio::Queue& queue, const rawstd::URI& location);
 
-    Session(
-        rawio::Queue& queue, const rawstd::URI& location, unsigned int depth
-    );
+    Session(rawio::Queue& queue, const rawstd::URI& location);
     Session(const Session&) = delete;
     Session(Session&&) noexcept = delete;
     virtual ~Session();
@@ -45,8 +41,6 @@ public:
     std::string str() const;
 
     inline const rawstd::URI& location() const noexcept { return _location; }
-
-    inline unsigned int depth() const noexcept { return _depth; }
 
     inline int fd() const noexcept { return _fd; }
 


### PR DESCRIPTION
This pull request cleans up the codebase by removing redundant `depth` parameters from `Connection` and `Session` classes. By centralizing the queue depth configuration, the changes improve maintainability and ensure consistent resource allocation across the application's asynchronous operations.

* **Removed unused depth parameter**: Removed the `depth` parameter from `Connection` and `Session` constructors and associated methods to simplify the API.
* **Centralized queue configuration**: Introduced a global `QUEUE_DEPTH` macro in `src/connection.cpp` to standardize queue depth settings.
* **Optimized temporary queue usage**: Updated `Object` methods to use the new `QUEUE_DEPTH` constant instead of passing dynamic depth values, improving consistency.

(cherry picked from commit c5d77316927e6939517098b61427f397e9b68fbe)

Conflicts:
	src/ost_session.cpp