### PR TITLE
add: add wait_timeout (#379)

### DIFF
--- a/librawio/include/rawio/queue.hpp
+++ b/librawio/include/rawio/queue.hpp
@@ -125,7 +125,9 @@ public:
 
     virtual bool empty() const noexcept = 0;
 
-    virtual void wait(unsigned int timeout) = 0;
+    virtual void wait() = 0;
+
+    virtual void wait_timeout(unsigned int timeout) = 0;
 };
 
 } // namespace rawio

--- a/librawio/src/poll_queue.cpp
+++ b/librawio/src/poll_queue.cpp
@@ -37,6 +37,79 @@ Session& Queue::_get_session(int fd) {
     return *session;
 }
 
+void Queue::_wait_timeout(int timeout) {
+    while (_cqes.empty()) {
+        std::vector<pollfd> fds;
+        fds.reserve(_sessions.size());
+
+        std::unordered_map<int, std::shared_ptr<Session>>::iterator it =
+            _sessions.begin();
+
+        size_t i = 0;
+        while (it != _sessions.end()) {
+            if (!it->second->empty()) {
+                fds.push_back({
+                    .fd = it->second->fd(),
+                    .events = it->second->events(),
+                    .revents = 0,
+                });
+                assert(fds[i].events != 0);
+                ++it;
+                ++i;
+            } else {
+                it = _sessions.erase(it);
+            }
+        }
+
+        rawstd_trace("poll()\n");
+        int res = ::poll(fds.data(), fds.size(), timeout);
+        rawstd_trace("poll(): res = %d\n", res);
+        if (res == -1) {
+            RAWSTD_THROW_ERRNO();
+        }
+        if (res == 0) {
+            RAWSTD_THROW_SYSTEM_ERROR(ETIME);
+        }
+
+        for (const pollfd& fd : fds) {
+            rawstd_trace("poll(): revents = %d\n", fd.revents);
+            std::shared_ptr<Session>& s = _sessions.at(fd.fd);
+            s->process(_cqes, fd.revents);
+        }
+    }
+
+    while (!_cqes.empty()) {
+        std::unique_ptr<Event> event(_cqes.pop());
+        event->dispatch();
+        if (event->is_multishot() && !event->error()) {
+            if (event->is_poll()) {
+                std::unique_ptr<EventSimplexPoll> poll_event(
+                    static_cast<EventSimplexPoll*>(event.release())
+                );
+
+                Session& s = _get_session(poll_event->fd());
+                s.poll(std::move(poll_event));
+            } else if (event->is_accept()) {
+                std::unique_ptr<EventSimplexAccept> accept_event(
+                    static_cast<EventSimplexAccept*>(event.release())
+                );
+
+                Session& s = _get_session(accept_event->fd());
+                s.accept(std::move(accept_event));
+            } else if (event->is_read()) {
+                std::unique_ptr<EventSimplex> simplex_event(
+                    static_cast<EventSimplex*>(event.release())
+                );
+
+                Session& s = _get_session(simplex_event->fd());
+                s.read(std::move(simplex_event));
+            } else {
+                throw std::runtime_error("Unexpected multishot event");
+            }
+        }
+    }
+}
+
 const std::string& Queue::engine_name() {
     return ::engine_name;
 }
@@ -410,78 +483,12 @@ bool Queue::empty() const noexcept {
     return true;
 }
 
