### PR TITLE
fix: initialize uuid in tests (#444)

### DIFF
--- a/librawstd/tests/test_uuid.cpp
+++ b/librawstd/tests/test_uuid.cpp
@@ -34,7 +34,7 @@ TEST(UUIDTest, counter) {
 
 TEST(UUIDTest, version) {
     for (int version = 0; version < 16; ++version) {
-        RawstdUUID uuid;
+        RawstdUUID uuid = {};
         rawstd_uuid_set_version(&uuid, version);
         EXPECT_EQ(rawstd_uuid_get_version(&uuid), version);
     }
@@ -42,7 +42,7 @@ TEST(UUIDTest, version) {
 
 TEST(UUIDTest, variant) {
     for (int variant = 0; variant < 4; ++variant) {
-        RawstdUUID uuid;
+        RawstdUUID uuid = {};
         rawstd_uuid_set_variant(&uuid, variant);
         EXPECT_EQ(rawstd_uuid_get_variant(&uuid), variant);
     }


### PR DESCRIPTION
This pull request addresses potential undefined behavior in the librawstd test suite by ensuring that RawstdUUID structures are properly initialized before being passed to setter functions. This change prevents the use of uninitialized memory during unit testing.

### Highlights

* **Test Initialization**: Updated RawstdUUID instances in test cases to use aggregate initialization, ensuring memory is zero-initialized before use.

(cherry picked from commit b0cf1023d3f20339d6442b64651522622978b9d3)