### PR TITLE
fix: error handling (#403)

### DIFF
--- a/src/object.cpp
+++ b/src/object.cpp
@@ -475,7 +475,10 @@ int rawstor_object_pread(
         static_cast<rawstor::Object*>(object)->pread(
             buf, size, offset,
             [object, size, cb, data](size_t result, int error) {
-                cb(object, size, result, error, data);
+                int res = cb(object, size, result, error, data);
+                if (res < 0) {
+                    RAWSTD_THROW_SYSTEM_ERROR(-res);
+                }
             }
         );
         return 0;
@@ -500,7 +503,10 @@ int rawstor_object_preadv(
         static_cast<rawstor::Object*>(object)->preadv(
             iov, niov, size, offset,
             [object, size, cb, data](size_t result, int error) {
-                cb(object, size, result, error, data);
+                int res = cb(object, size, result, error, data);
+                if (res < 0) {
+                    RAWSTD_THROW_SYSTEM_ERROR(-res);
+                }
             }
         );
         return 0;
@@ -525,7 +531,10 @@ int rawstor_object_pwrite(
         static_cast<rawstor::Object*>(object)->pwrite(
             buf, size, offset,
             [object, size, cb, data](size_t result, int error) {
-                cb(object, size, result, error, data);
+                int res = cb(object, size, result, error, data);
+                if (res < 0) {
+                    RAWSTD_THROW_SYSTEM_ERROR(-res);
+                }
             }
         );
         return 0;
@@ -550,7 +559,10 @@ int rawstor_object_pwritev(
         static_cast<rawstor::Object*>(object)->pwritev(
             iov, niov, size, offset,
             [object, size, cb, data](size_t result, int error) {
-                cb(object, size, result, error, data);
+                int res = cb(object, size, result, error, data);
+                if (res < 0) {
+                    RAWSTD_THROW_SYSTEM_ERROR(-res);
+                }
             }
         );
         return 0;


### PR DESCRIPTION
This pull request improves error handling robustness within asynchronous operations and session management. By explicitly checking callback results and ensuring consistent failure states during exceptions, the changes prevent potential undefined behavior and improve system reliability.

* **Asynchronous Callback Error Handling**: Updated pread, preadv, pwrite, and pwritev operations to check callback return values and throw system errors when negative values are returned.
* **Session Error Management**: Enhanced exception handling in the receive context to ensure in-flight operations are failed before throwing system errors.

(cherry picked from commit edc73d5be5bec8214a600adb3fe08e24867b1941)

Conflicts:
	src/ost_session.cpp