-void Queue::wait(unsigned int timeout) {
-    while (_cqes.empty()) {
-        std::vector<pollfd> fds;
-        fds.reserve(_sessions.size());
+void Queue::wait() {
+    _wait_timeout(-1);
+}
 
-        std::unordered_map<int, std::shared_ptr<Session>>::iterator it =
-            _sessions.begin();
-
-        size_t i = 0;
-        while (it != _sessions.end()) {
-            if (!it->second->empty()) {
-                fds.push_back({
-                    .fd = it->second->fd(),
-                    .events = it->second->events(),
-                    .revents = 0,
-                });
-                assert(fds[i].events != 0);
-                ++it;
-                ++i;
-            } else {
-                it = _sessions.erase(it);
-            }
-        }
-
-        rawstd_trace("poll()\n");
-        int res = ::poll(fds.data(), fds.size(), timeout);
-        rawstd_trace("poll(): res = %d\n", res);
-        if (res == -1) {
-            RAWSTD_THROW_ERRNO();
-        }
-        if (res == 0) {
-            RAWSTD_THROW_SYSTEM_ERROR(ETIME);
-        }
-
-        for (const pollfd& fd : fds) {
-            rawstd_trace("poll(): revents = %d\n", fd.revents);
-            std::shared_ptr<Session>& s = _sessions.at(fd.fd);
-            s->process(_cqes, fd.revents);
-        }
-    }
-
-    while (!_cqes.empty()) {
-        std::unique_ptr<Event> event(_cqes.pop());
-        event->dispatch();
-
-        if (event->is_multishot() && !event->error()) {
-            if (event->is_poll()) {
-                std::unique_ptr<EventSimplexPoll> poll_event(
-                    static_cast<EventSimplexPoll*>(event.release())
-                );
-
-                Session& s = _get_session(poll_event->fd());
-                s.poll(std::move(poll_event));
-            } else if (event->is_accept()) {
-                std::unique_ptr<EventSimplexAccept> accept_event(
-                    static_cast<EventSimplexAccept*>(event.release())
-                );
-
-                Session& s = _get_session(accept_event->fd());
-                s.accept(std::move(accept_event));
-            } else if (event->is_read()) {
-                std::unique_ptr<EventSimplex> simplex_event(
-                    static_cast<EventSimplex*>(event.release())
-                );
-
-                Session& s = _get_session(simplex_event->fd());
-                s.read(std::move(simplex_event));
-            } else {
-                throw std::runtime_error("Unexpected multishot event");
-            }
-        }
-    }
+void Queue::wait_timeout(unsigned int timeout) {
+    _wait_timeout(timeout);
 }
 
 } // namespace poll

--- a/librawio/src/poll_queue.hpp
+++ b/librawio/src/poll_queue.hpp
@@ -25,6 +25,8 @@ private:
 
     Session& _get_session(int fd);
 
+    void _wait_timeout(int timeout);
+
 public:
     static const std::string& engine_name();
     static void setup_fd(int fd);
@@ -118,7 +120,9 @@ public:
 
     bool empty() const noexcept override;
 
-    void wait(unsigned int timeout) override;
+    void wait() override;
+
+    void wait_timeout(unsigned int timeout) override;
 };
 
 } // namespace poll

