### PR TITLE
ref: add template to dispatch method (#406)

### DIFF
--- a/librawio/src/poll_event.cpp
+++ b/librawio/src/poll_event.cpp
@@ -6,6 +6,7 @@
 #include <rawstd/logging.h>
 
 #include <system_error>
+#include <utility>
 #include <vector>
 
 #include <sys/types.h>
@@ -15,15 +16,14 @@
 
 namespace {
 
-inline void dispatch(
-    const rawstd::TraceEvent& trace_event, size_t result, int error,
-    const std::function<void(size_t, int)>& cb
-) {
+template <typename T, typename... Args>
+inline void
+dispatch(const rawstd::TraceEvent& trace_event, T&& cb, Args&&... args) {
     RAWSTD_TRACE_EVENT_MESSAGE(trace_event, "%s\n", "callback");
 #ifdef RAWSTD_TRACE_EVENTS
     try {
 #endif
-        cb(result, error);
+        std::forward<T>(cb)(std::forward<Args>(args)...);
 #ifdef RAWSTD_TRACE_EVENTS
     } catch (const std::exception& e) {
         RAWSTD_TRACE_EVENT_MESSAGE(
@@ -41,7 +41,7 @@ namespace rawio {
 namespace poll {
 
 void EventMultiplex::dispatch() {
-    ::dispatch(trace_event, _result, _error, _cb);
+    ::dispatch(trace_event, _cb, _result, _error);
 }
 
 size_t EventMultiplexScalar::shift(size_t shift) noexcept {
@@ -96,11 +96,11 @@ ssize_t EventSimplexPoll::process() noexcept {
 }
 
 void EventSimplexPollOneshot::dispatch() {
-    ::dispatch(trace_event, _result, _error, _cb);
+    ::dispatch(trace_event, _cb, _result, _error);
 }
 
 void EventSimplexPollMultishot::dispatch() {
-    ::dispatch(trace_event, _result, _error, _cb);
+    ::dispatch(trace_event, _cb, _result, _error);
     _result = 0;
 }
 
@@ -139,7 +139,7 @@ ssize_t EventSimplexAcceptOneshot::process() noexcept {
 }
 
 void EventSimplexAcceptOneshot::dispatch() {
-    ::dispatch(trace_event, _result, _error, _cb);
+    ::dispatch(trace_event, _cb, _result, _error);
 }
 
 ssize_t EventSimplexAcceptMultishot::process() noexcept {
@@ -177,12 +177,12 @@ ssize_t EventSimplexAcceptMultishot::process() noexcept {
 }
 
 void EventSimplexAcceptMultishot::dispatch() {
-    ::dispatch(trace_event, _result, _error, _cb);
+    ::dispatch(trace_event, _cb, _result, _error);
     _result = 0;
 }
 
 void EventSimplexScalarRead::dispatch() {
-    ::dispatch(trace_event, _result, _error, _cb);
+    ::dispatch(trace_event, _cb, _result, _error);
 }
 
 ssize_t EventSimplexScalarRead::process() noexcept {
@@ -206,7 +206,7 @@ ssize_t EventSimplexScalarRead::process() noexcept {
 }
 
 void EventSimplexVectorRead::dispatch() {
-    ::dispatch(trace_event, _result, _error, _cb);
+    ::dispatch(trace_event, _cb, _result, _error);
 }
 
 ssize_t EventSimplexVectorRead::process() noexcept {
@@ -230,7 +230,7 @@ ssize_t EventSimplexVectorRead::process() noexcept {
 }
 
 void EventSimplexScalarPositionalRead::dispatch() {
-    ::dispatch(trace_event, _result, _error, _cb);
+    ::dispatch(trace_event, _cb, _result, _error);
 }
 
 ssize_t EventSimplexScalarPositionalRead::process() noexcept {
@@ -254,7 +254,7 @@ ssize_t EventSimplexScalarPositionalRead::process() noexcept {
 }
 
 void EventSimplexVectorPositionalRead::dispatch() {
-    ::dispatch(trace_event, _result, _error, _cb);
+    ::dispatch(trace_event, _cb, _result, _error);
 }
 
 ssize_t EventSimplexVectorPositionalRead::process() noexcept {
@@ -278,7 +278,7 @@ ssize_t EventSimplexVectorPositionalRead::process() noexcept {
 }
 
 void EventSimplexScalarRecv::dispatch() {
-    ::dispatch(trace_event, _result, _error, _cb);
+    ::dispatch(trace_event, _cb, _result, _error);
 }
 
 ssize_t EventSimplexScalarRecv::process() noexcept {
@@ -423,7 +423,7 @@ ssize_t EventSimplexVectorRecvMultishot::process() noexcept {
 }
 
 void EventSimplexMessageRead::dispatch() {
-    ::dispatch(trace_event, _result, _error, _cb);
+    ::dispatch(trace_event, _cb, _result, _error);
 }
 
 ssize_t EventSimplexMessageRead::process() noexcept {
@@ -474,7 +474,7 @@ ssize_t EventMultiplexVectorWrite::process() noexcept {
 }
 
 void EventSimplexScalarPositionalWrite::dispatch() {
-    ::dispatch(trace_event, _result, _error, _cb);
+    ::dispatch(trace_event, _cb, _result, _error);
 }
 
 ssize_t EventSimplexScalarPositionalWrite::process() noexcept {
@@ -498,7 +498,7 @@ ssize_t EventSimplexScalarPositionalWrite::process() noexcept {
 }
 
 void EventSimplexVectorPositionalWrite::dispatch() {
-    ::dispatch(trace_event, _result, _error, _cb);
+    ::dispatch(trace_event, _cb, _result, _error);
 }
 
 ssize_t EventSimplexVectorPositionalWrite::process() noexcept {
@@ -522,7 +522,7 @@ ssize_t EventSimplexVectorPositionalWrite::process() noexcept {
 }
 
 void EventSimplexScalarSend::dispatch() {
-    ::dispatch(trace_event, _result, _error, _cb);
+    ::dispatch(trace_event, _cb, _result, _error);
 }
 
 ssize_t EventSimplexScalarSend::process() noexcept {
@@ -546,7 +546,7 @@ ssize_t EventSimplexScalarSend::process() noexcept {
 }
 
 void EventSimplexMessageWrite::dispatch() {
-    ::dispatch(trace_event, _result, _error, _cb);
+    ::dispatch(trace_event, _cb, _result, _error);
 }
 
 ssize_t EventSimplexMessageWrite::process() noexcept {


### PR DESCRIPTION
This pull request refactors the event dispatching mechanism in `poll_event.cpp` to improve performance and flexibility. By transitioning from a fixed `std::function` signature to a variadic template with perfect forwarding, the code now avoids unnecessary copies and supports a wider range of callable types. The changes also include necessary header updates to maintain build portability.

### Highlights

* **Template-based Dispatch**: Refactored the internal `dispatch` function to use a template with perfect forwarding, allowing for more flexible callback signatures and support for move-only types.
* **Standard Library Inclusion**: Added the `<utility>` header to `poll_event.cpp` to support `std::forward` and ensure portable compilation.
* **Call Site Updates**: Updated all `dispatch()` method implementations across various event classes to accommodate the new variadic template signature.

(cherry picked from commit fb13cd0972aae45909f481e6045ba8895fb9e8bf)