### PR TITLE
add: retry connect interruptions (#411)

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -84,7 +84,7 @@ std::vector<std::shared_ptr<Session>> Connection::_open(
             }
 
             break;
-        } catch (const std::system_error& e) {
+        } catch (const std::exception& e) {
             if (attempt != rawstor_opts_io_attempts()) {
                 rawstd_warning(
                     "Open session failed; error: %s; "

--- a/src/ost_session.cpp
+++ b/src/ost_session.cpp
@@ -17,6 +17,8 @@
 
 #include <arpa/inet.h>
 
+#include <poll.h>
+
 #include <algorithm>
 #include <iterator>
 #include <memory>
@@ -662,8 +664,62 @@ int Session::_connect() {
         rawstd_info(
             "fd %d: Connecting to %s...\n", fd, location().str().c_str()
         );
-        if (connect(fd, (sockaddr*)&servaddr, sizeof(servaddr)) == -1) {
-            RAWSTD_THROW_ERRNO();
+        int res = connect(fd, (sockaddr*)&servaddr, sizeof(servaddr));
+        if (res == -1) {
+            if (errno == EINTR) {
+                errno = 0;
+
+                pollfd fds = {
+                    .fd = fd,
+                    .events = POLLOUT,
+                    .revents = 0,
+                };
+                rawstd_warning("Connect interrupted; polling...\n");
+                for (unsigned int attempt = 1;
+                     attempt <= rawstor_opts_io_attempts(); ++attempt) {
+                    try {
+                        res = poll(&fds, 1, so_sndtimeo);
+                        if (res == -1) {
+                            RAWSTD_THROW_ERRNO();
+                        }
+                        if (res == 0) {
+                            RAWSTD_THROW_SYSTEM_ERROR(ETIMEDOUT);
+                        }
+                        break;
+                    } catch (const std::exception& e) {
+                        if (attempt != rawstor_opts_io_attempts()) {
+                            rawstd_warning(
+                                "Poll failed; error: %s; "
+                                "attempt: %d of %d; retrying...\n",
+                                e.what(), attempt, rawstor_opts_io_attempts()
+                            );
+                        } else {
+                            rawstd_warning(
+                                "Poll failed; error: %s; "
+                                "attempt: %d of %d; failing...\n",
+                                e.what(), attempt, rawstor_opts_io_attempts()
+                            );
+                            throw;
+                        }
+                    }
+                }
+
+                int value = 0;
+                socklen_t value_len = sizeof(value);
+                res = getsockopt(fd, SOL_SOCKET, SO_ERROR, &value, &value_len);
+                if (res == -1) {
+                    RAWSTD_THROW_ERRNO();
+                }
+                if (value) {
+                    RAWSTD_THROW_SYSTEM_ERROR(value);
+                }
+
+                if (!(fds.revents & POLLOUT)) {
+                    RAWSTD_THROW_SYSTEM_ERROR(ENOTCONN);
+                }
+            } else {
+                RAWSTD_THROW_ERRNO();
+            }
         }
         rawstd_info("fd %d: Connected\n", fd);
 


### PR DESCRIPTION
This pull request introduces a mechanism to handle interrupted system calls during socket connections. By detecting 'EINTR' errors, the code now enters a polling state to wait for the connection to complete asynchronously, rather than failing immediately. This improves the reliability of network operations in environments where signals may frequently interrupt system calls.

### Highlights

* **Connection Interruption Handling**: Implemented robust handling for 'EINTR' signals during socket connection attempts by utilizing 'poll' to wait for the socket to become writable.
* **Error Propagation**: Updated exception handling to catch 'std::exception' instead of 'std::system_error' to ensure broader and more reliable error catching during connection retries.
* **Connection Validation**: Added 'getsockopt' checks after polling to verify the actual connection status and ensure that any underlying socket errors are correctly identified and propagated.

(cherry picked from commit ae26780da0bc93e668dd0271415222f0ef7ecca3)