--- a/librawio/src/uring_queue.cpp
+++ b/librawio/src/uring_queue.cpp
@@ -42,7 +42,7 @@ Queue::~Queue() {
         } else {
             while (true) {
                 try {
-                    wait(0);
+                    wait_timeout(0);
                 } catch (const std::system_error& e) {
                     if (e.code().value() != ETIME) {
                         rawstd_error("Failed to wait: %s\n", e.what());
@@ -57,6 +57,65 @@ Queue::~Queue() {
     }
 
     io_uring_queue_exit(&_ring);
+}
+
+void Queue::_dispatch() {
+    unsigned int nr = 0;
+
+    try {
+        unsigned int head;
+        io_uring_cqe* cqe;
+        io_uring_for_each_cqe(&_ring, head, cqe) {
+            rawstd_trace("cqe->res = %d\n", cqe->res);
+
+            ++nr;
+            --_events;
+
+            std::unique_ptr<std::function<void(size_t, int, unsigned int)>> p(
+                static_cast<std::function<void(size_t, int, unsigned int)>*>(
+                    io_uring_cqe_get_data(cqe)
+                )
+            );
+
+            size_t result;
+            int error;
+            if (cqe->res >= 0) [[likely]] {
+                result = cqe->res;
+                error = 0;
+            } else {
+                result = 0;
+                error = -cqe->res;
+            }
+
+            try {
+                rawstd_trace(
+                    "callback: result = %zu, error = %d\n", result, error
+                );
+                (*p)(result, error, cqe->flags);
+                rawstd_trace("callback success\n");
+            } catch (...) {
+                rawstd_trace("callback error\n");
+                if (cqe->flags & IORING_CQE_F_MORE) {
+                    p.release();
+                }
+                throw;
+            }
+
+            if (cqe->flags & IORING_CQE_F_MORE) {
+                p.release();
+            }
+        }
+    } catch (...) {
+        if (nr) {
+            io_uring_cq_advance(&_ring, nr);
+        }
+        throw;
+    }
+
+    if (nr) {
+        // TODO: use __io_uring_buf_ring_cq_advance here
+        io_uring_cq_advance(&_ring, nr);
+    }
 }
 
 const std::string& Queue::engine_name() {
@@ -645,77 +704,38 @@ bool Queue::empty() const noexcept {
     return _events == 0;
 }
 
-void Queue::wait(unsigned int timeout) {
+void Queue::wait() {
+    rawstd_trace("io_uring_submit_and_wait()\n");
+    // Ideally used with a ring setup with
+    // IORING_SETUP_SINGLE_ISSUER|IORING_SETUP_DEFER_TASKRUN as that will
+    // greatly reduce the number of context switches that an application
+    // will see waiting on multiple requests.
+    int res = io_uring_submit_and_wait(&_ring, 1);
+    rawstd_trace("io_uring_submit_and_wait(): res = %d\n", res);
+    if (res < 0) {
+        RAWSTD_THROW_SYSTEM_ERROR(-res);
+    }
+
+    _dispatch();
+}
+
+void Queue::wait_timeout(unsigned int timeout) {
+    io_uring_cqe* cqe;
     __kernel_timespec ts = {
         .tv_sec = timeout / 1000, .tv_nsec = 1000000u * (timeout % 1000)
     };
-
-    io_uring_cqe* cqe;
     rawstd_trace("io_uring_submit_and_wait_timeout()\n");
     int res = io_uring_submit_and_wait_timeout(&_ring, &cqe, 1, &ts, nullptr);
     rawstd_trace("io_uring_submit_and_wait_timeout(): res = %d\n", res);
     if (res < 0) {
         RAWSTD_THROW_SYSTEM_ERROR(-res);
     }
+
     if (cqe == nullptr) {
         RAWSTD_THROW_SYSTEM_ERROR(ETIME);
     }
 
-    unsigned int nr = 0;
-
-    try {
-        unsigned int head;
-        io_uring_for_each_cqe(&_ring, head, cqe) {
-            rawstd_trace("cqe->res = %d\n", cqe->res);
-
-            ++nr;
-            --_events;
-
-            std::unique_ptr<std::function<void(size_t, int, unsigned int)>> p(
-                static_cast<std::function<void(size_t, int, unsigned int)>*>(
-                    io_uring_cqe_get_data(cqe)
-                )
-            );
-
-            size_t result;
-            int error;
-            if (cqe->res >= 0) [[likely]] {
-                result = cqe->res;
-                error = 0;
-            } else {
-                result = 0;
-                error = -cqe->res;
-            }
-
-            try {
-                rawstd_trace(
-                    "callback: result = %zu, error = %d\n", result, error
-                );
-                (*p)(result, error, cqe->flags);
-                rawstd_trace("callback success\n");
-            } catch (...) {
-                rawstd_trace("callback error\n");
-                if (cqe->flags & IORING_CQE_F_MORE) {
-                    p.release();
-                }
-                throw;
-            }
-
-            if (cqe->flags & IORING_CQE_F_MORE) {
-                p.release();
-            }
-        }
-    } catch (...) {
-        if (nr) {
-            io_uring_cq_advance(&_ring, nr);
-        }
-        throw;
-    }
-
-    if (nr) {
-        // TODO: use __io_uring_buf_ring_cq_advance here
-        io_uring_cq_advance(&_ring, nr);
-    }
+    _dispatch();
 }
 
 } // namespace uring

--- a/librawio/src/uring_queue.hpp
+++ b/librawio/src/uring_queue.hpp
@@ -16,6 +16,8 @@ private:
     io_uring _ring;
     unsigned int _events;
 
+    void _dispatch();
+
 public:
     static const std::string& engine_name();
     static void setup_fd(int fd);
@@ -110,7 +112,9 @@ public:
 
     bool empty() const noexcept override;
 
-    void wait(unsigned int timeout) override;
+    void wait() override;
+
+    void wait_timeout(unsigned int timeout) override;
 };
 
 } // namespace uring

--- a/librawio/tests/fixture.cpp
+++ b/librawio/tests/fixture.cpp
@@ -23,7 +23,7 @@ QueueTest::QueueTest(unsigned int depth) :
 void QueueTest::_wait_all() {
     try {
         while (true) {
-            _queue->wait(0);
+            _queue->wait_timeout(0);
         }
     } catch (const std::system_error& e) {
         if (e.code().value() != ETIME) {

--- a/librawio/tests/test_basics.cpp
+++ b/librawio/tests/test_basics.cpp
@@ -21,7 +21,7 @@ TEST_F(BasicsTest, empty) {
     const char server_buf[] = "data";
     _server.write(server_buf, sizeof(server_buf));
     _server.wait();
-    EXPECT_THROW(_queue->wait(0), std::system_error);
+    EXPECT_THROW(_queue->wait_timeout(0), std::system_error);
 
     size_t result = 0;
     int error = 0;
@@ -30,9 +30,9 @@ TEST_F(BasicsTest, empty) {
         error = e;
     });
 
-    EXPECT_NO_THROW(_queue->wait(0));
+    EXPECT_NO_THROW(_queue->wait_timeout(0));
 
-    EXPECT_THROW(_queue->wait(0), std::system_error);
+    EXPECT_THROW(_queue->wait_timeout(0), std::system_error);
 }
 
 TEST_F(BasicsTest, pollin) {
@@ -46,7 +46,7 @@ TEST_F(BasicsTest, pollin) {
         result = r;
         error = e;
     });
-    _queue->wait(0);
+    _queue->wait_timeout(0);
 
     EXPECT_EQ(result, (size_t)POLLIN);
     EXPECT_EQ(error, 0);
@@ -59,7 +59,7 @@ TEST_F(BasicsTest, pollout) {
         result = r;
         error = e;
     });
-    _queue->wait(0);
+    _queue->wait_timeout(0);
 
     EXPECT_EQ(result, (size_t)POLLOUT);
     EXPECT_EQ(error, 0);
@@ -95,7 +95,7 @@ TEST_F(BasicsTest, accept) {
         }
     );
 
-    EXPECT_NO_THROW(_queue->wait(0));
+    EXPECT_NO_THROW(_queue->wait_timeout(0));
     EXPECT_GT(result, (size_t)0);
     EXPECT_EQ(error, 0);
 }
@@ -116,7 +116,7 @@ TEST_F(BasicsTest, read) {
             error = e;
         }
     );
