### PR TITLE
fix: graceful vhost disconnect (#387)

### DIFF
--- a/vhost/device.cpp
+++ b/vhost/device.cpp
@@ -167,6 +167,9 @@ public:
             return 0;
         } catch (const std::system_error& e) {
             return -e.code().value();
+        } catch (const std::exception& e) {
+            rawstd_error("%s\n", e.what());
+            return -EINVAL;
         }
     }
 
@@ -367,6 +370,14 @@ void set_protocol_features(VuDev* dev, uint64_t features) {
     d.set_protocol_features(features);
 }
 
+int process_msg(VuDev*, VhostUserMsg* vmsg, int*) {
+    if (vmsg->request == VHOST_USER_NONE) {
+        rawstd_info("Disconnect\n");
+        return 1;
+    }
+    return 0;
+}
+
 void process_request(std::unique_ptr<Request> req) {
     size_t in_size = rawstd_iovec_size(req->in_iov(), req->in_niov());
 
@@ -502,7 +513,7 @@ Device::Device(const std::string& target, int fd) :
         .set_features = ::set_features,
         .get_protocol_features = ::get_protocol_features,
         .set_protocol_features = ::set_protocol_features,
-        .process_msg = nullptr,
+        .process_msg = ::process_msg,
         .queue_set_started = ::queue_set_started,
         .queue_is_processed_in_order = nullptr,
         .get_config = ::get_config,
@@ -668,6 +679,10 @@ void Device::loop() {
         int res = rawstor_wait();
         if (res == -ETIME) {
             continue;
+        }
+
+        if (res == -EPIPE) {
+            break;
         }
 
         if (res == -EINTR) {


### PR DESCRIPTION
This pull request introduces more robust error handling and lifecycle management for vhost-user connections. By explicitly handling disconnect signals and common socket error codes, the daemon is now better equipped to manage abrupt frontend disconnections without crashing.

* **Graceful Disconnect Handling**: Implemented a new `process_msg` function to handle `VHOST_USER_NONE` requests, allowing the device to recognize and log disconnect events.
* **Error Handling Improvements**: Added a catch-all for `std::exception` in the task runner to prevent daemon crashes and updated the main loop to break on `EPIPE` errors.

(cherry picked from commit 0edea088768431c08a965a57536bd5784bca00db)

Conflicts:
	vhost/device.cpp