### PR TITLE
ref: static function for Connection control plane functions (#375)

### DIFF
--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -36,6 +36,12 @@ private:
         unsigned int attempt);
 
 public:
+    static void create(const rawstd::URI& target, const RawstorObjectSpec& sp);
+
+    static void remove(const rawstd::URI& target);
+
+    static void spec(const rawstd::URI& target, RawstorObjectSpec* sp);
+
     Connection();
     Connection(const Connection&) = delete;
     ~Connection();
@@ -46,12 +52,6 @@ public:
     void invalidate_session(const std::shared_ptr<Session>& s);
 
     const rawstd::URI* location() const noexcept;
-
-    void create(const rawstd::URI& target, const RawstorObjectSpec& sp);
-
-    void remove(const rawstd::URI& target);
-
-    void spec(const rawstd::URI& target, RawstorObjectSpec* sp);
 
     void open(const rawstd::URI& location, Object* object, size_t nsessions);
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -119,7 +119,7 @@ void Object::create(
     try {
         for (const auto& location : locations) {
             rawstd::URI target = rawstd::URI(location, id_string);
-            rawstor::Connection().create(target, sp);
+            rawstor::Connection::create(target, sp);
             ret.push_back(target);
         }
     } catch (...) {
@@ -145,7 +145,7 @@ void Object::remove(const std::vector<rawstd::URI>& targets) {
     std::exception_ptr eptr;
     for (const auto& target : targets) {
         try {
-            rawstor::Connection().remove(target);
+            rawstor::Connection::remove(target);
         } catch (const std::exception& e) {
             rawstd_error("%s\n", e.what());
 
@@ -169,7 +169,7 @@ void Object::spec(
     validate_different_uris(targets);
     validate_same_uuid(targets);
 
-    rawstor::Connection().spec(targets.front(), sp);
+    rawstor::Connection::spec(targets.front(), sp);
 }
 
 std::vector<rawstd::URI> Object::locations() const {


### PR DESCRIPTION
This pull request refactors the Connection class by transitioning several control plane functions from instance methods to static methods. This change simplifies the API usage by removing the requirement to instantiate a Connection object when performing these specific operations, leading to cleaner and more efficient code across the codebase.

### Highlights

* **Refactoring Connection methods**: Converted create, remove, and spec methods in the Connection class from instance methods to static methods.
* **Code cleanup**: Updated all call sites in Object.cpp to invoke these methods statically, removing the need to instantiate Connection objects for these operations.

(cherry picked from commit f566768ef155263957bc9c484292c63e05df120c)