-    _queue->wait(0);
+    _queue->wait_timeout(0);
 
     EXPECT_EQ(result, sizeof(client_buf));
     EXPECT_EQ(error, 0);
@@ -138,7 +138,7 @@ TEST_F(BasicsTest, recv) {
             error = e;
         }
     );
-    _queue->wait(0);
+    _queue->wait_timeout(0);
 
     EXPECT_EQ(result, sizeof(client_buf));
     EXPECT_EQ(error, 0);
@@ -156,7 +156,7 @@ TEST_F(BasicsTest, write) {
             error = e;
         }
     );
-    _queue->wait(0);
+    _queue->wait_timeout(0);
 
     char server_buf[sizeof(client_buf)];
     _server.read(server_buf, sizeof(server_buf));
@@ -178,7 +178,7 @@ TEST_F(BasicsTest, send) {
             error = e;
         }
     );
-    _queue->wait(0);
+    _queue->wait_timeout(0);
 
     char server_buf[sizeof(client_buf)];
     _server.read(server_buf, sizeof(server_buf));

--- a/librawio/tests/test_cancel.cpp
+++ b/librawio/tests/test_cancel.cpp
@@ -29,12 +29,12 @@ TEST_F(CancelTest, poll) {
             error = e;
         });
 
-    EXPECT_THROW(_queue->wait(0), std::system_error);
+    EXPECT_THROW(_queue->wait_timeout(0), std::system_error);
 
     _queue->cancel(event);
 
