### PR TITLE
add: better poll and accept callback signature (#410)

### DIFF
--- a/librawio/include/rawio/queue.hpp
+++ b/librawio/include/rawio/queue.hpp
@@ -41,19 +41,18 @@ public:
     virtual Event* close(int fd, std::function<void(int)>&& cb) = 0;
 
     virtual Event*
-    poll(int fd, unsigned int mask, std::function<void(size_t, int)>&& cb) = 0;
+    poll(int fd, unsigned int mask, std::function<void(int)>&& cb) = 0;
 
     virtual Event* poll_multishot(
-        int fd, unsigned int mask, std::function<void(size_t, int)>&& cb
+        int fd, unsigned int mask, std::function<void(int)>&& cb
     ) = 0;
 
     virtual Event* accept(
         int fd, sockaddr* addr, socklen_t* addrlen,
-        std::function<void(size_t, int)>&& cb
+        std::function<void(int)>&& cb
     ) = 0;
 
-    virtual Event*
-    accept_multishot(int fd, std::function<void(size_t, int)>&& cb) = 0;
+    virtual Event* accept_multishot(int fd, std::function<void(int)>&& cb) = 0;
 
     virtual Event* read(
         int fd, void* buf, size_t size, std::function<void(size_t, int)>&& cb

--- a/librawio/src/poll_event.cpp
+++ b/librawio/src/poll_event.cpp
@@ -105,11 +105,19 @@ ssize_t EventSimplexPoll::process() noexcept {
 }
 
 void EventSimplexPollOneshot::dispatch() {
-    ::dispatch(trace_event, _cb, _result, _error);
+    if (!_error) {
+        ::dispatch(trace_event, _cb, _result);
+    } else {
+        ::dispatch(trace_event, _cb, -_error);
+    }
 }
 
 void EventSimplexPollMultishot::dispatch() {
-    ::dispatch(trace_event, _cb, _result, _error);
+    if (!_error) {
+        ::dispatch(trace_event, _cb, _result);
+    } else {
+        ::dispatch(trace_event, _cb, -_error);
+    }
     _result = 0;
 }
 
@@ -148,7 +156,11 @@ ssize_t EventSimplexAcceptOneshot::process() noexcept {
 }
 
 void EventSimplexAcceptOneshot::dispatch() {
-    ::dispatch(trace_event, _cb, _result, _error);
+    if (!_error) {
+        ::dispatch(trace_event, _cb, _result);
+    } else {
+        ::dispatch(trace_event, _cb, -_error);
+    }
 }
 
 ssize_t EventSimplexAcceptMultishot::process() noexcept {
@@ -186,7 +198,11 @@ ssize_t EventSimplexAcceptMultishot::process() noexcept {
 }
 
 void EventSimplexAcceptMultishot::dispatch() {
-    ::dispatch(trace_event, _cb, _result, _error);
+    if (!_error) {
+        ::dispatch(trace_event, _cb, _result);
+    } else {
+        ::dispatch(trace_event, _cb, -_error);
+    }
     _result = 0;
 }
 

--- a/librawio/src/poll_event.hpp
+++ b/librawio/src/poll_event.hpp
@@ -227,13 +227,12 @@ public:
 
 class EventSimplexPollOneshot final : public EventSimplexPoll {
 private:
-    std::function<void(size_t, int)> _cb;
+    std::function<void(int)> _cb;
 
 public:
     EventSimplexPollOneshot(
         Queue& q, int fd, unsigned int mask,
-        const rawstd::TraceEvent& trace_event,
-        std::function<void(size_t, int)>&& cb
+        const rawstd::TraceEvent& trace_event, std::function<void(int)>&& cb
     ) :
         EventSimplexPoll(q, fd, mask, trace_event),
         _cb(std::move(cb)) {}
@@ -243,13 +242,12 @@ public:
 
 class EventSimplexPollMultishot final : public EventSimplexPoll {
 private:
-    std::function<void(size_t, int)> _cb;
+    std::function<void(int)> _cb;
 
 public:
     EventSimplexPollMultishot(
         Queue& q, int fd, unsigned int mask,
-        const rawstd::TraceEvent& trace_event,
-        std::function<void(size_t, int)>&& cb
+        const rawstd::TraceEvent& trace_event, std::function<void(int)>&& cb
     ) :
         EventSimplexPoll(q, fd, mask, trace_event),
         _cb(std::move(cb)) {}
@@ -281,13 +279,12 @@ class EventSimplexAcceptOneshot final : public EventSimplexAccept {
 private:
     sockaddr* _addr;
     socklen_t* _addrlen;
-    std::function<void(size_t, int)> _cb;
+    std::function<void(int)> _cb;
 
 public:
     EventSimplexAcceptOneshot(
         Queue& q, int fd, sockaddr* addr, socklen_t* addrlen,
-        const rawstd::TraceEvent& trace_event,
-        std::function<void(size_t, int)>&& cb
+        const rawstd::TraceEvent& trace_event, std::function<void(int)>&& cb
     ) :
         EventSimplexAccept(q, fd, trace_event),
         _addr(addr),
@@ -303,12 +300,12 @@ public:
 
 class EventSimplexAcceptMultishot final : public EventSimplexAccept {
 private:
-    std::function<void(size_t, int)> _cb;
+    std::function<void(int)> _cb;
 
 public:
     EventSimplexAcceptMultishot(
         Queue& q, int fd, const rawstd::TraceEvent& trace_event,
-        std::function<void(size_t, int)>&& cb
+        std::function<void(int)>&& cb
     ) :
         EventSimplexAccept(q, fd, trace_event),
         _cb(std::move(cb)) {}

--- a/librawio/src/poll_queue.cpp
+++ b/librawio/src/poll_queue.cpp
@@ -205,7 +205,7 @@ rawio::Event* Queue::close(int fd, std::function<void(int)>&& cb) {
 }
 
 rawio::Event*
-Queue::poll(int fd, unsigned int mask, std::function<void(size_t, int)>&& cb) {
+Queue::poll(int fd, unsigned int mask, std::function<void(int)>&& cb) {
     rawstd::TraceEvent trace_event =
         RAWSTD_TRACE_EVENT('|', "fd = %d, mask = %u\n", fd, mask);
     Session& s = _get_session(fd);
@@ -221,7 +221,7 @@ Queue::poll(int fd, unsigned int mask, std::function<void(size_t, int)>&& cb) {
 }
 
 rawio::Event* Queue::poll_multishot(
-    int fd, unsigned int mask, std::function<void(size_t, int)>&& cb
+    int fd, unsigned int mask, std::function<void(int)>&& cb
 ) {
     rawstd::TraceEvent trace_event =
         RAWSTD_TRACE_EVENT('|', "fd = %d, mask = %u\n", fd, mask);
@@ -238,8 +238,7 @@ rawio::Event* Queue::poll_multishot(
 }
 
 rawio::Event* Queue::accept(
-    int fd, sockaddr* addr, socklen_t* addrlen,
-    std::function<void(size_t, int)>&& cb
+    int fd, sockaddr* addr, socklen_t* addrlen, std::function<void(int)>&& cb
 ) {
     rawstd::TraceEvent trace_event = RAWSTD_TRACE_EVENT('|', "fd = %d\n", fd);
     Session& s = _get_session(fd);
@@ -254,8 +253,7 @@ rawio::Event* Queue::accept(
     return ret;
 }
 
-rawio::Event*
-Queue::accept_multishot(int fd, std::function<void(size_t, int)>&& cb) {
+rawio::Event* Queue::accept_multishot(int fd, std::function<void(int)>&& cb) {
     rawstd::TraceEvent trace_event = RAWSTD_TRACE_EVENT('|', "fd = %d\n", fd);
     Session& s = _get_session(fd);
 

--- a/librawio/src/poll_queue.hpp
+++ b/librawio/src/poll_queue.hpp
@@ -42,21 +42,20 @@ public:
 
     rawio::Event* close(int fd, std::function<void(int)>&& cb) override;
 
-    rawio::Event* poll(
-        int fd, unsigned int mask, std::function<void(size_t, int)>&& cb
-    ) override;
+    rawio::Event*
+    poll(int fd, unsigned int mask, std::function<void(int)>&& cb) override;
 
     rawio::Event* poll_multishot(
-        int fd, unsigned int mask, std::function<void(size_t, int)>&& cb
+        int fd, unsigned int mask, std::function<void(int)>&& cb
     ) override;
 
     rawio::Event* accept(
         int fd, sockaddr* addr, socklen_t* addrlen,
-        std::function<void(size_t, int)>&& cb
+        std::function<void(int)>&& cb
     ) override;
 
     rawio::Event*
-    accept_multishot(int fd, std::function<void(size_t, int)>&& cb) override;
+    accept_multishot(int fd, std::function<void(int)>&& cb) override;
 
     rawio::Event* read(
         int fd, void* buf, size_t size, std::function<void(size_t, int)>&& cb

--- a/librawio/src/uring_queue.cpp
+++ b/librawio/src/uring_queue.cpp
@@ -206,7 +206,7 @@ rawio::Event* Queue::close(int fd, std::function<void(int)>&& cb) {
 }
 
 rawio::Event*
-Queue::poll(int fd, unsigned int mask, std::function<void(size_t, int)>&& cb) {
+Queue::poll(int fd, unsigned int mask, std::function<void(int)>&& cb) {
     rawstd::TraceEvent trace_event =
         RAWSTD_TRACE_EVENT('|', "fd = %d, mask = %u\n", fd, mask);
     io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
@@ -220,7 +220,11 @@ Queue::poll(int fd, unsigned int mask, std::function<void(size_t, int)>&& cb) {
                 RAWSTD_TRACE_EVENT_MESSAGE(
                     trace_event, "result = %zu, error = %d\n", result, error
                 );
-                cb(result, error);
+                if (!error) {
+                    cb(result);
+                } else {
+                    cb(-error);
+                }
             }
         );
     io_uring_prep_poll_add(sqe, fd, mask);
@@ -231,7 +235,7 @@ Queue::poll(int fd, unsigned int mask, std::function<void(size_t, int)>&& cb) {
 }
 
 rawio::Event* Queue::poll_multishot(
-    int fd, unsigned int mask, std::function<void(size_t, int)>&& cb
+    int fd, unsigned int mask, std::function<void(int)>&& cb
 ) {
     rawstd::TraceEvent trace_event =
         RAWSTD_TRACE_EVENT('|', "fd = %d, mask = %u\n", fd, mask);
@@ -247,7 +251,11 @@ rawio::Event* Queue::poll_multishot(
                 RAWSTD_TRACE_EVENT_MESSAGE(
                     trace_event, "result = %zu, error = %d\n", result, error
                 );
-                cb(result, error);
+                if (!error) {
+                    cb(result);
+                } else {
+                    cb(-error);
+                }
             }
         );
     io_uring_sqe_set_data(sqe, p.get());
@@ -256,8 +264,7 @@ rawio::Event* Queue::poll_multishot(
 }
 
 rawio::Event* Queue::accept(
-    int fd, sockaddr* addr, socklen_t* addrlen,
-    std::function<void(size_t, int)>&& cb
+    int fd, sockaddr* addr, socklen_t* addrlen, std::function<void(int)>&& cb
 ) {
     rawstd::TraceEvent trace_event = RAWSTD_TRACE_EVENT('|', "fd = %d\n", fd);
     io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
@@ -295,7 +302,11 @@ rawio::Event* Queue::accept(
                         error = EIO;
                     }
                 }
-                cb(result, error);
+                if (!error) {
+                    cb(result);
+                } else {
+                    cb(-error);
+                }
             }
         );
     io_uring_prep_accept(sqe, fd, addr, addrlen, 0);
@@ -305,8 +316,7 @@ rawio::Event* Queue::accept(
     return static_cast<rawio::Event*>(p.release());
 }
 
-rawio::Event*
-Queue::accept_multishot(int fd, std::function<void(size_t, int)>&& cb) {
+rawio::Event* Queue::accept_multishot(int fd, std::function<void(int)>&& cb) {
     rawstd::TraceEvent trace_event = RAWSTD_TRACE_EVENT('|', "fd = %d\n", fd);
     io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
     if (sqe == nullptr) {
@@ -344,7 +354,11 @@ Queue::accept_multishot(int fd, std::function<void(size_t, int)>&& cb) {
                         error = EIO;
                     }
                 }
-                cb(result, error);
+                if (!error) {
+                    cb(result);
+                } else {
+                    cb(-error);
+                }
             }
         );
     io_uring_sqe_set_data(sqe, p.get());

--- a/librawio/src/uring_queue.hpp
+++ b/librawio/src/uring_queue.hpp
@@ -31,21 +31,20 @@ public:
 
     rawio::Event* close(int fd, std::function<void(int)>&& cb);
 
-    rawio::Event* poll(
-        int fd, unsigned int mask, std::function<void(size_t, int)>&& cb
-    ) override;
+    rawio::Event*
+    poll(int fd, unsigned int mask, std::function<void(int)>&& cb) override;
 
     rawio::Event* poll_multishot(
-        int fd, unsigned int mask, std::function<void(size_t, int)>&& cb
+        int fd, unsigned int mask, std::function<void(int)>&& cb
     ) override;
 
     rawio::Event* accept(
         int fd, sockaddr* addr, socklen_t* addrlen,
-        std::function<void(size_t, int)>&& cb
+        std::function<void(int)>&& cb
     ) override;
 
     rawio::Event*
-    accept_multishot(int fd, std::function<void(size_t, int)>&& cb) override;
+    accept_multishot(int fd, std::function<void(int)>&& cb) override;
 
     rawio::Event* read(
         int fd, void* buf, size_t size, std::function<void(size_t, int)>&& cb

--- a/librawio/tests/test_basics.cpp
+++ b/librawio/tests/test_basics.cpp
@@ -26,12 +26,8 @@ TEST_F(BasicsTest, empty) {
     _server.wait();
     EXPECT_THROW(_queue->wait_timeout(0), std::system_error);
 
-    size_t result = 0;
-    int error = 0;
-    _queue->poll(_fd, POLLIN, [&result, &error](size_t r, int e) {
-        result = r;
-        error = e;
-    });
+    int result = 0;
+    _queue->poll(_fd, POLLIN, [&result](int r) { result = r; });
 
     EXPECT_NO_THROW(_queue->wait_timeout(0));
 
@@ -43,29 +39,19 @@ TEST_F(BasicsTest, pollin) {
     _server.write(server_buf, sizeof(server_buf));
     _server.wait();
 
-    size_t result = 0;
-    int error = 0;
-    _queue->poll(_fd, POLLIN, [&result, &error](size_t r, int e) {
-        result = r;
-        error = e;
-    });
+    int result = 0;
+    _queue->poll(_fd, POLLIN, [&result](int r) { result = r; });
     _queue->wait_timeout(0);
 
-    EXPECT_EQ(result, (size_t)POLLIN);
-    EXPECT_EQ(error, 0);
+    EXPECT_EQ(result, POLLIN);
 }
 
 TEST_F(BasicsTest, pollout) {
-    size_t result = 0;
-    int error = 0;
-    _queue->poll(_fd, POLLOUT, [&result, &error](size_t r, int e) {
-        result = r;
-        error = e;
-    });
+    int result = 0;
+    _queue->poll(_fd, POLLOUT, [&result](int r) { result = r; });
     _queue->wait_timeout(0);
 
-    EXPECT_EQ(result, (size_t)POLLOUT);
-    EXPECT_EQ(error, 0);
+    EXPECT_EQ(result, POLLOUT);
 }
 
 TEST_F(BasicsTest, accept) {
@@ -88,19 +74,13 @@ TEST_F(BasicsTest, accept) {
     );
     _server.wait();
 
-    size_t result = 0;
-    int error = 0;
-    _queue->accept(
-        client_socket.fd(), nullptr, nullptr,
-        [&result, &error](size_t r, int e) {
-            result = r;
-            error = e;
-        }
-    );
+    int result = -1;
+    _queue->accept(client_socket.fd(), nullptr, nullptr, [&result](int r) {
+        result = r;
+    });
 
     EXPECT_NO_THROW(_queue->wait_timeout(0));
-    EXPECT_GT(result, (size_t)0);
-    EXPECT_EQ(error, 0);
+    EXPECT_GE(result, 0);
 }
 
 TEST_F(BasicsTest, read) {

--- a/librawio/tests/test_cancel.cpp
+++ b/librawio/tests/test_cancel.cpp
@@ -21,13 +21,9 @@ TEST_F(CancelTest, cancel_noent) {
 }
 
 TEST_F(CancelTest, poll) {
-    size_t result = 0;
-    int error = 0;
+    int result = 0;
     rawio::Event* event =
-        _queue->poll(_fd, POLLIN, [&result, &error](size_t r, int e) {
-            result = r;
-            error = e;
-        });
+        _queue->poll(_fd, POLLIN, [&result](int r) { result = r; });
 
     EXPECT_THROW(_queue->wait_timeout(0), std::system_error);
 
@@ -36,8 +32,7 @@ TEST_F(CancelTest, poll) {
     EXPECT_NO_THROW(_queue->wait_timeout(0));
     EXPECT_THROW(_queue->wait_timeout(0), std::system_error);
 
-    EXPECT_EQ(result, (size_t)0);
-    EXPECT_EQ(error, ECANCELED);
+    EXPECT_EQ(result, -ECANCELED);
 }
 
 TEST_F(CancelTest, poll_completed) {
@@ -45,19 +40,14 @@ TEST_F(CancelTest, poll_completed) {
     _server.write(server_buf, sizeof(server_buf));
     _server.wait();
 
-    size_t result = 0;
-    int error = 0;
+    int result = 0;
     rawio::Event* event =
-        _queue->poll(_fd, POLLIN, [&result, &error](size_t r, int e) {
-            result = r;
-            error = e;
-        });
+        _queue->poll(_fd, POLLIN, [&result](int r) { result = r; });
 
     _queue->wait_timeout(0);
 
     EXPECT_THROW(_queue->cancel(event), std::system_error);
-    EXPECT_EQ(result, (size_t)POLLIN);
-    EXPECT_EQ(error, 0);
+    EXPECT_EQ(result, POLLIN);
 }
 
 TEST_F(CancelTest, read) {
@@ -158,12 +148,8 @@ TEST_F(CancelTest, write_completed) {
 }
 
 TEST_F(CancelTest, cancel_all) {
-    size_t result_poll = 0;
-    int error_poll = 0;
-    _queue->poll(_fd, POLLIN, [&result_poll, &error_poll](size_t r, int e) {
-        result_poll = r;
-        error_poll = e;
-    });
+    int result_poll = 0;
+    _queue->poll(_fd, POLLIN, [&result_poll](int r) { result_poll = r; });
 
     char client_buf_read[10];
     size_t result_read = 0;
@@ -191,8 +177,7 @@ TEST_F(CancelTest, cancel_all) {
 
     EXPECT_NO_THROW(_wait_all());
 
-    EXPECT_EQ(result_poll, (size_t)0);
-    EXPECT_EQ(error_poll, ECANCELED);
+    EXPECT_EQ(result_poll, -ECANCELED);
     EXPECT_EQ(result_read, (size_t)0);
     EXPECT_EQ(error_read, ECANCELED);
 #ifndef RAWIO_WITH_LIBURING

--- a/librawio/tests/test_multishot.cpp
+++ b/librawio/tests/test_multishot.cpp
@@ -46,39 +46,31 @@ TEST_F(MultishotTest, poll) {
     _server.write(server_buf, sizeof(server_buf));
     _server.wait();
 
-    size_t result = 0;
-    int error = 0;
+    int result = 0;
     unsigned int count = 0;
-    rawio::Event* event = _queue->poll_multishot(
-        _fd, POLLIN, [&result, &error, &count](size_t r, int e) {
+    rawio::Event* event =
+        _queue->poll_multishot(_fd, POLLIN, [&result, &count](int r) {
             result = r;
-            error = e;
             ++count;
-        }
-    );
+        });
 
     EXPECT_NO_THROW(_queue->wait_timeout(0));
-    EXPECT_EQ(result, (size_t)POLLIN);
-    EXPECT_EQ(error, 0);
+    EXPECT_EQ(result, POLLIN);
     EXPECT_EQ(count, 1u);
 
     _server.write(server_buf, sizeof(server_buf));
     _server.wait();
 
     result = 0;
-    error = 0;
     EXPECT_NO_THROW(_queue->wait_timeout(0));
-    EXPECT_EQ(result, (size_t)POLLIN);
-    EXPECT_EQ(error, 0);
+    EXPECT_EQ(result, POLLIN);
     EXPECT_EQ(count, 2u);
 
     EXPECT_NO_THROW(_queue->cancel(event));
 
     result = 0;
-    error = 0;
     EXPECT_NO_THROW(_queue->wait_timeout(0));
-    EXPECT_EQ(result, (size_t)0);
-    EXPECT_EQ(error, ECANCELED);
+    EXPECT_EQ(result, -ECANCELED);
     EXPECT_EQ(count, 3u);
 }
 
@@ -103,20 +95,16 @@ TEST_F(MultishotTest, accept) {
     );
     _server.wait();
 
-    size_t result = 0;
-    int error = 0;
+    int result = 0;
     unsigned int count = 0;
-    rawio::Event* event = _queue->accept_multishot(
-        client_socket.fd(), [&result, &error, &count](size_t r, int e) {
+    rawio::Event* event =
+        _queue->accept_multishot(client_socket.fd(), [&result, &count](int r) {
             result = r;
-            error = e;
             ++count;
-        }
-    );
+        });
 
     EXPECT_NO_THROW(_queue->wait_timeout(0));
-    EXPECT_GT(result, (size_t)0);
-    EXPECT_EQ(error, 0);
+    EXPECT_GT(result, 0);
     EXPECT_EQ(count, 1u);
 
     _server.connect(
@@ -125,19 +113,15 @@ TEST_F(MultishotTest, accept) {
     _server.wait();
 
     result = 0;
-    error = 0;
     EXPECT_NO_THROW(_queue->wait_timeout(0));
-    EXPECT_GT(result, (size_t)0);
-    EXPECT_EQ(error, 0);
+    EXPECT_GT(result, 0);
     EXPECT_EQ(count, 2u);
 
     EXPECT_NO_THROW(_queue->cancel(event));
 
     result = 0;
-    error = 0;
     EXPECT_NO_THROW(_queue->wait_timeout(0));
-    EXPECT_EQ(result, (size_t)0);
-    EXPECT_EQ(error, ECANCELED);
+    EXPECT_EQ(result, -ECANCELED);
     EXPECT_EQ(count, 3u);
 }
 

--- a/librawio/tests/test_pollhup.cpp
+++ b/librawio/tests/test_pollhup.cpp
@@ -18,33 +18,23 @@ TEST_F(PollHupTest, pollin) {
     _server.close();
     _server.wait();
 
-    size_t result = 0;
-    int error = 0;
-    _queue->poll(_fd, POLLIN, [&result, &error](size_t r, int e) {
-        result = r;
-        error = e;
-    });
+    int result = 0;
+    _queue->poll(_fd, POLLIN, [&result](int r) { result = r; });
     _queue->wait_timeout(0);
 
     EXPECT_TRUE(result & POLLIN);
     EXPECT_TRUE(result & POLLHUP);
-    EXPECT_EQ(error, 0);
 }
 
 TEST_F(PollHupTest, pollout) {
     _server.close();
     _server.wait();
 
-    size_t result = 0;
-    int error = 0;
-    _queue->poll(_fd, POLLOUT, [&result, &error](size_t r, int e) {
-        result = r;
-        error = e;
-    });
+    int result = 0;
+    _queue->poll(_fd, POLLOUT, [&result](int r) { result = r; });
     _queue->wait_timeout(0);
 
     EXPECT_TRUE(result & POLLHUP);
-    EXPECT_EQ(error, 0);
 }
 
 TEST_F(PollHupTest, read) {

--- a/src/rawstor.cpp
+++ b/src/rawstor.cpp
@@ -126,8 +126,13 @@ int rawstor_fd_poll(
     int fd, unsigned int mask, RawstorIOCallback* cb, void* data
 ) noexcept {
     try {
-        rawstor::io_queue->poll(fd, mask, [cb, data](size_t result, int error) {
-            int res = cb(result, error, data);
+        rawstor::io_queue->poll(fd, mask, [cb, data](int result) {
+            int res;
+            if (result >= 0) {
+                res = cb(result, 0, data);
+            } else {
+                res = cb(0, -result, data);
+            }
             if (res) {
                 RAWSTD_THROW_SYSTEM_ERROR(-res);
             }


### PR DESCRIPTION
This pull request standardizes the callback signatures for poll and accept operations within the library. By consolidating the result and error parameters into a single integer return value, the codebase achieves a more streamlined and idiomatic API. The changes propagate through the core queue logic, internal event dispatchers, and the test suite, ensuring consistent error handling and improved maintainability.

* **Refactored Callback Signatures**: Updated poll and accept callback signatures across the library to use a single integer result parameter instead of separate result and error parameters, simplifying the interface.
* **Error Handling Update**: Modified internal dispatch logic to handle negative result values as errors, ensuring consistent error propagation throughout the IO queue implementations.
* **Test Suite Adjustments**: Updated all relevant unit tests to align with the new callback signature, simplifying result checking and error verification.

(cherry picked from commit 553dd55e8b7a95948d78b0e165266ac903e76a48)

Conflicts:
	librawio/src/rawio.cpp
	tests/server.cpp