### PR TITLE
add: move cid to request frame head (#394)

### DIFF
--- a/src/ost_protocol.h
+++ b/src/ost_protocol.h
@@ -23,11 +23,12 @@ extern "C" {
 #define RAWSTOR_CMD_READ 1
 #define RAWSTOR_CMD_WRITE 2
 #define RAWSTOR_CMD_DISCARD 3
-typedef uint32_t RawstorOSTCommandType;
+typedef uint16_t RawstorOSTCommandType;
 
 struct RawstorOSTFrameHead {
     uint32_t magic;
-    RawstorOSTCommandType cmd; // RawstorOSTCommandType
+    RawstorOSTCommandType cmd;
+    uint16_t cid;
 } RAWSTOR_PACKED;
 
 /* Minimalistic protocol frame */
@@ -45,7 +46,6 @@ struct RawstorOSTFrameBasic {
 } RAWSTOR_PACKED;
 
 struct RawstorOSTFrameIOBody {
-    uint16_t cid;
     uint64_t offset;
     uint32_t len;
     uint64_t hash;
@@ -59,7 +59,6 @@ struct RawstorOSTFrameIO {
 
 /* response frames */
 struct RawstorOSTFrameResponseBody {
-    uint16_t cid;
     // TODO: if we send length in res - it should be the same type
     // (signed-unsigned too)
     int32_t res;

--- a/src/ost_session.cpp
+++ b/src/ost_session.cpp
@@ -140,9 +140,9 @@ public:
     inline RawstorOSTFrameResponse* response() noexcept { return &_response; }
 
     SessionOp& find_op() {
-        auto it = _ops.find(_response.body.cid);
+        auto it = _ops.find(_response.head.cid);
         if (it == _ops.end()) {
-            rawstd_error("Unexpected cid: %u\n", _response.body.cid);
+            rawstd_error("Unexpected cid: %u\n", _response.head.cid);
             RAWSTD_THROW_SYSTEM_ERROR(EPROTO);
         }
 
@@ -250,6 +250,7 @@ public:
                 {
                     .magic = RAWSTOR_MAGIC,
                     .cmd = RAWSTOR_CMD_SET_OBJECT,
+                    .cid = cid,
                 },
             .body = {
                 .obj_id = {},
@@ -311,10 +312,10 @@ public:
                 {
                     .magic = RAWSTOR_MAGIC,
                     .cmd = RAWSTOR_CMD_READ,
+                    .cid = cid,
                 },
             .body =
                 {
-                    .cid = cid,
                     .offset = (uint64_t)offset,
                     .len = (uint32_t)_size,
                     .hash = 0,
@@ -388,10 +389,10 @@ public:
                 {
                     .magic = RAWSTOR_MAGIC,
                     .cmd = RAWSTOR_CMD_READ,
+                    .cid = cid,
                 },
             .body =
                 {
-                    .cid = cid,
                     .offset = (uint64_t)offset,
                     .len = (uint32_t)_size,
                     .hash = 0,
@@ -458,9 +459,9 @@ public:
                 {
                     .magic = RAWSTOR_MAGIC,
                     .cmd = RAWSTOR_CMD_WRITE,
+                    .cid = cid,
                 },
             .body = {
-                .cid = cid,
                 .offset = (uint64_t)offset,
                 .len = (uint32_t)size,
                 .hash = hash(buf, size),
@@ -524,9 +525,9 @@ public:
                 {
                     .magic = RAWSTOR_MAGIC,
                     .cmd = RAWSTOR_CMD_WRITE,
+                    .cid = cid,
                 },
             .body = {
-                .cid = cid,
                 .offset = (uint64_t)offset,
                 .len = (uint32_t)size,
                 .hash = hash(iov, niov),
@@ -811,6 +812,7 @@ void Session::set_object(rawstor::Object* object) {
             {
                 .magic = RAWSTOR_MAGIC,
                 .cmd = RAWSTOR_CMD_SET_OBJECT,
+                .cid = _cid_counter++,
             },
         .body = {
             .obj_id = {},


### PR DESCRIPTION
This pull request refactors the Rawstor protocol by moving the command ID (cid) field into the common frame header. This change simplifies the protocol structure by removing redundant fields from individual body types and ensures that the cid is consistently available for all request and response processing. The internal session handling logic has been updated to accommodate this change, ensuring robust identification of operations throughout the request-response lifecycle.

* **Protocol Header Update**: Moved the command ID (cid) field from the request/response bodies to the shared RawstorOSTFrameHead structure to centralize identification.
* **Codebase Refactoring**: Updated internal session methods to accept the frame header as an argument, ensuring the cid is correctly propagated and utilized across all IO operations.
* **Consistency Improvements**: Cleaned up redundant cid fields in IO and response bodies and ensured the server correctly echoes the cid in response frames.

(cherry picked from commit 51157fd9602b0cd3cc7906365982a29977b20db6)

Conflicts:
	ost/session.cpp
	ost/session.hpp
	src/ost_protocol.h
	src/ost_session.cpp