-    EXPECT_NO_THROW(_queue->wait(0));
-    EXPECT_THROW(_queue->wait(0), std::system_error);
+    EXPECT_NO_THROW(_queue->wait_timeout(0));
+    EXPECT_THROW(_queue->wait_timeout(0), std::system_error);
 
     EXPECT_EQ(result, (size_t)0);
     EXPECT_EQ(error, ECANCELED);
@@ -53,7 +53,7 @@ TEST_F(CancelTest, poll_completed) {
             error = e;
         });
 
-    _queue->wait(0);
+    _queue->wait_timeout(0);
 
     EXPECT_THROW(_queue->cancel(event), std::system_error);
     EXPECT_EQ(result, (size_t)POLLIN);
@@ -72,13 +72,13 @@ TEST_F(CancelTest, read) {
         }
     );
 
-    EXPECT_THROW(_queue->wait(0), std::system_error);
+    EXPECT_THROW(_queue->wait_timeout(0), std::system_error);
 
     _queue->cancel(event);
 
-    EXPECT_NO_THROW(_queue->wait(0));
+    EXPECT_NO_THROW(_queue->wait_timeout(0));
 
-    EXPECT_THROW(_queue->wait(0), std::system_error);
+    EXPECT_THROW(_queue->wait_timeout(0), std::system_error);
 
     EXPECT_EQ(result, (size_t)0);
     EXPECT_EQ(error, ECANCELED);
@@ -100,7 +100,7 @@ TEST_F(CancelTest, read_completed) {
         }
     );
 
-    _queue->wait(0);
+    _queue->wait_timeout(0);
 
     EXPECT_THROW(_queue->cancel(event), std::system_error);
     EXPECT_EQ(result, sizeof(client_buf));
@@ -126,9 +126,9 @@ TEST_F(CancelTest, write) {
 
     _queue->cancel(event);
 
-    EXPECT_NO_THROW(_queue->wait(0));
+    EXPECT_NO_THROW(_queue->wait_timeout(0));
 
-    EXPECT_THROW(_queue->wait(0), std::system_error);
+    EXPECT_THROW(_queue->wait_timeout(0), std::system_error);
 
     EXPECT_EQ(result, (size_t)0);
     EXPECT_EQ(error, ECANCELED);
@@ -145,7 +145,7 @@ TEST_F(CancelTest, write_completed) {
             error = e;
         }
     );
-    _queue->wait(0);
+    _queue->wait_timeout(0);
 
     char server_buf[sizeof(client_buf)];
     _server.read(server_buf, sizeof(server_buf));

--- a/librawio/tests/test_multishot.cpp
+++ b/librawio/tests/test_multishot.cpp
@@ -57,7 +57,7 @@ TEST_F(MultishotTest, poll) {
         }
     );
 
-    EXPECT_NO_THROW(_queue->wait(0));
+    EXPECT_NO_THROW(_queue->wait_timeout(0));
     EXPECT_EQ(result, (size_t)POLLIN);
     EXPECT_EQ(error, 0);
     EXPECT_EQ(count, 1u);
