### PR TITLE
fix: fetch full history in perftests to handle library version (#389)

### DIFF
--- a/.github/workflows/perftest.yml
+++ b/.github/workflows/perftest.yml
@@ -42,6 +42,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         path: librawstor
+        fetch-depth: 0
     - name: install librawstor
       run: |
         pushd .


### PR DESCRIPTION
(cherry picked from commit c6f76126e1f3ebd5541c942e2c828562e2e36e39)