### PR TITLE
add: version header (#383)

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,2 +1,3 @@
 **/3rdparty/**
 ./librawstd/include/rawstd/logging_config.h
+./include/rawstor/version.h

--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,10 @@ AC_CONFIG_MACRO_DIRS([m4])
 
 
 AC_SUBST([PACKAGE_VERSION_SHORT], [`echo ${PACKAGE_VERSION%%-*}`])
+AC_SUBST([PACKAGE_VERSION_MAJOR], [`echo ${PACKAGE_VERSION_SHORT%%.*}`])
+AC_SUBST([PACKAGE_VERSION_MINOR_PATCH], [`echo ${PACKAGE_VERSION_SHORT#*.}`])
+AC_SUBST([PACKAGE_VERSION_MINOR], [`echo ${PACKAGE_VERSION_MINOR_PATCH%%.*}`])
+AC_SUBST([PACKAGE_VERSION_PATCH], [`echo ${PACKAGE_VERSION_MINOR_PATCH#*.}`])
 AC_SUBST([RPM_RELEASE], [`[[[ ${PACKAGE_VERSION} == *-* ]]] && RELEASE=${PACKAGE_VERSION#*-} && echo ${RELEASE//-/^} || echo "0"`])
 AC_SUBST([LIBRARY_VERSION], [`VERSION=${PACKAGE_VERSION_SHORT%.*} && echo ${VERSION//./:}:0`])
 
@@ -94,6 +98,7 @@ AS_IF([test "x$with_libxxhash" == "xyes"], [
 
 AC_CONFIG_FILES(
     [Makefile]
+    [include/rawstor/version.h]
     [librawstd/include/rawstd/logging_config.h]
     [librawstd/Makefile]
     [librawstd/src/Makefile]

--- a/include/rawstor.h
+++ b/include/rawstor.h
@@ -9,5 +9,6 @@
 
 #include <rawstor/object.h>
 #include <rawstor/rawstor.h>
+#include <rawstor/version.h>
 
 #endif // RAWSTOR_H

--- a/include/rawstor/.gitignore
+++ b/include/rawstor/.gitignore
@@ -1,0 +1,1 @@
+/version.h

--- a/include/rawstor/version.h.in
+++ b/include/rawstor/version.h.in
@@ -1,0 +1,16 @@
+/**
+ * Copyright (C) 2025-2026, Vasily Stepanov (vasily.stepanov@gmail.com)
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+ */
+
+#ifndef RAWSTOR_VERSION_H
+#define RAWSTOR_VERSION_H
+
+#define RAWSTOR_VERSION_MAJOR @PACKAGE_VERSION_MAJOR@
+
+#define RAWSTOR_VERSION_MINOR @PACKAGE_VERSION_MINOR@
+
+#define RAWSTOR_VERSION_PATCH @PACKAGE_VERSION_PATCH@
+
+#endif // RAWSTOR_VERSION_H

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,7 +25,8 @@ librawstor_base_la_HEADERS = $(top_srcdir)/include/rawstor.h
 librawstor_ladir = $(includedir)/rawstor
 
 librawstor_la_HEADERS = $(top_srcdir)/include/rawstor/object.h \
-                        $(top_srcdir)/include/rawstor/rawstor.h
+                        $(top_srcdir)/include/rawstor/rawstor.h \
+                        $(top_builddir)/include/rawstor/version.h
 
 librawstor_la_SOURCES = connection.cpp \
                         connection.hpp \


### PR DESCRIPTION
This pull request implements a mechanism to expose the library's versioning information to the C++ code. By dynamically generating a version header file during the configuration process, the project can now programmatically access major, minor, and patch version numbers, improving maintainability and consistency across the library.

* **Version Header Implementation**: Introduced a generated version.h header file to expose library versioning information (major, minor, and patch) to the codebase.
* **Build System Updates**: Updated configure.ac to parse version components from the package version and configured the generation of the version header.
* **Header Integration**: Included the new version header in the main rawstor.h file and updated the Makefile to ensure the generated header is correctly included in the build process.

(cherry picked from commit f8596fe59032f0b571bb903f28adade8df8ab169)

Conflicts:
	src/Makefile.am