@@ -67,7 +67,7 @@ TEST_F(MultishotTest, poll) {
 
     result = 0;
     error = 0;
-    EXPECT_NO_THROW(_queue->wait(0));
+    EXPECT_NO_THROW(_queue->wait_timeout(0));
     EXPECT_EQ(result, (size_t)POLLIN);
     EXPECT_EQ(error, 0);
     EXPECT_EQ(count, 2u);
@@ -76,7 +76,7 @@ TEST_F(MultishotTest, poll) {
 
     result = 0;
     error = 0;
-    EXPECT_NO_THROW(_queue->wait(0));
+    EXPECT_NO_THROW(_queue->wait_timeout(0));
     EXPECT_EQ(result, (size_t)0);
     EXPECT_EQ(error, ECANCELED);
     EXPECT_EQ(count, 3u);
@@ -114,7 +114,7 @@ TEST_F(MultishotTest, accept) {
         }
     );
 
-    EXPECT_NO_THROW(_queue->wait(0));
+    EXPECT_NO_THROW(_queue->wait_timeout(0));
     EXPECT_GT(result, (size_t)0);
     EXPECT_EQ(error, 0);
     EXPECT_EQ(count, 1u);
@@ -126,7 +126,7 @@ TEST_F(MultishotTest, accept) {
 
     result = 0;
     error = 0;
-    EXPECT_NO_THROW(_queue->wait(0));
+    EXPECT_NO_THROW(_queue->wait_timeout(0));
     EXPECT_GT(result, (size_t)0);
     EXPECT_EQ(error, 0);
     EXPECT_EQ(count, 2u);
@@ -135,7 +135,7 @@ TEST_F(MultishotTest, accept) {
 
     result = 0;
     error = 0;
-    EXPECT_NO_THROW(_queue->wait(0));
+    EXPECT_NO_THROW(_queue->wait_timeout(0));
     EXPECT_EQ(result, (size_t)0);
     EXPECT_EQ(error, ECANCELED);
     EXPECT_EQ(count, 3u);
@@ -197,7 +197,7 @@ TEST_F(MultishotTest, recv) {
         EXPECT_EQ(items[4].error(), ECANCELED);
     }
 
-    EXPECT_THROW(_queue->wait(0), std::system_error);
+    EXPECT_THROW(_queue->wait_timeout(0), std::system_error);
     EXPECT_EQ(items.size(), (size_t)5);
 }
 
@@ -250,7 +250,7 @@ TEST_F(MultishotTest, recv_overflow) {
 
     EXPECT_THROW(_queue->cancel(event), std::system_error);
 
-    EXPECT_THROW(_queue->wait(0), std::system_error);
+    EXPECT_THROW(_queue->wait_timeout(0), std::system_error);
     EXPECT_EQ(items.size(), (size_t)5);
 }
 
@@ -314,7 +314,7 @@ TEST_F(MultishotTest, recv_partial) {
 
     EXPECT_NO_THROW(_queue->cancel(event));
 
-    EXPECT_NO_THROW(_queue->wait(0));
+    EXPECT_NO_THROW(_queue->wait_timeout(0));
     if (items.size() >= 5) {
         EXPECT_EQ(items[4].result(), (size_t)1);
         EXPECT_EQ(items[4].error(), ECANCELED);
@@ -386,7 +386,7 @@ TEST_F(MultishotTest, recv_fill_buf) {
 
     EXPECT_NO_THROW(_queue->cancel(event));
 
-    EXPECT_NO_THROW(_queue->wait(0));
+    EXPECT_NO_THROW(_queue->wait_timeout(0));
     if (items.size() >= 5) {
         EXPECT_EQ(items[4].result(), (size_t)1);
         EXPECT_EQ(items[4].error(), ECANCELED);

--- a/librawio/tests/test_pollhup.cpp
+++ b/librawio/tests/test_pollhup.cpp
@@ -24,7 +24,7 @@ TEST_F(PollHupTest, pollin) {
         result = r;
         error = e;
     });
-    _queue->wait(0);
+    _queue->wait_timeout(0);
 
     EXPECT_TRUE(result & POLLIN);
     EXPECT_TRUE(result & POLLHUP);
@@ -41,7 +41,7 @@ TEST_F(PollHupTest, pollout) {
         result = r;
         error = e;
     });
-    _queue->wait(0);
+    _queue->wait_timeout(0);
 
     EXPECT_TRUE(result & POLLHUP);
     EXPECT_EQ(error, 0);
@@ -60,7 +60,7 @@ TEST_F(PollHupTest, read) {
         result = r;
         error = e;
     });
-    _queue->wait(0);
+    _queue->wait_timeout(0);
 
     EXPECT_EQ(result, (size_t)5);
     EXPECT_EQ(error, 0);
@@ -81,7 +81,7 @@ TEST_F(PollHupTest, write) {
             error = e;
         }
     );
-    _queue->wait(0);
+    _queue->wait_timeout(0);
 
     EXPECT_EQ(result, (size_t)0);
     EXPECT_EQ(error, EPIPE);

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -45,7 +45,7 @@ public:
 
     void wait() {
         while (_operations > 0) {
-            _q->wait(rawstor_opts_wait_timeout());
+            _q->wait_timeout(rawstor_opts_wait_timeout());
         }
     }
 };

--- a/src/ost_session.cpp
+++ b/src/ost_session.cpp
@@ -880,7 +880,7 @@ void Session::set_object(rawstor::Object* object) {
     );
 
     while (!completed) {
-        queue->wait(rawstor_opts_wait_timeout());
+        queue->wait_timeout(rawstor_opts_wait_timeout());
     }
 }
 

