### PR TITLE
add: option to control queue depth (#377)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rawstor client library
+# Rawstor library and tools
 
 [![Unit Test Status](https://github.com/rawstor/librawstor/actions/workflows/unittest.yml/badge.svg?branch=main)](https://github.com/rawstor/librawstor/actions/workflows/unittest.yml)
 
@@ -36,15 +36,22 @@ qemu-system-x86_64 \
     -device vhost-user-blk-pci,chardev=rawstor1,num-queues=1,disable-legacy=on
 ```
 
-## Configure
+## Environment Variables
 
-### Disable liburing
+The following environment variables can be used to tune the behavior of the Rawstor client and server.
+Default values are shown below.
 
-```
-./configure --without-liburing
-```
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RAWSTOR_OPTS_QUEUE_DEPTH` | `256` | Maximum number of requests that can be queued internally. Higher values allow deeper burst handling but increase memory usage. |
+| `RAWSTOR_OPTS_WAIT_TIMEOUT` | `5000` | Timeout for waiting on internal operations (e.g., queue readiness). |
+| `RAWSTOR_OPTS_IO_ATTEMPTS` | `3` | Number of retry attempts for I/O operations that encounter recoverable errors. |
+| `RAWSTOR_OPTS_SESSIONS` | `1` | Number of concurrent sessions that Rawstor client will open for each object. |
+| `RAWSTOR_OPTS_SO_SNDTIMEO` | `5000` | Socket send timeout. Sets `SO_SNDTIMEO` for network sockets. |
+| `RAWSTOR_OPTS_SO_RCVTIMEO` | `5000` | Socket receive timeout. Sets `SO_RCVTIMEO` for network sockets. |
+| `RAWSTOR_OPTS_TCP_USER_TIMEOUT` | `5000` | TCP user timeout (Linux `TCP_USER_TIMEOUT`). Defines how long transmitted data may remain unacknowledged before the connection is closed. |
 
-This will replace liburing with poll.
+> **Note:** All timeout values are expressed in milliseconds unless stated otherwise.
 
 ## rawstor-vhost
 

--- a/include/rawstor/rawstor.h
+++ b/include/rawstor/rawstor.h
@@ -87,6 +87,7 @@ int rawstor_fd_sendmsg(
  */
 
 struct RawstorOpts {
+    unsigned int queue_depth;
     unsigned int wait_timeout;
     unsigned int io_attempts;
     unsigned int sessions;

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -20,11 +20,6 @@
 
 #include <cstring>
 
-/**
- * TODO: Make it global
- */
-#define QUEUE_DEPTH 256
-
 namespace {
 
 /**
@@ -36,9 +31,9 @@ private:
     std::unique_ptr<rawio::Queue> _q;
 
 public:
-    Queue(unsigned int operations, unsigned int depth) :
+    Queue(unsigned int operations) :
         _operations(operations),
-        _q(rawio::Queue::create(depth)) {}
+        _q(rawio::Queue::create(rawstor_opts_queue_depth())) {}
 
     Queue(const Queue&) = delete;
 
@@ -232,7 +227,7 @@ void Connection::create(
         RAWSTD_THROW_SYSTEM_ERROR(-res);
     }
 
-    Queue q(1, QUEUE_DEPTH);
+    Queue q(1);
 
     std::unique_ptr<Session> s = Session::create(q.queue(), target.parent());
     s->create(id, sp, [&q](int error) {
@@ -253,7 +248,7 @@ void Connection::remove(const rawstd::URI& target) {
         RAWSTD_THROW_SYSTEM_ERROR(-res);
     }
 
-    Queue q(1, QUEUE_DEPTH);
+    Queue q(1);
 
     std::unique_ptr<Session> s = Session::create(q.queue(), target.parent());
     s->remove(id, [&q](int error) {
@@ -274,7 +269,7 @@ void Connection::spec(const rawstd::URI& target, RawstorObjectSpec* sp) {
         RAWSTD_THROW_SYSTEM_ERROR(-res);
     }
 
-    Queue q(1, QUEUE_DEPTH);
+    Queue q(1);
 
     std::unique_ptr<Session> s = Session::create(q.queue(), target.parent());
     s->spec(id, [&q, sp](const RawstorObjectSpec& spec, int error) {

--- a/src/opts.c
+++ b/src/opts.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#define RAWSTOR_OPTS_QUEUE_DEPTH 256
 #define RAWSTOR_OPTS_WAIT_TIMEOUT 5000
 #define RAWSTOR_OPTS_IO_ATTEMPTS 3
 #define RAWSTOR_OPTS_SESSIONS 1
@@ -28,6 +29,13 @@ static unsigned int get_env_uint(const char* name, int def) {
 }
 
 int rawstor_opts_initialize(const struct RawstorOpts* opts) {
+    _rawstor_opts.queue_depth =
+        (opts != NULL && opts->queue_depth != 0)
+            ? opts->queue_depth
+            : get_env_uint(
+                  "RAWSTOR_OPTS_QUEUE_DEPTH", RAWSTOR_OPTS_QUEUE_DEPTH
+              );
+
     _rawstor_opts.wait_timeout =
         (opts != NULL && opts->wait_timeout != 0)
             ? opts->wait_timeout
@@ -75,6 +83,10 @@ void rawstor_opts_terminate(void) {
     /**
      * Free opts here.
      */
+}
+
+unsigned int rawstor_opts_queue_depth(void) {
+    return _rawstor_opts.queue_depth;
 }
 
 unsigned int rawstor_opts_wait_timeout(void) {

--- a/src/opts.h
+++ b/src/opts.h
@@ -9,6 +9,7 @@ extern "C" {
 
 // defined in rawstor.h
 // struct RawstorOpts {
+//     unsigned int queue_depth;
 //     unsigned int wait_timeout;
 //     unsigned int io_attempts;
 //     unsigned int sessions;
@@ -20,6 +21,8 @@ extern "C" {
 int rawstor_opts_initialize(const struct RawstorOpts* opts);
 
 void rawstor_opts_terminate(void);
+
+unsigned int rawstor_opts_queue_depth(void);
 
 unsigned int rawstor_opts_wait_timeout(void);
 

--- a/src/rawstor.cpp
+++ b/src/rawstor.cpp
@@ -23,8 +23,6 @@
 #include <cstdlib>
 #include <cstring>
 
-#define QUEUE_DEPTH 256
-
 namespace rawstor {
 
 rawio::Queue* io_queue;
@@ -54,7 +52,8 @@ int rawstor_initialize(const RawstorOpts* opts) noexcept {
         }
 
         try {
-            std::unique_ptr<rawio::Queue> q = rawio::Queue::create(QUEUE_DEPTH);
+            std::unique_ptr<rawio::Queue> q =
+                rawio::Queue::create(rawstor_opts_queue_depth());
             rawstor::io_queue = q.get();
             q.release();
         } catch (...) {


### PR DESCRIPTION
This pull request introduces a configurable queue depth for the Rawstor client, providing users with the flexibility to balance burst handling and memory usage. It replaces hardcoded constants with a dynamic configuration mechanism, updates the public API to support this new setting, and improves documentation regarding environment variable tuning.

### Highlights

* **Queue Depth Configuration**: Added a configurable queue depth option for the Rawstor client, allowing users to tune performance via the `RAWSTOR_OPTS_QUEUE_DEPTH` environment variable or the `RawstorOpts` struct.
* **Documentation Updates**: Updated the README to include a comprehensive table of environment variables for tuning client and server behavior.
* **Refactoring Queue Usage**: Removed hardcoded queue depth definitions in favor of dynamic configuration and optimized short-lived synchronous operations to use a more efficient queue size.

(cherry picked from commit b27d5eb23cba605a651924643413e51728d5b643)