### PR TITLE
add: async open and close (#408)

### DIFF
--- a/librawio/include/rawio/queue.hpp
+++ b/librawio/include/rawio/queue.hpp
@@ -1,6 +1,7 @@
 #ifndef RAWIO_QUEUE_HPP
 #define RAWIO_QUEUE_HPP
 
+#include <functional>
 #include <memory>
 #include <string>
 
@@ -8,10 +9,8 @@
 #include <sys/types.h>
 #include <sys/uio.h>
 
+#include <fcntl.h>
 #include <unistd.h>
-
-#include <functional>
-#include <memory>
 
 namespace rawio {
 
@@ -34,6 +33,12 @@ public:
     Queue& operator=(Queue&&) = delete;
 
     inline unsigned int depth() const noexcept { return _depth; }
+
+    virtual Event* open(
+        const char* path, int flags, mode_t mode, std::function<void(int)>&& cb
+    ) = 0;
+
+    virtual Event* close(int fd, std::function<void(int)>&& cb) = 0;
 
     virtual Event*
     poll(int fd, unsigned int mask, std::function<void(size_t, int)>&& cb) = 0;

--- a/librawio/src/poll_event.cpp
+++ b/librawio/src/poll_event.cpp
@@ -40,6 +40,15 @@ dispatch(const rawstd::TraceEvent& trace_event, T&& cb, Args&&... args) {
 namespace rawio {
 namespace poll {
 
+void EventEval::dispatch() {
+    ::dispatch(trace_event, _cb, _result);
+}
+
+ssize_t EventEval::process() noexcept {
+    _result = _eval();
+    return _result;
+}
+
 void EventMultiplex::dispatch() {
     ::dispatch(trace_event, _cb, _result, _error);
 }

--- a/librawio/src/poll_event.hpp
+++ b/librawio/src/poll_event.hpp
@@ -76,6 +76,33 @@ public:
     int fd() const noexcept { return _fd; }
 };
 
+class EventEval final : public Event {
+private:
+    std::function<int()> _eval;
+    std::function<void(int)> _cb;
+
+public:
+    EventEval(
+        Queue& q, const rawstd::TraceEvent& trace_event,
+        std::function<int()>&& eval, std::function<void(int)>&& cb
+    ) :
+        Event(q, -1, trace_event),
+        _eval(std::move(eval)),
+        _cb(std::move(cb)) {}
+
+    void dispatch() override;
+
+    bool is_completed() const noexcept override { return true; }
+    bool is_multiplex() const noexcept override { return false; }
+    bool is_multishot() const noexcept override { return false; }
+    bool is_poll() const noexcept override { return false; }
+    bool is_accept() const noexcept override { return false; }
+    bool is_read() const noexcept override { return false; }
+    bool is_write() const noexcept override { return false; }
+
+    ssize_t process() noexcept override;
+};
+
 class EventSimplex : public Event {
 public:
     EventSimplex(Queue& q, int fd, const rawstd::TraceEvent& trace_event) :

--- a/librawio/src/poll_queue.cpp
+++ b/librawio/src/poll_queue.cpp
@@ -38,6 +38,14 @@ Session& Queue::_get_session(int fd) {
 }
 
 void Queue::_wait_timeout(int timeout) {
+    while (!_eval_sqes.empty()) {
+        std::unique_ptr<EventEval> event = std::move(_eval_sqes.front());
+        _eval_sqes.pop_front();
+
+        event->process();
+        _cqes.push(std::move(event));
+    }
+
     while (_cqes.empty()) {
         std::vector<pollfd> fds;
         fds.reserve(_sessions.size());
@@ -110,6 +118,10 @@ void Queue::_wait_timeout(int timeout) {
     }
 }
 
+void Queue::_eval(std::unique_ptr<EventEval>&& event) {
+    _eval_sqes.push_back(std::move(event));
+}
+
 const std::string& Queue::engine_name() {
     return ::engine_name;
 }
@@ -145,6 +157,51 @@ void Queue::setup_fd(int fd) {
             RAWSTD_THROW_SYSTEM_ERROR(-res);
         }
     }
+}
+
+rawio::Event* Queue::open(
+    const char* path, int flags, mode_t mode, std::function<void(int)>&& cb
+) {
+    rawstd::TraceEvent trace_event =
+        RAWSTD_TRACE_EVENT('|', "flags = %d, mode = %d\n", flags, mode);
+
+    std::unique_ptr<EventEval> event = std::make_unique<EventEval>(
+        *this, trace_event,
+        [path, flags, mode]() -> int {
+            int res = ::open(path, flags, mode);
+            if (res == -1) {
+                res = -errno;
+                errno = 0;
+            }
+            return res;
+        },
+        std::move(cb)
+    );
+
+    rawio::Event* ret = static_cast<rawio::Event*>(event.get());
+    _eval(std::move(event));
+    return ret;
+}
+
+rawio::Event* Queue::close(int fd, std::function<void(int)>&& cb) {
+    rawstd::TraceEvent trace_event = RAWSTD_TRACE_EVENT('|', "%s\n", "");
+
+    std::unique_ptr<EventEval> event = std::make_unique<EventEval>(
+        *this, trace_event,
+        [fd]() -> int {
+            int res = ::close(fd);
+            if (res == -1) {
+                res = -errno;
+                errno = 0;
+            }
+            return res;
+        },
+        std::move(cb)
+    );
+
+    rawio::Event* ret = static_cast<rawio::Event*>(event.get());
+    _eval(std::move(event));
+    return ret;
 }
 
 rawio::Event*

--- a/librawio/src/poll_queue.hpp
+++ b/librawio/src/poll_queue.hpp
@@ -20,6 +20,7 @@ class Session;
 
 class Queue final : public rawio::Queue {
 private:
+    std::list<std::unique_ptr<EventEval>> _eval_sqes;
     std::unordered_map<int, std::shared_ptr<Session>> _sessions;
     rawstd::RingBuf<Event> _cqes;
 
@@ -27,11 +28,19 @@ private:
 
     void _wait_timeout(int timeout);
 
+    void _eval(std::unique_ptr<EventEval>&& event);
+
 public:
     static const std::string& engine_name();
     static void setup_fd(int fd);
 
     explicit Queue(unsigned int depth) : rawio::Queue(depth), _cqes(depth) {}
+
+    rawio::Event* open(
+        const char* path, int flags, mode_t mode, std::function<void(int)>&& cb
+    ) override;
+
+    rawio::Event* close(int fd, std::function<void(int)>&& cb) override;
 
     rawio::Event* poll(
         int fd, unsigned int mask, std::function<void(size_t, int)>&& cb

--- a/librawio/src/uring_queue.cpp
+++ b/librawio/src/uring_queue.cpp
@@ -150,6 +150,61 @@ void Queue::setup_fd(int fd) {
     }
 }
 
+rawio::Event* Queue::open(
+    const char* path, int flags, mode_t mode, std::function<void(int)>&& cb
+) {
+    rawstd::TraceEvent trace_event =
+        RAWSTD_TRACE_EVENT('|', "flags = %d, mode = %u\n", flags, mode);
+    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
+    if (sqe == nullptr) {
+        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
+    }
+    std::unique_ptr<std::function<void(size_t, int, unsigned int)>> p =
+        std::make_unique<std::function<void(size_t, int, unsigned int)>>(
+            [cb = std::move(cb),
+             trace_event](size_t result, int error, unsigned int) {
+                RAWSTD_TRACE_EVENT_MESSAGE(
+                    trace_event, "result = %zu, error = %d\n", result, error
+                );
+                if (!error) {
+                    cb(result);
+                } else {
+                    cb(-error);
+                }
+            }
+        );
+    io_uring_prep_openat(sqe, AT_FDCWD, path, flags, mode);
+    io_uring_sqe_set_data(sqe, p.get());
+
+    return static_cast<rawio::Event*>(p.release());
+}
+
+rawio::Event* Queue::close(int fd, std::function<void(int)>&& cb) {
+    rawstd::TraceEvent trace_event = RAWSTD_TRACE_EVENT('|', "%s\n", "");
+    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
+    if (sqe == nullptr) {
+        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
+    }
+    std::unique_ptr<std::function<void(size_t, int, unsigned int)>> p =
+        std::make_unique<std::function<void(size_t, int, unsigned int)>>(
+            [cb = std::move(cb),
+             trace_event](size_t result, int error, unsigned int) {
+                RAWSTD_TRACE_EVENT_MESSAGE(
+                    trace_event, "result = %zu, error = %d\n", result, error
+                );
+                if (!error) {
+                    cb(result);
+                } else {
+                    cb(-error);
+                }
+            }
+        );
+    io_uring_prep_close(sqe, fd);
+    io_uring_sqe_set_data(sqe, p.get());
+
+    return static_cast<rawio::Event*>(p.release());
+}
+
 rawio::Event*
 Queue::poll(int fd, unsigned int mask, std::function<void(size_t, int)>&& cb) {
     rawstd::TraceEvent trace_event =

--- a/librawio/src/uring_queue.hpp
+++ b/librawio/src/uring_queue.hpp
@@ -25,6 +25,12 @@ public:
     explicit Queue(unsigned int depth);
     ~Queue();
 
+    rawio::Event* open(
+        const char* path, int flags, mode_t mode, std::function<void(int)>&& cb
+    );
+
+    rawio::Event* close(int fd, std::function<void(int)>&& cb);
+
     rawio::Event* poll(
         int fd, unsigned int mask, std::function<void(size_t, int)>&& cb
     ) override;

--- a/librawio/tests/test_basics.cpp
+++ b/librawio/tests/test_basics.cpp
@@ -10,6 +10,9 @@
 
 #include <poll.h>
 
+#include <filesystem>
+#include <sstream>
+
 namespace {
 
 class BasicsTest : public rawio::tests::QueueTest {
@@ -187,6 +190,31 @@ TEST_F(BasicsTest, send) {
     EXPECT_EQ(result, sizeof(client_buf));
     EXPECT_EQ(error, 0);
     EXPECT_EQ(strcmp(server_buf, client_buf), 0);
+}
+
+TEST(OpenCloseTest, basics) {
+    std::filesystem::path path =
+        std::filesystem::temp_directory_path() / "rawio_tests";
+    std::ostringstream oss;
+    std::filesystem::create_directory(path);
+    oss << path.string() << "/open_close.test";
+    std::string filename = oss.str();
+
+    std::unique_ptr<rawio::Queue> queue = rawio::Queue::create(1);
+
+    int fd = -1;
+    queue->open(
+        filename.c_str(), O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR,
+        [&fd](int result) { fd = result; }
+    );
+    EXPECT_EQ(fd, -1);
+    queue->wait();
+    EXPECT_GT(fd, 0);
+
+    queue->close(fd, [&fd](int result) { fd = result; });
+    EXPECT_GT(fd, 0);
+    queue->wait();
+    EXPECT_EQ(fd, 0);
 }
 
 } // unnamed namespace


### PR DESCRIPTION
This pull request extends the `rawio` library by adding support for asynchronous file open and close operations. By introducing an `EventEval` class, the library can now queue and execute these operations asynchronously, consistent with the existing poll-based event system. This change improves the library's capability to handle file I/O without blocking the main execution thread.

* **Asynchronous File Operations**: Introduced asynchronous `open` and `close` operations to the `Queue` interface, enabling non-blocking file system interactions.
* **Event Evaluation Mechanism**: Implemented `EventEval` to handle deferred execution of synchronous system calls within the asynchronous queue architecture.
* **Testing**: Added a new test case in `test_basics.cpp` to verify the functionality of the newly added asynchronous open and close operations.

(cherry picked from commit f0443b0c292495c40401e2af7694926808704a93)

Conflicts:
	librawio/include/rawio/queue.hpp