--- a/src/rawstor.cpp
+++ b/src/rawstor.cpp
@@ -107,7 +107,7 @@ void rawstor_terminate() noexcept {
 
 int rawstor_wait() noexcept {
     try {
-        rawstor::io_queue->wait(rawstor_opts_wait_timeout());
+        rawstor::io_queue->wait_timeout(rawstor_opts_wait_timeout());
         return 0;
     } catch (const std::system_error& e) {
         return -e.code().value();

--- a/tests/test_lifecycle.cpp
+++ b/tests/test_lifecycle.cpp
@@ -103,7 +103,7 @@ TEST_P(LifecycleTest, create_spec_remove) {
     EXPECT_EQ(res, (int)strlen(object_uris));
     _backend->close();
     try {
-        rawstor::io_queue->wait(0);
+        rawstor::io_queue->wait_timeout(0);
     } catch (...) {
     }
 
@@ -122,7 +122,7 @@ TEST_P(LifecycleTest, create_spec_remove) {
     }
     _backend->close();
     try {
-        rawstor::io_queue->wait(0);
+        rawstor::io_queue->wait_timeout(0);
     } catch (...) {
     }
 
@@ -137,7 +137,7 @@ TEST_P(LifecycleTest, create_spec_remove) {
         _backend->close();
     }
     try {
-        rawstor::io_queue->wait(0);
+        rawstor::io_queue->wait_timeout(0);
     } catch (...) {
     }
 }


### PR DESCRIPTION
This pull request refactors the queue waiting mechanism by decoupling indefinite waits from timed waits. By introducing specific methods for these operations, the codebase becomes more expressive and less prone to errors associated with magic numbers or ambiguous method signatures. The changes also include internal refactoring to consolidate logic, improving maintainability and readability across both the poll and io_uring implementations.

* **API Refactoring**: Split the existing `wait(unsigned int timeout)` method into two distinct methods: `wait()` for indefinite waiting and `wait_timeout(unsigned int timeout)` for timed waiting.
* **Code Consolidation**: Introduced a private `_wait_timeout` helper method in the `poll` engine and a `_dispatch` helper method in the `uring` engine to reduce code duplication.
* **Test Updates**: Updated all test suites and internal service calls to utilize the new `wait_timeout` API, ensuring consistent behavior across the codebase.

(cherry picked from commit 8a49f4ae845a7a877531962b1c330eb5b515be8e)

Conflicts:
	librawio/include/rawio/queue.hpp
	librawio/src/poll_queue.cpp
	librawio/src/poll_queue.hpp
	librawio/src/uring_queue.cpp
	librawio/src/uring_queue.hpp
	librawio/tests/test_multishot.cpp