### PR TITLE
add: async object create, remove and spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,198 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Layout
+
+This repository is the main project of a three-repo workspace; the two forks live in sibling directories:
+
+| Directory | Description |
+|-----------|-------------|
+| `.` (this repo) | librawstor — async I/O library, OST server, vhost-user backend |
+| `../fio/` | Fork of Jens Axboe's fio with a custom `librawstor` engine |
+| `../qemu/` | Fork of QEMU with a native rawstor block driver |
+
+---
+
+## librawstor
+
+### Build
+
+```bash
+./autogen.sh
+./configure --prefix=${HOME}/local
+make -j$(nproc)
+make install
+```
+
+Key `./configure` flags:
+
+| Flag | Effect |
+|------|--------|
+| `--enable-debug` | Enable DEBUG-level logging |
+| `--enable-trace` | Enable TRACE-level logging |
+| `--enable-asan` | Enable AddressSanitizer |
+| `--without-liburing` | Fall back to poll-based I/O (no io_uring) |
+| `--without-libxxhash` | Disable xxhash support |
+| `--without-python3` | Skip python bindings (`pyrawstor/`) — needed on PEP 668 distros where pip refuses to install into the system python |
+| `--disable-tests` | Skip building test binaries |
+
+Required system packages: `libxxhash-dev libgtest-dev liburing-dev`
+
+### Tests
+
+```bash
+make test          # run all tests (librawstd + librawio + integration tests)
+make -C librawstd test
+make -C librawio test
+make -C tests test
+```
+
+CI runs tests with `--enable-asan` and sets `ASAN_OPTIONS=detect_odr_violation=0`.
+
+If `io_uring_setup()` fails with `EPERM`, check `sysctl kernel.io_uring_disabled` — it must be `0`.
+
+### Architecture
+
+```
+librawstd/     utilities: hash, list, mempool, URI, UUID, socket, threading, logging
+librawio/      async I/O queue abstraction — io_uring (default) or poll backend
+src/           librawstor.so — public C API, connection/session management
+include/       public headers (rawstor.h, rawstor/{rawstor,object,rawio,protocol,version}.h)
+cli/           rawstor-cli (create, remove, show, testio subcommands)
+ost/           rawstor-ost — OST protocol server
+vhost/         rawstor-vhost — vhost-user virtio block device backend for QEMU
+pyrawstor/     python bindings
+tests/         integration tests
+deb/ rpm/      packaging
+```
+
+**Layer dependencies:** `src/` links against `librawio` + `librawstd`; `ost/` and `vhost/` link against `src/`.
+
+### Storage backends (Session drivers)
+
+The storage backend is selected by the URI scheme in `--location`. All backends implement the `rawstor::Session` abstract class (`src/session.hpp`). The factory is in `src/session.cpp`.
+
+| Scheme | Class | Backing store | Object identity |
+|--------|-------|---------------|-----------------|
+| `file://` | `rawstor::file::Session` | `<path>/<uuid>.dat` + `<path>/<uuid>.spec` | files |
+| `lvm://` | `rawstor::lvm::Session` | LV named `<uuid>` in a VG | block device `/dev/<vg>/<uuid>` |
+| `zfs://` | `rawstor::zfs::Session` | zvol `<parent_dataset>/<uuid>` | block device `/dev/zvol/<parent_dataset>/<uuid>` |
+| `ost://` | `rawstor::ost::Session` | remote OST server | forwarded via OST protocol |
+
+`lvm::Session` and `zfs::Session` share a common base `rawstor::BlkdevSession` (`src/blkdev_session.{hpp,cpp}`) which implements `spec` (via `ioctl BLKGETSIZE64`), `set_object` (open block device), and all pread/pwrite methods. Subclasses only implement `create`/`remove` (via `lvcreate`/`lvremove` and `zfs create`/`zfs destroy` respectively). The commands are spawned with `posix_spawnp` and their exit is observed by polling a pidfd on the I/O queue; after `create`, the device node is awaited on a timerfd (bounded by the `wait_device_timeout` option). `spec` for blkdev backends reports the actual device size (LVM rounds up to the VG extent size; ZFS rounds up to volblocksize).
+
+**URI examples:**
+```
+file:///var/rawstor          → objects at /var/rawstor/<uuid>.dat
+lvm:///dev/rawstor_vg        → objects as LVs in VG rawstor_vg
+zfs:///tank/rawstor          → objects as zvols at tank/rawstor/<uuid>
+ost://127.0.0.1:9090         → remote OST server
+```
+
+LVM and ZFS backends require `lvcreate`/`lvremove`/`zfs` in PATH and appropriate privileges (root or capability delegation). The whole control plane (`create`/`remove`/`spec`/`connect`/`set_object`) and the hot I/O path (pread/pwrite) are async: blkdev commands run via `posix_spawnp` + pidfd, the file backend control plane runs in a detached worker thread (`src/worker.{hpp,cpp}`) that reports back through a pipe on the queue.
+
+### Public API
+
+The C public API is in `include/rawstor/rawstor.h`. Key entry points:
+
+- `rawstor_initialize(opts)` / `rawstor_terminate()` — lib lifecycle (call once per process/worker)
+- `rawstor_wait()` — drive the I/O completion loop (block until at least one event fires)
+- `rawstor_fd_*` — async fd operations (read, write, send, recv, poll, accept — single-shot and multishot variants)
+- `rawstor_fd_cancel(event)` / `rawstor_fd_cancel_all(fd)` — cancel in-flight operations
+- `rawstor_object_open/close/pread/pwrite/spec` — object-level block I/O
+- `rawstor_object_{create,remove,spec,open}_async` — non-blocking control-plane variants driven by a caller-supplied `RawIOQueue`; completion is delivered via callback
+
+All async functions complete via callbacks (`RawstorIOCallback`). Callbacks run from an I/O completion context — avoid blocking inside them.
+
+Every `RawstorOpts` field (`io_attempts`, `sessions`, `so_sndtimeo`, `so_rcvtimeo`, `tcp_user_timeout`, `wait_device_timeout`) can also be set via an environment variable of the same name: `RAWSTOR_OPTS_<FIELD>` (e.g. `RAWSTOR_OPTS_IO_ATTEMPTS=5`).
+
+### Locations and Targets
+
+- **Location** — backend address: `file:///path/to/dir` or `ost://host:port`
+- **Target** — location + UUID: `ost://host:port/<uuid>` or `file:///path/<uuid>`
+- Comma-separated lists activate **mirroring** (two `ost://`) or **data locality** (mixed `file://` + `ost://`)
+
+### Code Style
+
+C code: `std=gnu99`, C++ code: `std=c++20`. Both compile with `-Wall -Wextra -Werror`.
+
+clang-format is LLVM-based with 4-space indent and left pointer alignment. Run formatting via `.github/tools/clang-format.sh`.
+
+Branch naming convention: `add/<feature>`, `fix/<bug>`, `ref/<component>`.
+
+---
+
+## fio (librawstor engine)
+
+### Build
+
+fio auto-detects librawstor via `pkg-config`. Install librawstor first, then:
+
+```bash
+cd ../fio
+./configure          # detects librawstor; use --disable-librawstor to skip
+make -j$(nproc)
+```
+
+### Running the librawstor engine
+
+The custom engine lives in `../fio/engines/librawstor.c`. Use `--ioengine=librawstor` and pass a rawstor target URI as `--filename`:
+
+```bash
+fio --ioengine=librawstor \
+    --filename="ost://127.0.0.1:8080/<uuid>" \
+    --name=randread --rw=randread --bs=4k --iodepth=32 --size=1G
+```
+
+Colons in the target URI must be escaped as `\:` in fio job files (the `.github/tools/fio.sh` helper handles this automatically).
+
+The engine is async (`FIO_ASYNCIO_SETS_ISSUE_TIME`). It calls `rawstor_initialize(NULL)` on first file open and `rawstor_terminate()` when all files are closed. The engine sizes its `RawIOQueue` to fio's `--iodepth`.
+
+---
+
+## qemu (native block driver)
+
+`../qemu` is a fork of upstream QEMU with ~20 rawstor-specific commits on top. All custom code is confined to 7 files:
+
+```
+block/rawstor.c            native rawstor block driver
+block/meson.build          +1 line to wire in block/rawstor.c
+meson.build                librawstor detection via cc.find_library()
+meson_options.txt          --rawstor feature option (auto/enabled/disabled)
+qapi/block-core.json       BlockdevOptionsRawstor, BlockdevCreateOptionsRawstor
+scripts/meson-buildoptions.sh  --enable/disable-rawstor passthrough
+README.md                  build instructions
+```
+
+### Build
+
+Requires librawstor installed first. Out-of-tree build:
+
+```bash
+export PKG_CONFIG_PATH=${HOME}/local/lib/pkgconfig
+mkdir ../qemu/build && cd ../qemu/build
+../configure \
+    --extra-cflags="$(pkg-config --cflags rawstor)" \
+    --extra-ldflags="$(pkg-config --libs rawstor)"
+make -j$(nproc)
+```
+
+The rawstor feature is auto-detected; force it with `-Drawstor=enabled` (meson) or `--enable-rawstor` (configure wrapper).
+
+### Block driver design
+
+`block/rawstor.c` registers the `rawstor` protocol driver. Key design points:
+
+- **Thread model:** A dedicated `rawstor_thread` runs the librawstor event loop (`rawstor_wait()`) in a separate thread. QEMU coroutines communicate with it by writing a `RawstorTask*` pointer over a `pipe()`. The rawstor completion callback schedules a bottom-half (`aio_bh_schedule_oneshot`) back on the QEMU AIO context to wake the coroutine.
+- **URI syntax:** Block devices are addressed as `rawstor:object-uri=<target>` — the driver's `parse_filename` splits this key=value string. Colons inside a URI value must be escaped with `\`.
+- **Max transfer:** Hard-capped at 4096 bytes (`bdrv_refresh_limits`). This is a known limitation (no comment in code).
+- **QAPI types:** `BlockdevOptionsRawstor { object-uri: str }` and `BlockdevCreateOptionsRawstor { size, *uri }`.
+
+### Example QEMU invocation
+
+```bash
+qemu-system-x86_64 \
+    -blockdev rawstor,node-name=stor,object-uri=ost://127.0.0.1:8080/<uuid> \
+    -device virtio-blk-pci,drive=stor
+```

--- a/include/rawstor/object.h
+++ b/include/rawstor/object.h
@@ -207,6 +207,83 @@ int rawstor_object_create_at(
 int rawstor_object_remove(const char* target) RAWSTOR_NOEXCEPT;
 
 /**
+ * @brief Asynchronously retrieve metadata about a stored object.
+ *
+ * Non-blocking variant of rawstor_object_spec(). The operation is driven by
+ * @p queue; @p cb is invoked exactly once from the queue completion context
+ * with 0 on success or a negative errno value on failure. On success @p spec
+ * is filled before @p cb is invoked; it must stay valid until then.
+ *
+ * @param queue   I/O queue that drives the operation.
+ * @param target  Target string, see rawstor_object_spec().
+ * @param spec    Pointer to a RawstorObjectSpec structure that will be
+ *                filled with the object's metadata on success. Must stay
+ *                valid until @p cb is invoked.
+ * @param cb      Completion callback.
+ * @param data    Opaque pointer passed to @p cb.
+ *
+ * @return 0 if the operation was started, negative errno otherwise (in which
+ *         case @p cb is never invoked).
+ *
+ * @see rawstor_object_spec
+ */
+int rawstor_object_spec_async(
+    RawIOQueue* queue, const char* target, struct RawstorObjectSpec* spec,
+    int (*cb)(int result, void* data), void* data
+) RAWSTOR_NOEXCEPT;
+
+/**
+ * @brief Asynchronously create a new empty object at the specified target.
+ *
+ * Non-blocking variant of rawstor_object_create(). The operation is driven
+ * by @p queue; @p cb is invoked exactly once from the queue completion
+ * context with 0 on success or a negative errno value on failure. If the
+ * target contains multiple URIs (mirroring or locality), the object is
+ * created on every backend in the list; on failure, targets already created
+ * are removed before @p cb is invoked.
+ *
+ * @param queue   I/O queue that drives the operation.
+ * @param target  Target string, see rawstor_object_create().
+ * @param spec    Desired object metadata. Copied internally; does not need
+ *                to stay valid after the call returns.
+ * @param cb      Completion callback.
+ * @param data    Opaque pointer passed to @p cb.
+ *
+ * @return 0 if the operation was started, negative errno otherwise (in which
+ *         case @p cb is never invoked).
+ *
+ * @see rawstor_object_create
+ */
+int rawstor_object_create_async(
+    RawIOQueue* queue, const char* target, const struct RawstorObjectSpec* spec,
+    int (*cb)(int result, void* data), void* data
+) RAWSTOR_NOEXCEPT;
+
+/**
+ * @brief Asynchronously remove an object.
+ *
+ * Non-blocking variant of rawstor_object_remove(). The operation is driven
+ * by @p queue; @p cb is invoked exactly once from the queue completion
+ * context with 0 on success or a negative errno value on failure. If the
+ * target contains multiple URIs, the object is removed from every backend
+ * in the list even if some of them fail; the first error is reported.
+ *
+ * @param queue   I/O queue that drives the operation.
+ * @param target  Target string, see rawstor_object_remove().
+ * @param cb      Completion callback.
+ * @param data    Opaque pointer passed to @p cb.
+ *
+ * @return 0 if the operation was started, negative errno otherwise (in which
+ *         case @p cb is never invoked).
+ *
+ * @see rawstor_object_remove
+ */
+int rawstor_object_remove_async(
+    RawIOQueue* queue, const char* target, int (*cb)(int result, void* data),
+    void* data
+) RAWSTOR_NOEXCEPT;
+
+/**
  * @brief Open an existing object for reading and/or writing.
  *
  * Given a target string (as defined in the Rawstor location/target syntax),

--- a/include/rawstor/object.h
+++ b/include/rawstor/object.h
@@ -325,6 +325,32 @@ int rawstor_object_open(
 ) RAWSTOR_NOEXCEPT;
 
 /**
+ * @brief Asynchronously open an existing object.
+ *
+ * Non-blocking variant of rawstor_object_open(). The operation is driven by
+ * @p queue; @p cb is invoked exactly once from the queue completion context.
+ * On success @p result is 0 and @p object is a valid handle that must be
+ * closed with rawstor_object_close(). On failure @p result is a negative
+ * errno value and @p object is NULL.
+ *
+ * @param queue   I/O queue that drives the operation and subsequent I/O on
+ *                the opened object.
+ * @param target  Target string, see rawstor_object_open().
+ * @param cb      Completion callback.
+ * @param data    Opaque pointer passed to @p cb.
+ *
+ * @return 0 if the operation was started, negative errno otherwise (in which
+ *         case @p cb is never invoked).
+ *
+ * @see rawstor_object_open
+ * @see rawstor_object_close
+ */
+int rawstor_object_open_async(
+    RawIOQueue* queue, const char* target,
+    int (*cb)(RawstorObject* object, int result, void* data), void* data
+) RAWSTOR_NOEXCEPT;
+
+/**
  * @brief Close an opened object and release associated resources.
  *
  * This function closes a RawstorObject handle previously obtained via

--- a/include/rawstor/rawstor.h
+++ b/include/rawstor/rawstor.h
@@ -23,6 +23,11 @@ struct RawstorOpts {
     unsigned int so_sndtimeo;
     unsigned int so_rcvtimeo;
     unsigned int tcp_user_timeout;
+    /**
+     * How long to wait, in milliseconds, for a block device node to appear
+     * after a backend provisioning command (lvcreate, zfs create) succeeds.
+     */
+    unsigned int wait_device_timeout;
 };
 
 int rawstor_initialize(const struct RawstorOpts* opts) RAWSTOR_NOEXCEPT;

--- a/librawio/src/uring_queue.cpp
+++ b/librawio/src/uring_queue.cpp
@@ -109,6 +109,27 @@ const std::string& Queue::engine_name() {
     return ::engine_name;
 }
 
+io_uring_sqe* Queue::_get_sqe() {
+    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
+    if (sqe == nullptr) {
+        /*
+         * The submission ring is full of not yet submitted entries: flush
+         * them and retry. Small rings (sized to the caller's iodepth)
+         * overflow easily when completion callbacks prepare follow-up
+         * operations before the next wait submits the backlog.
+         */
+        int res = io_uring_submit(&_ring);
+        if (res < 0) {
+            RAWSTD_THROW_SYSTEM_ERROR(-res);
+        }
+        sqe = io_uring_get_sqe(&_ring);
+        if (sqe == nullptr) {
+            RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
+        }
+    }
+    return sqe;
+}
+
 void Queue::setup_fd(int fd) {
     int res;
     static unsigned int bufsize = 4096 * 64 * 4;
@@ -142,10 +163,7 @@ rawio::Event* Queue::open(
 ) {
     rawstd::TraceEvent trace_event =
         RAWSTD_TRACE_EVENT('|', "flags = %d, mode = %u\n", flags, mode);
-    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
-    if (sqe == nullptr) {
-        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
-    }
+    io_uring_sqe* sqe = _get_sqe();
     auto p = std::make_unique<std::function<void(ssize_t, unsigned int)>>(
         [cb = std::move(cb), trace_event](ssize_t result, unsigned int) {
             RAWSTD_TRACE_EVENT_MESSAGE(trace_event, "result = %zd\n", result);
@@ -160,10 +178,7 @@ rawio::Event* Queue::open(
 
 rawio::Event* Queue::close(int fd, std::function<void(int)>&& cb) {
     rawstd::TraceEvent trace_event = RAWSTD_TRACE_EVENT('|', "%s\n", "");
-    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
-    if (sqe == nullptr) {
-        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
-    }
+    io_uring_sqe* sqe = _get_sqe();
     auto p = std::make_unique<std::function<void(ssize_t, unsigned int)>>(
         [cb = std::move(cb), trace_event](ssize_t result, unsigned int) {
             RAWSTD_TRACE_EVENT_MESSAGE(trace_event, "result = %zd\n", result);
@@ -180,10 +195,7 @@ rawio::Event*
 Queue::poll(int fd, unsigned int mask, std::function<void(int)>&& cb) {
     rawstd::TraceEvent trace_event =
         RAWSTD_TRACE_EVENT('|', "fd = %d, mask = %u\n", fd, mask);
-    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
-    if (sqe == nullptr) {
-        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
-    }
+    io_uring_sqe* sqe = _get_sqe();
     auto p = std::make_unique<std::function<void(ssize_t, unsigned int)>>(
         [cb = std::move(cb), trace_event](ssize_t result, unsigned int) {
             RAWSTD_TRACE_EVENT_MESSAGE(trace_event, "result = %zd\n", result);
@@ -201,10 +213,7 @@ rawio::Event* Queue::poll_multishot(
 ) {
     rawstd::TraceEvent trace_event =
         RAWSTD_TRACE_EVENT('|', "fd = %d, mask = %u\n", fd, mask);
-    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
-    if (sqe == nullptr) {
-        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
-    }
+    io_uring_sqe* sqe = _get_sqe();
     io_uring_prep_poll_multishot(sqe, fd, mask);
     auto p = std::make_unique<std::function<void(ssize_t, unsigned int)>>(
         [cb = std::move(cb), trace_event](ssize_t result, unsigned int) {
@@ -221,10 +230,7 @@ rawio::Event* Queue::accept(
     int fd, sockaddr* addr, socklen_t* addrlen, std::function<void(int)>&& cb
 ) {
     rawstd::TraceEvent trace_event = RAWSTD_TRACE_EVENT('|', "fd = %d\n", fd);
-    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
-    if (sqe == nullptr) {
-        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
-    }
+    io_uring_sqe* sqe = _get_sqe();
     auto p = std::make_unique<std::function<void(ssize_t, unsigned int)>>(
         [cb = std::move(cb), trace_event](ssize_t result, unsigned int) {
             RAWSTD_TRACE_EVENT_MESSAGE(trace_event, "result = %zd\n", result);
@@ -260,10 +266,7 @@ rawio::Event* Queue::accept(
 
 rawio::Event* Queue::accept_multishot(int fd, std::function<void(int)>&& cb) {
     rawstd::TraceEvent trace_event = RAWSTD_TRACE_EVENT('|', "fd = %d\n", fd);
-    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
-    if (sqe == nullptr) {
-        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
-    }
+    io_uring_sqe* sqe = _get_sqe();
     io_uring_prep_multishot_accept(sqe, fd, nullptr, nullptr, 0);
     auto p = std::make_unique<std::function<void(ssize_t, unsigned int)>>(
         [cb = std::move(cb), trace_event](ssize_t result, unsigned int) {
@@ -302,10 +305,7 @@ rawio::Event* Queue::connect(
     std::function<void(int)>&& cb
 ) {
     rawstd::TraceEvent trace_event = RAWSTD_TRACE_EVENT('|', "fd = %d\n", fd);
-    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
-    if (sqe == nullptr) {
-        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
-    }
+    io_uring_sqe* sqe = _get_sqe();
     io_uring_prep_connect(sqe, fd, addr, addrlen);
     auto p = std::make_unique<std::function<void(ssize_t, unsigned int)>>(
         [cb = std::move(cb), trace_event](ssize_t result, unsigned int) {
@@ -323,10 +323,7 @@ rawio::Event* Queue::read(
 ) {
     rawstd::TraceEvent trace_event =
         RAWSTD_TRACE_EVENT('|', "fd = %d, size = %zu\n", fd, size);
-    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
-    if (sqe == nullptr) {
-        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
-    }
+    io_uring_sqe* sqe = _get_sqe();
     io_uring_prep_read(sqe, fd, buf, size, 0);
     auto p = std::make_unique<std::function<void(ssize_t, unsigned int)>>(
         [cb = std::move(cb), trace_event](ssize_t result, unsigned int) {
@@ -348,10 +345,7 @@ rawio::Event* Queue::readv(
 ) {
     rawstd::TraceEvent trace_event =
         RAWSTD_TRACE_EVENT('|', "fd = %d, niov = %zu\n", fd, niov);
-    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
-    if (sqe == nullptr) {
-        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
-    }
+    io_uring_sqe* sqe = _get_sqe();
     io_uring_prep_readv(sqe, fd, iov, niov, 0);
     auto p = std::make_unique<std::function<void(ssize_t, unsigned int)>>(
         [cb = std::move(cb), trace_event](ssize_t result, unsigned int) {
@@ -375,10 +369,7 @@ rawio::Event* Queue::pread(
     rawstd::TraceEvent trace_event = RAWSTD_TRACE_EVENT(
         '|', "fd = %d, size = %zu, offset = %jd\n", fd, size, (intmax_t)offset
     );
-    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
-    if (sqe == nullptr) {
-        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
-    }
+    io_uring_sqe* sqe = _get_sqe();
     io_uring_prep_read(sqe, fd, buf, size, offset);
     auto p = std::make_unique<std::function<void(ssize_t, unsigned int)>>(
         [cb = std::move(cb), trace_event](ssize_t result, unsigned int) {
@@ -402,10 +393,7 @@ rawio::Event* Queue::preadv(
     rawstd::TraceEvent trace_event = RAWSTD_TRACE_EVENT(
         '|', "fd = %d, niov = %u, offset = %jd\n", fd, niov, (intmax_t)offset
     );
-    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
-    if (sqe == nullptr) {
-        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
-    }
+    io_uring_sqe* sqe = _get_sqe();
     io_uring_prep_readv(sqe, fd, iov, niov, offset);
     auto p = std::make_unique<std::function<void(ssize_t, unsigned int)>>(
         [cb = std::move(cb), trace_event](ssize_t result, unsigned int) {
@@ -429,10 +417,7 @@ rawio::Event* Queue::recv(
     rawstd::TraceEvent trace_event = RAWSTD_TRACE_EVENT(
         '|', "fd = %d, size = %zu, flags = %u\n", fd, size, flags
     );
-    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
-    if (sqe == nullptr) {
-        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
-    }
+    io_uring_sqe* sqe = _get_sqe();
     io_uring_prep_recv(sqe, fd, buf, size, flags);
     auto p = std::make_unique<std::function<void(ssize_t, unsigned int)>>(
         [cb = std::move(cb), trace_event](ssize_t result, unsigned int) {
@@ -471,10 +456,7 @@ rawio::Event* Queue::recv_multishot(
         }
     );
 
-    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
-    if (sqe == nullptr) {
-        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
-    }
+    io_uring_sqe* sqe = _get_sqe();
     io_uring_prep_recv_multishot(sqe, fd, nullptr, 0, flags);
     sqe->flags |= IOSQE_BUFFER_SELECT;
     sqe->buf_group = buffer->id();
@@ -502,10 +484,7 @@ rawio::Event* Queue::recvmsg(
     rawstd::TraceEvent trace_event = RAWSTD_TRACE_EVENT(
         '|', "fd = %d, niov = %zu, flags = %u\n", fd, msg->msg_iovlen, flags
     );
-    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
-    if (sqe == nullptr) {
-        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
-    }
+    io_uring_sqe* sqe = _get_sqe();
     auto p = std::make_unique<std::function<void(ssize_t, unsigned int)>>(
         [cb = std::move(cb), trace_event](ssize_t result, unsigned int) {
             RAWSTD_TRACE_EVENT_MESSAGE(trace_event, "result = %zd\n", result);
@@ -527,10 +506,7 @@ rawio::Event* Queue::write(
 ) {
     rawstd::TraceEvent trace_event =
         RAWSTD_TRACE_EVENT('|', "fd = %d, size = %zu\n", fd, size);
-    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
-    if (sqe == nullptr) {
-        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
-    }
+    io_uring_sqe* sqe = _get_sqe();
     auto p = std::make_unique<std::function<void(ssize_t, unsigned int)>>(
         [cb = std::move(cb), trace_event](ssize_t result, unsigned int) {
             RAWSTD_TRACE_EVENT_MESSAGE(trace_event, "result = %zd\n", result);
@@ -553,10 +529,7 @@ rawio::Event* Queue::writev(
 ) {
     rawstd::TraceEvent trace_event =
         RAWSTD_TRACE_EVENT('|', "fd = %d, niov = %u\n", fd, niov);
-    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
-    if (sqe == nullptr) {
-        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
-    }
+    io_uring_sqe* sqe = _get_sqe();
     auto p = std::make_unique<std::function<void(ssize_t, unsigned int)>>(
         [cb = std::move(cb), trace_event](ssize_t result, unsigned int) {
             RAWSTD_TRACE_EVENT_MESSAGE(trace_event, "result = %zd\n", result);
@@ -580,10 +553,7 @@ rawio::Event* Queue::pwrite(
     rawstd::TraceEvent trace_event = RAWSTD_TRACE_EVENT(
         '|', "fd = %d, size = %zu, offset = %jd\n", fd, size, (intmax_t)offset
     );
-    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
-    if (sqe == nullptr) {
-        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
-    }
+    io_uring_sqe* sqe = _get_sqe();
     auto p = std::make_unique<std::function<void(ssize_t, unsigned int)>>(
         [cb = std::move(cb), trace_event](ssize_t result, unsigned int) {
             RAWSTD_TRACE_EVENT_MESSAGE(trace_event, "result = %zd\n", result);
@@ -607,10 +577,7 @@ rawio::Event* Queue::pwritev(
     rawstd::TraceEvent trace_event = RAWSTD_TRACE_EVENT(
         '|', "fd = %d, niov = %u, offset = %jd\n", fd, niov, (intmax_t)offset
     );
-    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
-    if (sqe == nullptr) {
-        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
-    }
+    io_uring_sqe* sqe = _get_sqe();
     auto p = std::make_unique<std::function<void(ssize_t, unsigned int)>>(
         [cb = std::move(cb), trace_event](ssize_t result, unsigned int) {
             RAWSTD_TRACE_EVENT_MESSAGE(trace_event, "result = %zd\n", result);
@@ -634,10 +601,7 @@ rawio::Event* Queue::send(
     rawstd::TraceEvent trace_event = RAWSTD_TRACE_EVENT(
         '|', "fd = %d, size = %zu, flags = %u\n", fd, size, flags
     );
-    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
-    if (sqe == nullptr) {
-        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
-    }
+    io_uring_sqe* sqe = _get_sqe();
     auto p = std::make_unique<std::function<void(ssize_t, unsigned int)>>(
         [cb = std::move(cb), trace_event](ssize_t result, unsigned int) {
             RAWSTD_TRACE_EVENT_MESSAGE(trace_event, "result = %zd\n", result);
@@ -661,10 +625,7 @@ rawio::Event* Queue::sendmsg(
     rawstd::TraceEvent trace_event = RAWSTD_TRACE_EVENT(
         '|', "fd = %d, niov = %zu, flags = %u\n", fd, msg->msg_iovlen, flags
     );
-    io_uring_sqe* sqe = io_uring_get_sqe(&_ring);
-    if (sqe == nullptr) {
-        RAWSTD_THROW_SYSTEM_ERROR(ENOBUFS);
-    }
+    io_uring_sqe* sqe = _get_sqe();
     auto p = std::make_unique<std::function<void(ssize_t, unsigned int)>>(
         [cb = std::move(cb), trace_event](ssize_t result, unsigned int) {
             RAWSTD_TRACE_EVENT_MESSAGE(trace_event, "result = %zd\n", result);

--- a/librawio/src/uring_queue.hpp
+++ b/librawio/src/uring_queue.hpp
@@ -15,6 +15,8 @@ class Queue final : public rawio::Queue {
 private:
     io_uring _ring;
 
+    io_uring_sqe* _get_sqe();
+
     void _dispatch();
 
 public:

--- a/librawio/tests/test_overflow.cpp
+++ b/librawio/tests/test_overflow.cpp
@@ -37,19 +37,34 @@ TEST_F(OverflowTest, push_three) {
         }
     ));
 
+    /*
+     * The queue holds only two entries. The uring engine flushes the
+     * backlog to the kernel and retries, so the third read succeeds; the
+     * poll engine has a fixed pending list and fails with ENOBUFS.
+     */
     char client_buf3[5];
     size_t result3 = 0;
     int error3 = 0;
-    EXPECT_THROW(
-        _queue->read(
+    if (rawio::Queue::engine_name() == "uring") {
+        EXPECT_NO_THROW(_queue->read(
             _fd, client_buf3, sizeof(client_buf3),
             [&result3, &error3](size_t r, int e) {
                 result3 = r;
                 error3 = e;
             }
-        ),
-        std::system_error
-    );
+        ));
+    } else {
+        EXPECT_THROW(
+            _queue->read(
+                _fd, client_buf3, sizeof(client_buf3),
+                [&result3, &error3](size_t r, int e) {
+                    result3 = r;
+                    error3 = e;
+                }
+            ),
+            std::system_error
+        );
+    }
 
     EXPECT_NO_THROW(_wait_all());
 
@@ -61,8 +76,14 @@ TEST_F(OverflowTest, push_three) {
     EXPECT_EQ(error2, 0);
     EXPECT_EQ(strncmp(client_buf2, "data2", 5), 0);
 
-    EXPECT_EQ(result3, (size_t)0);
-    EXPECT_EQ(error3, 0);
+    if (rawio::Queue::engine_name() == "uring") {
+        EXPECT_EQ(result3, sizeof(client_buf3));
+        EXPECT_EQ(error3, 0);
+        EXPECT_EQ(strncmp(client_buf3, "data3", 5), 0);
+    } else {
+        EXPECT_EQ(result3, (size_t)0);
+        EXPECT_EQ(error3, 0);
+    }
 }
 
 TEST_F(OverflowTest, push_two_pop_one) {

--- a/ost/session.cpp
+++ b/ost/session.cpp
@@ -168,6 +168,14 @@ struct OpCtx {
     std::weak_ptr<int> alive;
 };
 
+struct OpenCtx {
+    RawIOQueue* queue;
+    int fd;
+    uint16_t cid;
+    std::weak_ptr<int> alive;
+    rawstor::ostbackend::Session* session;
+};
+
 int op_complete(int result, void* data) noexcept {
     std::unique_ptr<OpCtx> ctx(static_cast<OpCtx*>(data));
 
@@ -196,7 +204,8 @@ Session::Session(RawIOQueue* queue, Server& server, int fd) :
     _recv_event(nullptr),
     _next(&Session::_recv_head),
     _object(nullptr),
-    _alive(std::make_shared<int>(0)) {
+    _alive(std::make_shared<int>(0)),
+    _open_pending(false) {
     int res = rawio_recv_multishot(
         _queue, _fd, 1u << 17, 64 * 4, sizeof(_request_head), 0, _recv, this,
         &_recv_event
@@ -503,9 +512,48 @@ void Session::_release(
     ctx.release();
 }
 
+int Session::_open_complete(
+    RawstorObject* object, int result, void* data
+) noexcept {
+    std::unique_ptr<OpenCtx> ctx(static_cast<OpenCtx*>(data));
+
+    if (ctx->alive.expired()) {
+        if (object != nullptr) {
+            int res = rawstor_object_close(object);
+            if (res < 0) {
+                rawstd_error(
+                    "Failed to close orphaned object: %s\n", strerror(-res)
+                );
+            }
+        }
+        return 0;
+    }
+
+    ctx->session->_open_pending = false;
+
+    if (result == 0) {
+        ctx->session->_object = object;
+    }
+
+    try {
+        send_response(
+            ctx->queue, ctx->fd, RAWSTOR_CMD_SET_OBJECT, ctx->cid, result, 0
+        );
+    } catch (const std::exception& e) {
+        rawstd_error("%s\n", e.what());
+    }
+
+    return 0;
+}
+
 void Session::_set_object(
     const RawstorOSTFrameHead& head, const RawstorOSTFrameBasicBody& body
 ) {
+    if (_open_pending) {
+        send_response(_queue, _fd, RAWSTOR_CMD_SET_OBJECT, head.cid, -EBUSY, 0);
+        return;
+    }
+
     if (_object != nullptr) {
         int res = rawstor_object_close(_object);
         if (res < 0) {
@@ -519,11 +567,19 @@ void Session::_set_object(
 
     std::vector<rawstd::URI> targets = _targets(uuid);
 
-    int result = rawstor_object_open(
-        _queue, rawstd::URI::uris(targets).c_str(), &_object
-    );
+    auto ctx =
+        std::make_unique<OpenCtx>(OpenCtx{_queue, _fd, head.cid, _alive, this});
 
-    send_response(_queue, _fd, RAWSTOR_CMD_SET_OBJECT, head.cid, result, 0);
+    int res = rawstor_object_open_async(
+        _queue, rawstd::URI::uris(targets).c_str(), _open_complete, ctx.get()
+    );
+    if (res < 0) {
+        send_response(_queue, _fd, RAWSTOR_CMD_SET_OBJECT, head.cid, res, 0);
+        return;
+    }
+
+    _open_pending = true;
+    ctx.release();
 }
 
 void Session::_read(

--- a/ost/session.cpp
+++ b/ost/session.cpp
@@ -154,6 +154,36 @@ void send_response(
     cb.release();
 }
 
+/*
+ * Completion context for async object operations (allocate/release).
+ * The session may be destroyed while the operation is in flight; alive
+ * expires with it, in which case the response must not be sent: fd may
+ * already be closed or reused by another session.
+ */
+struct OpCtx {
+    RawIOQueue* queue;
+    int fd;
+    RawstorOSTCommandType cmd;
+    uint16_t cid;
+    std::weak_ptr<int> alive;
+};
+
+int op_complete(int result, void* data) noexcept {
+    std::unique_ptr<OpCtx> ctx(static_cast<OpCtx*>(data));
+
+    if (ctx->alive.expired()) {
+        return 0;
+    }
+
+    try {
+        send_response(ctx->queue, ctx->fd, ctx->cmd, ctx->cid, result, 0);
+    } catch (const std::exception& e) {
+        rawstd_error("%s\n", e.what());
+    }
+
+    return 0;
+}
+
 } // namespace
 
 namespace rawstor {
@@ -165,7 +195,8 @@ Session::Session(RawIOQueue* queue, Server& server, int fd) :
     _fd(fd),
     _recv_event(nullptr),
     _next(&Session::_recv_head),
-    _object(nullptr) {
+    _object(nullptr),
+    _alive(std::make_shared<int>(0)) {
     int res = rawio_recv_multishot(
         _queue, _fd, 1u << 17, 64 * 4, sizeof(_request_head), 0, _recv, this,
         &_recv_event
@@ -433,10 +464,20 @@ void Session::_allocate(
 
     std::vector<rawstd::URI> targets = _targets(uuid);
 
-    int result =
-        rawstor_object_create(rawstd::URI::uris(targets).c_str(), &spec);
+    auto ctx = std::make_unique<OpCtx>(
+        OpCtx{_queue, _fd, RAWSTOR_CMD_ALLOCATE, head.cid, _alive}
+    );
 
-    send_response(_queue, _fd, RAWSTOR_CMD_ALLOCATE, head.cid, result, 0);
+    int res = rawstor_object_create_async(
+        _queue, rawstd::URI::uris(targets).c_str(), &spec, op_complete,
+        ctx.get()
+    );
+    if (res < 0) {
+        send_response(_queue, _fd, RAWSTOR_CMD_ALLOCATE, head.cid, res, 0);
+        return;
+    }
+
+    ctx.release();
 }
 
 void Session::_release(
@@ -447,9 +488,19 @@ void Session::_release(
 
     std::vector<rawstd::URI> targets = _targets(uuid);
 
-    int result = rawstor_object_remove(rawstd::URI::uris(targets).c_str());
+    auto ctx = std::make_unique<OpCtx>(
+        OpCtx{_queue, _fd, RAWSTOR_CMD_RELEASE, head.cid, _alive}
+    );
 
-    send_response(_queue, _fd, RAWSTOR_CMD_RELEASE, head.cid, result, 0);
+    int res = rawstor_object_remove_async(
+        _queue, rawstd::URI::uris(targets).c_str(), op_complete, ctx.get()
+    );
+    if (res < 0) {
+        send_response(_queue, _fd, RAWSTOR_CMD_RELEASE, head.cid, res, 0);
+        return;
+    }
+
+    ctx.release();
 }
 
 void Session::_set_object(

--- a/ost/session.hpp
+++ b/ost/session.hpp
@@ -8,6 +8,7 @@
 #include <rawstd/uri.hpp>
 #include <rawstd/uuid.h>
 
+#include <memory>
 #include <vector>
 
 namespace rawstor {
@@ -28,6 +29,12 @@ private:
         RawstorOSTFrameIOBody io;
     } _request_body;
     RawstorObject* _object;
+
+    /*
+     * Expires on session destruction; async operation completions check it
+     * before touching _fd, which may be closed or reused by then.
+     */
+    std::shared_ptr<int> _alive;
 
     static ssize_t _recv(
         const iovec* iov, unsigned int niov, size_t result, int error,

--- a/ost/session.hpp
+++ b/ost/session.hpp
@@ -36,6 +36,12 @@ private:
      */
     std::shared_ptr<int> _alive;
 
+    /* An object open is in flight; concurrent SET_OBJECT gets EBUSY. */
+    bool _open_pending;
+
+    static int
+    _open_complete(RawstorObject* object, int result, void* data) noexcept;
+
     static ssize_t _recv(
         const iovec* iov, unsigned int niov, size_t result, int error,
         void* data

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -46,6 +46,8 @@ librawstor_la_SOURCES = blkdev_session.cpp \
                         opts.h \
                         session.cpp \
                         session.hpp \
+                        worker.cpp \
+                        worker.hpp \
                         zfs_session.cpp \
                         zfs_session.hpp \
                         rawstor.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -30,10 +30,14 @@ librawstor_la_HEADERS = $(top_srcdir)/include/rawstor/object.h \
                         $(top_srcdir)/include/rawstor/rawstor.h \
                         $(top_builddir)/include/rawstor/version.h
 
-librawstor_la_SOURCES = connection.cpp \
+librawstor_la_SOURCES = blkdev_session.cpp \
+                        blkdev_session.hpp \
+                        connection.cpp \
                         connection.hpp \
                         file_session.cpp \
                         file_session.hpp \
+                        lvm_session.cpp \
+                        lvm_session.hpp \
                         object.cpp \
                         object.hpp \
                         ost_session.cpp \
@@ -42,6 +46,8 @@ librawstor_la_SOURCES = connection.cpp \
                         opts.h \
                         session.cpp \
                         session.hpp \
+                        zfs_session.cpp \
+                        zfs_session.hpp \
                         rawstor.cpp
 
 librawstor_la_LDFLAGS = -version-info $(LIBRARY_VERSION)

--- a/src/blkdev_session.cpp
+++ b/src/blkdev_session.cpp
@@ -1,7 +1,6 @@
 #include "blkdev_session.hpp"
 
 #include "object.hpp"
-#include "rawstor_internals.hpp"
 
 #include <rawstd/gpp.hpp>
 #include <rawstd/logging.h>
@@ -21,14 +20,13 @@
 
 #include <cerrno>
 #include <cstring>
+#include <memory>
+#include <thread>
+#include <vector>
 
-namespace rawstor {
+namespace {
 
-BlkdevSession::BlkdevSession(rawio::Queue& queue, const rawstd::URI& location) :
-    Session(queue, location) {
-}
-
-int BlkdevSession::run_command(const char* const* argv) {
+int run_command(const char* const* argv) {
     pid_t pid = fork();
     if (pid < 0) {
         return -errno;
@@ -51,7 +49,7 @@ int BlkdevSession::run_command(const char* const* argv) {
     return 0;
 }
 
-int BlkdevSession::wait_for_device(const std::string& path, int timeout_ms) {
+int wait_for_device(const std::string& path, int timeout_ms = 5000) {
     const int interval_ms = 50;
     struct stat st;
 
@@ -64,6 +62,74 @@ int BlkdevSession::wait_for_device(const std::string& path, int timeout_ms) {
 
     rawstd_error("Timed out waiting for device %s\n", path.c_str());
     return -ETIMEDOUT;
+}
+
+} // namespace
+
+namespace rawstor {
+
+BlkdevSession::BlkdevSession(rawio::Queue& queue, const rawstd::URI& location) :
+    Session(queue, location) {
+}
+
+void BlkdevSession::run_async(
+    std::vector<std::string> cmd, std::string wait_path,
+    std::function<void(int)>&& cb
+) {
+    int pipe_fds[2];
+    if (pipe2(pipe_fds, O_CLOEXEC) != 0) {
+        cb(errno);
+        return;
+    }
+
+    /*
+     * Register an async read on the pipe's read end.  When the worker thread
+     * finishes and writes the result, the io_uring completion fires cb without
+     * ever having blocked the event loop.
+     */
+    auto result = std::make_shared<int>(0);
+    int rfd = pipe_fds[0];
+    _queue.read(
+        rfd, result.get(), sizeof(*result),
+        [rfd, result, cb = std::move(cb)](size_t bytes, int error) {
+            close(rfd);
+            cb(error || bytes != sizeof(*result) ? (error ? error : EIO)
+                                                 : *result);
+        }
+    );
+
+    /*
+     * Worker thread: builds argv from the string vector, runs the command,
+     * optionally polls for the block device node, then writes the errno result
+     * (0 = success, positive = errno) to the pipe write end and closes it.
+     * Closing the write end is the only action needed to release the pipe;
+     * the read end is owned by the io_uring completion above.
+     */
+    int wfd = pipe_fds[1];
+    std::thread([cmd = std::move(cmd), wait_path = std::move(wait_path),
+                 wfd]() {
+        std::vector<const char*> argv;
+        argv.reserve(cmd.size() + 1);
+        for (const auto& s : cmd) {
+            argv.push_back(s.c_str());
+        }
+        argv.push_back(nullptr);
+
+        int res = 0;
+        int rc = run_command(argv.data());
+        if (rc != 0) {
+            res = -rc;
+        } else if (!wait_path.empty()) {
+            rc = wait_for_device(wait_path);
+            if (rc != 0) {
+                res = -rc;
+            }
+        }
+
+        ssize_t n = write(wfd, &res, sizeof(res));
+        (void)n;
+        close(wfd);
+    }).detach();
 }
 
 void BlkdevSession::spec(

--- a/src/blkdev_session.cpp
+++ b/src/blkdev_session.cpp
@@ -1,0 +1,158 @@
+#include "blkdev_session.hpp"
+
+#include "object.hpp"
+#include "rawstor_internals.hpp"
+
+#include <rawstd/gpp.hpp>
+#include <rawstd/logging.h>
+#include <rawstd/uuid.h>
+
+#include <rawio/queue.hpp>
+
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <sys/wait.h>
+#include <linux/fs.h>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstring>
+
+namespace rawstor {
+
+BlkdevSession::BlkdevSession(rawio::Queue& queue, const rawstd::URI& location) :
+    Session(queue, location) {
+}
+
+int BlkdevSession::run_command(const char* const* argv) {
+    pid_t pid = fork();
+    if (pid < 0) {
+        return -errno;
+    }
+
+    if (pid == 0) {
+        execvp(argv[0], const_cast<char* const*>(argv));
+        _exit(127);
+    }
+
+    int status;
+    if (waitpid(pid, &status, 0) < 0) {
+        return -errno;
+    }
+
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        return -EIO;
+    }
+
+    return 0;
+}
+
+int BlkdevSession::wait_for_device(const std::string& path, int timeout_ms) {
+    const int interval_ms = 50;
+    struct stat st;
+
+    for (int elapsed = 0; elapsed < timeout_ms; elapsed += interval_ms) {
+        if (stat(path.c_str(), &st) == 0 && S_ISBLK(st.st_mode)) {
+            return 0;
+        }
+        usleep(interval_ms * 1000);
+    }
+
+    rawstd_error("Timed out waiting for device %s\n", path.c_str());
+    return -ETIMEDOUT;
+}
+
+void BlkdevSession::spec(
+    const RawstdUUID& id,
+    std::function<void(const RawstorObjectSpec&, int)>&& cb
+) {
+    std::string path = device_path(id);
+
+    int fd = open(path.c_str(), O_RDONLY | O_NONBLOCK);
+    if (fd == -1) {
+        RAWSTD_THROW_ERRNO();
+    }
+
+    uint64_t size = 0;
+    if (ioctl(fd, BLKGETSIZE64, &size) == -1) {
+        int err = errno;
+        close(fd);
+        errno = err;
+        RAWSTD_THROW_ERRNO();
+    }
+
+    close(fd);
+
+    cb(RawstorObjectSpec{size}, 0);
+}
+
+void BlkdevSession::set_object(Object* object) {
+    if (fd() != -1) {
+        throw std::runtime_error("Object already set");
+    }
+
+    std::string path = device_path(object->id());
+
+    rawstd_info("Connecting to %s...\n", path.c_str());
+
+    int fd = open(path.c_str(), O_RDWR | O_NONBLOCK);
+    if (fd == -1) {
+        RAWSTD_THROW_ERRNO();
+    }
+
+    rawstd_info("fd %d: Connected\n", fd);
+    set_fd(fd);
+}
+
+void BlkdevSession::pread(
+    void* buf, size_t size, off_t offset, std::function<void(size_t, int)>&& cb
+) {
+    rawstd_debug(
+        "%s(): fd = %d, size = %zu, offset = %jd\n", __FUNCTION__, fd(), size,
+        (intmax_t)offset
+    );
+
+    _queue.pread(fd(), buf, size, offset, std::move(cb));
+}
+
+void BlkdevSession::preadv(
+    iovec* iov, unsigned int niov, size_t size, off_t offset,
+    std::function<void(size_t, int)>&& cb
+) {
+    rawstd_debug(
+        "%s(): fd = %d, size = %zu, offset = %jd\n", __FUNCTION__, fd(), size,
+        (intmax_t)offset
+    );
+
+    _queue.preadv(fd(), iov, niov, offset, std::move(cb));
+}
+
+void BlkdevSession::pwrite(
+    const void* buf, size_t size, off_t offset,
+    std::function<void(size_t, int)>&& cb
+) {
+    rawstd_debug(
+        "%s(): fd = %d, size = %zu, offset = %jd\n", __FUNCTION__, fd(), size,
+        (intmax_t)offset
+    );
+
+    _queue.pwrite(fd(), buf, size, offset, std::move(cb));
+}
+
+void BlkdevSession::pwritev(
+    const iovec* iov, unsigned int niov, size_t size, off_t offset,
+    std::function<void(size_t, int)>&& cb
+) {
+    rawstd_debug(
+        "%s(): fd = %d, size = %zu, offset = %jd\n", __FUNCTION__, fd(), size,
+        (intmax_t)offset
+    );
+
+    _queue.pwritev(fd(), iov, niov, offset, std::move(cb));
+}
+
+} // namespace rawstor

--- a/src/blkdev_session.cpp
+++ b/src/blkdev_session.cpp
@@ -1,6 +1,7 @@
 #include "blkdev_session.hpp"
 
 #include "object.hpp"
+#include "worker.hpp"
 
 #include <rawstd/gpp.hpp>
 #include <rawstd/logging.h>
@@ -21,7 +22,6 @@
 #include <cerrno>
 #include <cstring>
 #include <memory>
-#include <thread>
 #include <vector>
 
 namespace {
@@ -76,60 +76,32 @@ void BlkdevSession::run_async(
     std::vector<std::string> cmd, std::string wait_path,
     std::function<void(int)>&& cb
 ) {
-    int pipe_fds[2];
-    if (pipe2(pipe_fds, O_CLOEXEC) != 0) {
-        cb(errno);
-        return;
-    }
-
-    /*
-     * Register an async read on the pipe's read end.  When the worker thread
-     * finishes and writes the result, the io_uring completion fires cb without
-     * ever having blocked the event loop.
-     */
-    auto result = std::make_shared<int>(0);
-    int rfd = pipe_fds[0];
-    _queue.read(
-        rfd, result.get(), sizeof(*result),
-        [rfd, result, cb = std::move(cb)](size_t bytes, int error) {
-            close(rfd);
-            cb(error || bytes != sizeof(*result) ? (error ? error : EIO)
-                                                 : *result);
-        }
-    );
-
-    /*
-     * Worker thread: builds argv from the string vector, runs the command,
-     * optionally polls for the block device node, then writes the errno result
-     * (0 = success, positive = errno) to the pipe write end and closes it.
-     * Closing the write end is the only action needed to release the pipe;
-     * the read end is owned by the io_uring completion above.
-     */
-    int wfd = pipe_fds[1];
-    std::thread([cmd = std::move(cmd), wait_path = std::move(wait_path),
-                 wfd]() {
-        std::vector<const char*> argv;
-        argv.reserve(cmd.size() + 1);
-        for (const auto& s : cmd) {
-            argv.push_back(s.c_str());
-        }
-        argv.push_back(nullptr);
-
-        int res = 0;
-        int rc = run_command(argv.data());
-        if (rc != 0) {
-            res = -rc;
-        } else if (!wait_path.empty()) {
-            rc = wait_for_device(wait_path);
-            if (rc != 0) {
-                res = -rc;
+    run_in_worker(
+        _queue,
+        [cmd = std::move(cmd), wait_path = std::move(wait_path)]() -> int {
+            std::vector<const char*> argv;
+            argv.reserve(cmd.size() + 1);
+            for (const auto& s : cmd) {
+                argv.push_back(s.c_str());
             }
-        }
+            argv.push_back(nullptr);
 
-        ssize_t n = write(wfd, &res, sizeof(res));
-        (void)n;
-        close(wfd);
-    }).detach();
+            int rc = run_command(argv.data());
+            if (rc != 0) {
+                return -rc;
+            }
+
+            if (!wait_path.empty()) {
+                rc = wait_for_device(wait_path);
+                if (rc != 0) {
+                    return -rc;
+                }
+            }
+
+            return 0;
+        },
+        std::move(cb)
+    );
 }
 
 void BlkdevSession::spec(

--- a/src/blkdev_session.cpp
+++ b/src/blkdev_session.cpp
@@ -1,7 +1,6 @@
 #include "blkdev_session.hpp"
 
 #include "object.hpp"
-#include "worker.hpp"
 
 #include <rawstd/gpp.hpp>
 #include <rawstd/logging.h>
@@ -12,56 +11,147 @@
 #include <linux/fs.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/timerfd.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <sys/wait.h>
 
 #include <fcntl.h>
+#include <poll.h>
+#include <spawn.h>
 #include <unistd.h>
 
 #include <cerrno>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <vector>
 
+extern char** environ;
+
 namespace {
 
-int run_command(const char* const* argv) {
-    pid_t pid = fork();
-    if (pid < 0) {
-        return -errno;
+/*
+ * Async external command execution: the command is spawned with
+ * posix_spawnp() and its exit is observed by polling a pidfd on the queue,
+ * so nothing ever blocks the event loop and no worker thread is needed.
+ * If wait_path is set, the block device node is then awaited by re-checking
+ * it on a periodic timerfd driven by the same queue.
+ */
+struct CmdState {
+    rawio::Queue& queue;
+    std::vector<std::string> cmd;
+    std::string wait_path;
+    std::function<void(int)> cb;
+    pid_t pid;
+    int pidfd;
+    int timerfd;
+    uint64_t expirations;
+    int elapsed_ms;
+};
+
+const int wait_device_interval_ms = 50;
+const int wait_device_timeout_ms = 5000;
+
+void cmd_finish(const std::shared_ptr<CmdState>& st, int error) {
+    if (st->pidfd != -1) {
+        close(st->pidfd);
+        st->pidfd = -1;
+    }
+    if (st->timerfd != -1) {
+        close(st->timerfd);
+        st->timerfd = -1;
+    }
+    st->cb(error);
+}
+
+bool device_present(const std::string& path) {
+    struct stat sb;
+    return stat(path.c_str(), &sb) == 0 && S_ISBLK(sb.st_mode);
+}
+
+void wait_device_arm(const std::shared_ptr<CmdState>& st);
+
+void wait_device_check(const std::shared_ptr<CmdState>& st) {
+    if (device_present(st->wait_path)) {
+        cmd_finish(st, 0);
+        return;
     }
 
-    if (pid == 0) {
-        execvp(argv[0], const_cast<char* const*>(argv));
-        _exit(127);
+    if (st->elapsed_ms >= wait_device_timeout_ms) {
+        rawstd_error(
+            "Timed out waiting for device %s\n", st->wait_path.c_str()
+        );
+        cmd_finish(st, ETIMEDOUT);
+        return;
     }
 
+    wait_device_arm(st);
+}
+
+void wait_device_arm(const std::shared_ptr<CmdState>& st) {
+    try {
+        st->queue.read(
+            st->timerfd, &st->expirations, sizeof(st->expirations),
+            [st](size_t, int error) {
+                if (error) {
+                    cmd_finish(st, error);
+                    return;
+                }
+                st->elapsed_ms +=
+                    wait_device_interval_ms * static_cast<int>(st->expirations);
+                wait_device_check(st);
+            }
+        );
+    } catch (const std::system_error& e) {
+        cmd_finish(st, e.code().value());
+    }
+}
+
+void wait_device(const std::shared_ptr<CmdState>& st) {
+    if (device_present(st->wait_path)) {
+        cmd_finish(st, 0);
+        return;
+    }
+
+    st->timerfd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
+    if (st->timerfd == -1) {
+        cmd_finish(st, errno);
+        return;
+    }
+
+    itimerspec its = {};
+    its.it_value.tv_nsec = wait_device_interval_ms * 1000000L;
+    its.it_interval.tv_nsec = wait_device_interval_ms * 1000000L;
+    if (timerfd_settime(st->timerfd, 0, &its, nullptr) == -1) {
+        cmd_finish(st, errno);
+        return;
+    }
+
+    wait_device_arm(st);
+}
+
+void reap_child(const std::shared_ptr<CmdState>& st) {
     int status;
-    if (waitpid(pid, &status, 0) < 0) {
-        return -errno;
+    pid_t rc = waitpid(st->pid, &status, WNOHANG);
+    if (rc <= 0) {
+        /* POLLIN on a pidfd implies the child has already exited. */
+        cmd_finish(st, rc < 0 ? errno : EIO);
+        return;
     }
 
     if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-        return -EIO;
+        cmd_finish(st, EIO);
+        return;
     }
 
-    return 0;
-}
-
-int wait_for_device(const std::string& path, int timeout_ms = 5000) {
-    const int interval_ms = 50;
-    struct stat st;
-
-    for (int elapsed = 0; elapsed < timeout_ms; elapsed += interval_ms) {
-        if (stat(path.c_str(), &st) == 0 && S_ISBLK(st.st_mode)) {
-            return 0;
-        }
-        usleep(interval_ms * 1000);
+    if (st->wait_path.empty()) {
+        cmd_finish(st, 0);
+        return;
     }
 
-    rawstd_error("Timed out waiting for device %s\n", path.c_str());
-    return -ETIMEDOUT;
+    wait_device(st);
 }
 
 } // namespace
@@ -76,32 +166,61 @@ void BlkdevSession::run_async(
     std::vector<std::string> cmd, std::string wait_path,
     std::function<void(int)>&& cb
 ) {
-    run_in_worker(
-        _queue,
-        [cmd = std::move(cmd), wait_path = std::move(wait_path)]() -> int {
-            std::vector<const char*> argv;
-            argv.reserve(cmd.size() + 1);
-            for (const auto& s : cmd) {
-                argv.push_back(s.c_str());
-            }
-            argv.push_back(nullptr);
+    std::shared_ptr<CmdState> st = std::make_shared<CmdState>(CmdState{
+        _queue, std::move(cmd), std::move(wait_path), std::move(cb), -1, -1, -1,
+        0, 0
+    });
 
-            int rc = run_command(argv.data());
-            if (rc != 0) {
-                return -rc;
-            }
+    /*
+     * argv only needs to stay valid until posix_spawnp() returns: glibc
+     * spawns with vfork semantics, so the parent resumes after the child
+     * has exec'ed.
+     */
+    std::vector<char*> argv;
+    argv.reserve(st->cmd.size() + 1);
+    for (auto& s : st->cmd) {
+        argv.push_back(s.data());
+    }
+    argv.push_back(nullptr);
 
-            if (!wait_path.empty()) {
-                rc = wait_for_device(wait_path);
-                if (rc != 0) {
-                    return -rc;
-                }
-            }
+    int rc =
+        posix_spawnp(&st->pid, argv[0], nullptr, nullptr, argv.data(), environ);
+    if (rc != 0) {
+        st->cb(rc);
+        return;
+    }
 
-            return 0;
-        },
-        std::move(cb)
-    );
+    st->pidfd = static_cast<int>(syscall(SYS_pidfd_open, st->pid, 0));
+    if (st->pidfd == -1) {
+        /*
+         * Not expected on kernels recent enough for io_uring; reap
+         * synchronously as a last resort so the child does not linger
+         * as a zombie.
+         */
+        int err = errno;
+        int status;
+        waitpid(st->pid, &status, 0);
+        st->cb(err);
+        return;
+    }
+
+    try {
+        st->queue.poll(st->pidfd, POLLIN, [st](int result) {
+            if (result < 0) {
+                cmd_finish(st, -result);
+                return;
+            }
+            reap_child(st);
+        });
+    } catch (const std::system_error& e) {
+        /*
+         * Queue submission failed; reap synchronously as a last resort so
+         * the child does not linger as a zombie.
+         */
+        int status;
+        waitpid(st->pid, &status, 0);
+        cmd_finish(st, e.code().value());
+    }
 }
 
 void BlkdevSession::spec(

--- a/src/blkdev_session.cpp
+++ b/src/blkdev_session.cpp
@@ -9,12 +9,12 @@
 
 #include <rawio/queue.hpp>
 
+#include <linux/fs.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <sys/wait.h>
-#include <linux/fs.h>
 
 #include <fcntl.h>
 #include <unistd.h>
@@ -72,17 +72,18 @@ void BlkdevSession::spec(
 ) {
     std::string path = device_path(id);
 
-    int fd = open(path.c_str(), O_RDONLY | O_NONBLOCK);
+    int fd = open(path.c_str(), O_RDONLY | O_CLOEXEC);
     if (fd == -1) {
-        RAWSTD_THROW_ERRNO();
+        cb({}, errno);
+        return;
     }
 
     uint64_t size = 0;
     if (ioctl(fd, BLKGETSIZE64, &size) == -1) {
         int err = errno;
         close(fd);
-        errno = err;
-        RAWSTD_THROW_ERRNO();
+        cb({}, err);
+        return;
     }
 
     close(fd);
@@ -99,7 +100,7 @@ void BlkdevSession::set_object(Object* object) {
 
     rawstd_info("Connecting to %s...\n", path.c_str());
 
-    int fd = open(path.c_str(), O_RDWR | O_NONBLOCK);
+    int fd = open(path.c_str(), O_RDWR | O_CLOEXEC);
     if (fd == -1) {
         RAWSTD_THROW_ERRNO();
     }

--- a/src/blkdev_session.cpp
+++ b/src/blkdev_session.cpp
@@ -1,6 +1,7 @@
 #include "blkdev_session.hpp"
 
 #include "object.hpp"
+#include "opts.h"
 
 #include <rawstd/gpp.hpp>
 #include <rawstd/logging.h>
@@ -52,7 +53,6 @@ struct CmdState {
 };
 
 const int wait_device_interval_ms = 50;
-const int wait_device_timeout_ms = 5000;
 
 void cmd_finish(const std::shared_ptr<CmdState>& st, int error) {
     if (st->pidfd != -1) {
@@ -79,7 +79,7 @@ void wait_device_check(const std::shared_ptr<CmdState>& st) {
         return;
     }
 
-    if (st->elapsed_ms >= wait_device_timeout_ms) {
+    if (st->elapsed_ms >= (int)rawstor_opts_wait_device_timeout()) {
         rawstd_error(
             "Timed out waiting for device %s\n", st->wait_path.c_str()
         );

--- a/src/blkdev_session.cpp
+++ b/src/blkdev_session.cpp
@@ -136,43 +136,60 @@ void BlkdevSession::spec(
     const RawstdUUID& id,
     std::function<void(const RawstorObjectSpec&, int)>&& cb
 ) {
-    std::string path = device_path(id);
+    /*
+     * The path buffer is kept alive by the callback capture: io_uring reads
+     * the string when the openat operation is executed, not when submitted.
+     * Opening a block device may block (suspended DM device, busy pool);
+     * io_uring handles that in a worker thread without stalling the loop.
+     * BLKGETSIZE64 reads an in-memory value and completes immediately.
+     */
+    auto path = std::make_shared<std::string>(device_path(id));
 
-    int fd = open(path.c_str(), O_RDONLY | O_CLOEXEC);
-    if (fd == -1) {
-        cb({}, errno);
-        return;
-    }
+    _queue.open(
+        path->c_str(), O_RDONLY | O_CLOEXEC, 0,
+        [path, cb = std::move(cb)](int result) {
+            if (result < 0) {
+                cb({}, -result);
+                return;
+            }
 
-    uint64_t size = 0;
-    if (ioctl(fd, BLKGETSIZE64, &size) == -1) {
-        int err = errno;
-        close(fd);
-        cb({}, err);
-        return;
-    }
+            uint64_t size = 0;
+            if (ioctl(result, BLKGETSIZE64, &size) == -1) {
+                int err = errno;
+                close(result);
+                cb({}, err);
+                return;
+            }
 
-    close(fd);
+            close(result);
 
-    cb(RawstorObjectSpec{size}, 0);
+            cb(RawstorObjectSpec{size}, 0);
+        }
+    );
 }
 
-void BlkdevSession::set_object(Object* object) {
+void BlkdevSession::set_object(Object* object, std::function<void(int)>&& cb) {
     if (fd() != -1) {
         throw std::runtime_error("Object already set");
     }
 
-    std::string path = device_path(object->id());
+    auto path = std::make_shared<std::string>(device_path(object->id()));
 
-    rawstd_info("Connecting to %s...\n", path.c_str());
+    rawstd_info("Connecting to %s...\n", path->c_str());
 
-    int fd = open(path.c_str(), O_RDWR | O_CLOEXEC);
-    if (fd == -1) {
-        RAWSTD_THROW_ERRNO();
-    }
+    _queue.open(
+        path->c_str(), O_RDWR | O_CLOEXEC, 0,
+        [this, path, cb = std::move(cb)](int result) {
+            if (result < 0) {
+                cb(-result);
+                return;
+            }
 
-    rawstd_info("fd %d: Connected\n", fd);
-    set_fd(fd);
+            rawstd_info("fd %d: Connected\n", result);
+            set_fd(result);
+            cb(0);
+        }
+    );
 }
 
 void BlkdevSession::pread(

--- a/src/blkdev_session.hpp
+++ b/src/blkdev_session.hpp
@@ -1,0 +1,57 @@
+#ifndef RAWSTOR_BLKDEV_SESSION_HPP
+#define RAWSTOR_BLKDEV_SESSION_HPP
+
+#include "session.hpp"
+
+#include <string>
+
+namespace rawstor {
+
+/*
+ * Shared base for local block-device storage backends (LVM, ZFS).
+ *
+ * Subclasses implement device_path() to map a UUID to a block device node,
+ * and create()/remove() to provision/deprovision that device.
+ * All I/O (pread/pwrite) and spec (BLKGETSIZE64) are handled here.
+ */
+class BlkdevSession : public Session {
+protected:
+    virtual std::string device_path(const RawstdUUID& id) const = 0;
+
+    static int run_command(const char* const* argv);
+    static int wait_for_device(const std::string& path, int timeout_ms = 5000);
+
+public:
+    BlkdevSession(rawio::Queue& queue, const rawstd::URI& location);
+
+    void spec(
+        const RawstdUUID& id,
+        std::function<void(const RawstorObjectSpec&, int)>&& cb
+    ) override;
+
+    void set_object(Object* object) override;
+
+    void pread(
+        void* buf, size_t size, off_t offset,
+        std::function<void(size_t, int)>&& cb
+    ) override;
+
+    void preadv(
+        iovec* iov, unsigned int niov, size_t size, off_t offset,
+        std::function<void(size_t, int)>&& cb
+    ) override;
+
+    void pwrite(
+        const void* buf, size_t size, off_t offset,
+        std::function<void(size_t, int)>&& cb
+    ) override;
+
+    void pwritev(
+        const iovec* iov, unsigned int niov, size_t size, off_t offset,
+        std::function<void(size_t, int)>&& cb
+    ) override;
+};
+
+} // namespace rawstor
+
+#endif // RAWSTOR_BLKDEV_SESSION_HPP

--- a/src/blkdev_session.hpp
+++ b/src/blkdev_session.hpp
@@ -3,7 +3,9 @@
 
 #include "session.hpp"
 
+#include <functional>
 #include <string>
+#include <vector>
 
 namespace rawstor {
 
@@ -18,8 +20,17 @@ class BlkdevSession : public Session {
 protected:
     virtual std::string device_path(const RawstdUUID& id) const = 0;
 
-    static int run_command(const char* const* argv);
-    static int wait_for_device(const std::string& path, int timeout_ms = 5000);
+    /*
+     * Runs cmd in a detached thread and optionally waits for wait_path to
+     * appear as a block device.  The result is communicated back to the
+     * caller's io_uring ring via a pipe, so the event loop is not blocked.
+     * cb is invoked from an io_uring completion callback with 0 on success
+     * or a positive errno value on failure.
+     */
+    void run_async(
+        std::vector<std::string> cmd, std::string wait_path,
+        std::function<void(int)>&& cb
+    );
 
 public:
     BlkdevSession(rawio::Queue& queue, const rawstd::URI& location);

--- a/src/blkdev_session.hpp
+++ b/src/blkdev_session.hpp
@@ -15,17 +15,22 @@ namespace rawstor {
  * Subclasses implement device_path() to map a UUID to a block device node,
  * and create()/remove() to provision/deprovision that device.
  * All I/O (pread/pwrite) and spec (BLKGETSIZE64) are handled here.
+ *
+ * spec() reports the actual device size: LVM rounds the requested size up
+ * to the VG extent size, and zfs-create(8) rejects sizes that are not a
+ * multiple of volblocksize. The file backend reports the requested size
+ * verbatim, so the specs of a mixed file/blkdev mirror may disagree.
  */
 class BlkdevSession : public Session {
 protected:
     virtual std::string device_path(const RawstdUUID& id) const = 0;
 
     /*
-     * Runs cmd in a detached thread and optionally waits for wait_path to
-     * appear as a block device.  The result is communicated back to the
-     * caller's io_uring ring via a pipe, so the event loop is not blocked.
-     * cb is invoked from an io_uring completion callback with 0 on success
-     * or a positive errno value on failure.
+     * Spawns cmd with posix_spawnp() and observes its exit by polling a
+     * pidfd on the queue; optionally waits for wait_path to appear as a
+     * block device afterwards (bounded by rawstor_opts_wait_device_timeout).
+     * Nothing blocks the event loop. cb is invoked from a queue completion
+     * callback with 0 on success or a positive errno value on failure.
      */
     void run_async(
         std::vector<std::string> cmd, std::string wait_path,

--- a/src/blkdev_session.hpp
+++ b/src/blkdev_session.hpp
@@ -40,7 +40,7 @@ public:
         std::function<void(const RawstorObjectSpec&, int)>&& cb
     ) override;
 
-    void set_object(Object* object) override;
+    void set_object(Object* object, std::function<void(int)>&& cb) override;
 
     void pread(
         void* buf, size_t size, off_t offset,

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -17,6 +17,7 @@
 #include <stdexcept>
 #include <string>
 
+#include <cerrno>
 #include <cstring>
 
 namespace rawstor {
@@ -24,7 +25,9 @@ namespace rawstor {
 Connection::Connection(rawio::Queue& queue) :
     _queue(queue),
     _object(nullptr),
-    _session_index(0) {
+    _session_index(0),
+    _alive(std::make_shared<int>(0)),
+    _reopens(0) {
 }
 
 Connection::~Connection() {
@@ -266,21 +269,58 @@ void Connection::invalidate_session(
         std::find(_sessions.begin(), _sessions.end(), s);
 
     if (it == _sessions.end()) {
+        /*
+         * The session was already invalidated by a concurrent operation.
+         * If its reopen is still in flight, the session list may be empty;
+         * park the caller until the reopen settles instead of letting it
+         * retry immediately and fail.
+         */
+        if (_reopens > 0) {
+            _reopen_waiters.push_back(std::move(cb));
+            return;
+        }
         cb(0);
         return;
     }
 
     _sessions.erase(it);
+    ++_reopens;
 
+    std::weak_ptr<int> alive = _alive;
     _open(
         s->location(), _object, 1,
-        [this, cb = std::move(cb)](
+        [this, alive, cb = std::move(cb)](
             std::vector<std::shared_ptr<Session>>&& sessions, int error
         ) {
+            /*
+             * The connection may be closed or destroyed while the reopen
+             * is in flight. The error must be nonzero: on zero the caller
+             * would retry the operation on the dead connection.
+             */
+            if (alive.expired()) {
+                cb(error ? error : ECANCELED);
+                return;
+            }
+
+            --_reopens;
             if (!error) {
                 _sessions.push_back(sessions.front());
             }
+
+            /*
+             * The waiters are drained after the last reopen settles; the
+             * swap keeps the vector consistent when a callback re-enters
+             * invalidate_session().
+             */
+            std::vector<std::function<void(int)>> waiters;
+            if (_reopens == 0) {
+                waiters.swap(_reopen_waiters);
+            }
+
             cb(error);
+            for (std::function<void(int)>& w : waiters) {
+                w(error);
+            }
         }
     );
 }
@@ -392,11 +432,16 @@ void Connection::open(
     const rawstd::URI& location, Object* object, size_t nsessions,
     std::function<void(int)>&& cb
 ) {
+    std::weak_ptr<int> alive = _alive;
     _open(
         location, object, nsessions,
-        [this, object, cb = std::move(cb)](
+        [this, alive, object, cb = std::move(cb)](
             std::vector<std::shared_ptr<Session>>&& sessions, int error
         ) {
+            if (alive.expired()) {
+                cb(error ? error : ECANCELED);
+                return;
+            }
             if (!error) {
                 _sessions = std::move(sessions);
                 _object = object;
@@ -407,6 +452,20 @@ void Connection::open(
 }
 
 void Connection::close() {
+    /*
+     * Expire in-flight open/reopen completions and re-arm for a possible
+     * later open. Parked waiters get a terminal error so their operations
+     * do not hang.
+     */
+    _alive = std::make_shared<int>(0);
+    _reopens = 0;
+
+    std::vector<std::function<void(int)>> waiters;
+    waiters.swap(_reopen_waiters);
+    for (std::function<void(int)>& w : waiters) {
+        w(ECANCELED);
+    }
+
     _sessions.clear();
     _object = nullptr;
 }

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -83,6 +83,25 @@ void Connection::_open_next(const std::shared_ptr<OpenState>& st) {
     }
 
     try {
+        st->sessions[st->next]->connect([st](int error) {
+            if (error) {
+                Connection::_open_failed(st, error);
+                return;
+            }
+            Connection::_open_set_object(st);
+        });
+    } catch (const std::system_error& e) {
+        _open_failed(st, e.code().value());
+    } catch (const std::bad_alloc& e) {
+        _open_failed(st, ENOMEM);
+    } catch (const std::exception& e) {
+        rawstd_error("%s\n", e.what());
+        _open_failed(st, EINVAL);
+    }
+}
+
+void Connection::_open_set_object(const std::shared_ptr<OpenState>& st) {
+    try {
         st->sessions[st->next]->set_object(st->object, [st](int error) {
             if (error) {
                 Connection::_open_failed(st, error);
@@ -286,8 +305,22 @@ void Connection::create(
 
     std::shared_ptr<Session> s = Session::create(queue, target.parent());
     Session* session = s.get();
-    session->create(id, sp, [s = std::move(s), cb = std::move(cb)](int error) {
-        cb(error);
+    session->connect([s = std::move(s), id, sp, cb = std::move(cb)](int error) {
+        if (error) {
+            cb(error);
+            return;
+        }
+
+        try {
+            s->create(id, sp, [s, cb](int error) { cb(error); });
+        } catch (const std::system_error& e) {
+            cb(e.code().value());
+        } catch (const std::bad_alloc& e) {
+            cb(ENOMEM);
+        } catch (const std::exception& e) {
+            rawstd_error("%s\n", e.what());
+            cb(EINVAL);
+        }
     });
 }
 
@@ -303,8 +336,22 @@ void Connection::remove(
 
     std::shared_ptr<Session> s = Session::create(queue, target.parent());
     Session* session = s.get();
-    session->remove(id, [s = std::move(s), cb = std::move(cb)](int error) {
-        cb(error);
+    session->connect([s = std::move(s), id, cb = std::move(cb)](int error) {
+        if (error) {
+            cb(error);
+            return;
+        }
+
+        try {
+            s->remove(id, [s, cb](int error) { cb(error); });
+        } catch (const std::system_error& e) {
+            cb(e.code().value());
+        } catch (const std::bad_alloc& e) {
+            cb(ENOMEM);
+        } catch (const std::exception& e) {
+            rawstd_error("%s\n", e.what());
+            cb(EINVAL);
+        }
     });
 }
 
@@ -320,12 +367,25 @@ void Connection::spec(
 
     std::shared_ptr<Session> s = Session::create(queue, target.parent());
     Session* session = s.get();
-    session->spec(
-        id, [s = std::move(s),
-             cb = std::move(cb)](const RawstorObjectSpec& spec, int error) {
-            cb(spec, error);
+    session->connect([s = std::move(s), id, cb = std::move(cb)](int error) {
+        if (error) {
+            cb({}, error);
+            return;
         }
-    );
+
+        try {
+            s->spec(id, [s, cb](const RawstorObjectSpec& spec, int error) {
+                cb(spec, error);
+            });
+        } catch (const std::system_error& e) {
+            cb({}, e.code().value());
+        } catch (const std::bad_alloc& e) {
+            cb({}, ENOMEM);
+        } catch (const std::exception& e) {
+            rawstd_error("%s\n", e.what());
+            cb({}, EINVAL);
+        }
+    });
 }
 
 void Connection::open(

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -19,38 +19,6 @@
 
 #include <cstring>
 
-namespace {
-
-/**
- * TODO: Remove this class.
- */
-class Queue final {
-private:
-    unsigned int _operations;
-    std::unique_ptr<rawio::Queue> _q;
-
-public:
-    Queue(unsigned int operations) :
-        _operations(operations),
-        _q(rawio::Queue::create(256)) {}
-
-    Queue(const Queue&) = delete;
-
-    Queue& operator=(const Queue&) = delete;
-
-    inline void sub_operation() noexcept { --_operations; }
-
-    inline rawio::Queue& queue() noexcept { return *_q; }
-
-    void wait() {
-        while (_operations > 0) {
-            _q->wait_timeout(rawstor_opts_tcp_user_timeout());
-        }
-    }
-};
-
-} // namespace
-
 namespace rawstor {
 
 Connection::Connection(rawio::Queue& queue) :
@@ -221,7 +189,8 @@ const rawstd::URI* Connection::location() const noexcept {
 }
 
 void Connection::create(
-    const rawstd::URI& target, const RawstorObjectSpec& sp
+    rawio::Queue& queue, const rawstd::URI& target, const RawstorObjectSpec& sp,
+    std::function<void(int)>&& cb
 ) {
     RawstdUUID id;
     int res = rawstd_uuid_from_string(&id, target.path().filename().c_str());
@@ -229,62 +198,48 @@ void Connection::create(
         RAWSTD_THROW_SYSTEM_ERROR(-res);
     }
 
-    Queue q(1);
-
-    std::unique_ptr<Session> s = Session::create(q.queue(), target.parent());
-    s->create(id, sp, [&q](int error) {
-        q.sub_operation();
-
-        if (error) {
-            RAWSTD_THROW_SYSTEM_ERROR(error);
-        }
+    std::shared_ptr<Session> s = Session::create(queue, target.parent());
+    Session* session = s.get();
+    session->create(id, sp, [s = std::move(s), cb = std::move(cb)](int error) {
+        cb(error);
     });
-
-    q.wait();
 }
 
-void Connection::remove(const rawstd::URI& target) {
+void Connection::remove(
+    rawio::Queue& queue, const rawstd::URI& target,
+    std::function<void(int)>&& cb
+) {
     RawstdUUID id;
     int res = rawstd_uuid_from_string(&id, target.path().filename().c_str());
     if (res) {
         RAWSTD_THROW_SYSTEM_ERROR(-res);
     }
 
-    Queue q(1);
-
-    std::unique_ptr<Session> s = Session::create(q.queue(), target.parent());
-    s->remove(id, [&q](int error) {
-        q.sub_operation();
-
-        if (error) {
-            RAWSTD_THROW_SYSTEM_ERROR(error);
-        }
+    std::shared_ptr<Session> s = Session::create(queue, target.parent());
+    Session* session = s.get();
+    session->remove(id, [s = std::move(s), cb = std::move(cb)](int error) {
+        cb(error);
     });
-
-    q.wait();
 }
 
-void Connection::spec(const rawstd::URI& target, RawstorObjectSpec* sp) {
+void Connection::spec(
+    rawio::Queue& queue, const rawstd::URI& target,
+    std::function<void(const RawstorObjectSpec&, int)>&& cb
+) {
     RawstdUUID id;
     int res = rawstd_uuid_from_string(&id, target.path().filename().c_str());
     if (res) {
         RAWSTD_THROW_SYSTEM_ERROR(-res);
     }
 
-    Queue q(1);
-
-    std::unique_ptr<Session> s = Session::create(q.queue(), target.parent());
-    s->spec(id, [&q, sp](const RawstorObjectSpec& spec, int error) {
-        q.sub_operation();
-
-        if (error) {
-            RAWSTD_THROW_SYSTEM_ERROR(error);
+    std::shared_ptr<Session> s = Session::create(queue, target.parent());
+    Session* session = s.get();
+    session->spec(
+        id, [s = std::move(s),
+             cb = std::move(cb)](const RawstorObjectSpec& spec, int error) {
+            cb(spec, error);
         }
-
-        *sp = spec;
-    });
-
-    q.wait();
+    );
 }
 
 void Connection::open(

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -35,44 +35,101 @@ Connection::~Connection() {
     }
 }
 
-std::vector<std::shared_ptr<Session>> Connection::_open(
-    const rawstd::URI& location, Object* object, size_t nsessions
-) {
+/*
+ * Async session opening chain: each attempt creates nsessions sessions and
+ * binds them to the object one by one via async set_object(); on any failure
+ * the whole batch is dropped and the attempt is retried up to
+ * rawstor_opts_io_attempts() times.
+ */
+struct Connection::OpenState {
+    rawio::Queue& queue;
+    rawstd::URI location;
+    Object* object;
+    size_t nsessions;
+    std::function<void(std::vector<std::shared_ptr<Session>>&&, int)> cb;
     std::vector<std::shared_ptr<Session>> sessions;
+    size_t next;
+    unsigned int attempt;
+};
 
-    for (unsigned int attempt = 1; attempt <= rawstor_opts_io_attempts();
-         ++attempt) {
-        try {
-            sessions.clear();
-            sessions.reserve(nsessions);
-            for (size_t i = 0; i < nsessions; ++i) {
-                sessions.push_back(Session::create(_queue, location));
-            }
+void Connection::_open_attempt(const std::shared_ptr<OpenState>& st) {
+    st->sessions.clear();
+    st->next = 0;
 
-            for (std::shared_ptr<Session> s : sessions) {
-                s->set_object(object);
-            }
-
-            break;
-        } catch (const std::exception& e) {
-            if (attempt != rawstor_opts_io_attempts()) {
-                rawstd_warning(
-                    "Open session failed; error: %s; "
-                    "attempt: %d of %d; retrying...\n",
-                    e.what(), attempt, rawstor_opts_io_attempts()
-                );
-            } else {
-                rawstd_warning(
-                    "Open session failed; error: %s; "
-                    "attempt: %d of %d; failing...\n",
-                    e.what(), attempt, rawstor_opts_io_attempts()
-                );
-                throw;
-            }
+    try {
+        st->sessions.reserve(st->nsessions);
+        for (size_t i = 0; i < st->nsessions; ++i) {
+            st->sessions.push_back(Session::create(st->queue, st->location));
         }
+    } catch (const std::system_error& e) {
+        _open_failed(st, e.code().value());
+        return;
+    } catch (const std::bad_alloc& e) {
+        _open_failed(st, ENOMEM);
+        return;
+    } catch (const std::exception& e) {
+        rawstd_error("%s\n", e.what());
+        _open_failed(st, EINVAL);
+        return;
     }
 
-    return sessions;
+    _open_next(st);
+}
+
+void Connection::_open_next(const std::shared_ptr<OpenState>& st) {
+    if (st->next == st->sessions.size()) {
+        st->cb(std::move(st->sessions), 0);
+        return;
+    }
+
+    try {
+        st->sessions[st->next]->set_object(st->object, [st](int error) {
+            if (error) {
+                Connection::_open_failed(st, error);
+                return;
+            }
+            ++st->next;
+            Connection::_open_next(st);
+        });
+    } catch (const std::system_error& e) {
+        _open_failed(st, e.code().value());
+    } catch (const std::bad_alloc& e) {
+        _open_failed(st, ENOMEM);
+    } catch (const std::exception& e) {
+        rawstd_error("%s\n", e.what());
+        _open_failed(st, EINVAL);
+    }
+}
+
+void Connection::_open_failed(const std::shared_ptr<OpenState>& st, int error) {
+    if (st->attempt != rawstor_opts_io_attempts()) {
+        rawstd_warning(
+            "Open session failed; error: %s; "
+            "attempt: %d of %d; retrying...\n",
+            std::strerror(error), st->attempt, rawstor_opts_io_attempts()
+        );
+        ++st->attempt;
+        _open_attempt(st);
+        return;
+    }
+
+    rawstd_warning(
+        "Open session failed; error: %s; "
+        "attempt: %d of %d; failing...\n",
+        std::strerror(error), st->attempt, rawstor_opts_io_attempts()
+    );
+    st->sessions.clear();
+    st->cb({}, error);
+}
+
+void Connection::_open(
+    const rawstd::URI& location, Object* object, size_t nsessions,
+    std::function<void(std::vector<std::shared_ptr<Session>>&&, int)>&& cb
+) {
+    std::shared_ptr<OpenState> st = std::make_shared<OpenState>(
+        OpenState{_queue, location, object, nsessions, std::move(cb), {}, 0, 1}
+    );
+    _open_attempt(st);
 }
 
 void Connection::_op(
@@ -132,7 +189,26 @@ void Connection::_op(
             );
 
             try {
-                invalidate_session(s);
+                invalidate_session(
+                    s, [this, s, func_name, size, offset, cb, op, attempt,
+                        result](int error) mutable {
+                        if (error) {
+                            rawstd_error(
+                                "IO %s: size = %zu, offset = %jd; "
+                                "reopen failed on %s: %s; "
+                                "attempt %d of %d; failing...\n",
+                                func_name, size, (intmax_t)offset,
+                                s->str().c_str(), std::strerror(error),
+                                attempt + 1, rawstor_opts_io_attempts()
+                            );
+                            (*cb)(result, error);
+                            return;
+                        }
+
+                        _op(func_name, size, offset, std::move(cb), op,
+                            attempt + 1);
+                    }
+                );
             } catch (const std::system_error& e) {
                 (*cb)(result, e.code().value());
                 return;
@@ -147,8 +223,6 @@ void Connection::_op(
                 (*cb)(result, EIO);
                 return;
             }
-
-            _op(func_name, size, offset, std::move(cb), op, attempt + 1);
         }
     );
 }
@@ -166,18 +240,30 @@ std::shared_ptr<Session> Connection::get_next_session() {
     return s;
 }
 
-void Connection::invalidate_session(const std::shared_ptr<Session>& s) {
+void Connection::invalidate_session(
+    const std::shared_ptr<Session>& s, std::function<void(int)>&& cb
+) {
     typename std::vector<std::shared_ptr<Session>>::iterator it =
         std::find(_sessions.begin(), _sessions.end(), s);
 
-    if (it != _sessions.end()) {
-        _sessions.erase(it);
-
-        std::vector<std::shared_ptr<Session>> new_sessions =
-            _open(s->location(), _object, 1);
-
-        _sessions.push_back(new_sessions.front());
+    if (it == _sessions.end()) {
+        cb(0);
+        return;
     }
+
+    _sessions.erase(it);
+
+    _open(
+        s->location(), _object, 1,
+        [this, cb = std::move(cb)](
+            std::vector<std::shared_ptr<Session>>&& sessions, int error
+        ) {
+            if (!error) {
+                _sessions.push_back(sessions.front());
+            }
+            cb(error);
+        }
+    );
 }
 
 const rawstd::URI* Connection::location() const noexcept {
@@ -243,10 +329,21 @@ void Connection::spec(
 }
 
 void Connection::open(
-    const rawstd::URI& location, Object* object, size_t nsessions
+    const rawstd::URI& location, Object* object, size_t nsessions,
+    std::function<void(int)>&& cb
 ) {
-    _sessions = _open(location, object, nsessions);
-    _object = object;
+    _open(
+        location, object, nsessions,
+        [this, object, cb = std::move(cb)](
+            std::vector<std::shared_ptr<Session>>&& sessions, int error
+        ) {
+            if (!error) {
+                _sessions = std::move(sessions);
+                _object = object;
+            }
+            cb(error);
+        }
+    );
 }
 
 void Connection::close() {

--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -21,14 +21,22 @@ class Session;
 
 class Connection final {
 private:
+    struct OpenState;
+
     rawio::Queue& _queue;
     Object* _object;
 
     std::vector<std::shared_ptr<Session>> _sessions;
     size_t _session_index;
 
-    std::vector<std::shared_ptr<Session>>
-    _open(const rawstd::URI& location, Object* object, size_t nsessions);
+    static void _open_attempt(const std::shared_ptr<OpenState>& st);
+    static void _open_next(const std::shared_ptr<OpenState>& st);
+    static void _open_failed(const std::shared_ptr<OpenState>& st, int error);
+
+    void _open(
+        const rawstd::URI& location, Object* object, size_t nsessions,
+        std::function<void(std::vector<std::shared_ptr<Session>>&&, int)>&& cb
+    );
 
     void
     _op(const char* func_name, size_t size, off_t offset,
@@ -61,11 +69,16 @@ public:
     Connection& operator=(const Connection&) = delete;
 
     std::shared_ptr<Session> get_next_session();
-    void invalidate_session(const std::shared_ptr<Session>& s);
+    void invalidate_session(
+        const std::shared_ptr<Session>& s, std::function<void(int)>&& cb
+    );
 
     const rawstd::URI* location() const noexcept;
 
-    void open(const rawstd::URI& location, Object* object, size_t nsessions);
+    void open(
+        const rawstd::URI& location, Object* object, size_t nsessions,
+        std::function<void(int)>&& cb
+    );
 
     void close();
 

--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -31,6 +31,7 @@ private:
 
     static void _open_attempt(const std::shared_ptr<OpenState>& st);
     static void _open_next(const std::shared_ptr<OpenState>& st);
+    static void _open_set_object(const std::shared_ptr<OpenState>& st);
     static void _open_failed(const std::shared_ptr<OpenState>& st, int error);
 
     void _open(

--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -39,11 +39,20 @@ private:
         unsigned int attempt);
 
 public:
-    static void create(const rawstd::URI& target, const RawstorObjectSpec& sp);
+    static void create(
+        rawio::Queue& queue, const rawstd::URI& target,
+        const RawstorObjectSpec& sp, std::function<void(int)>&& cb
+    );
 
-    static void remove(const rawstd::URI& target);
+    static void remove(
+        rawio::Queue& queue, const rawstd::URI& target,
+        std::function<void(int)>&& cb
+    );
 
-    static void spec(const rawstd::URI& target, RawstorObjectSpec* sp);
+    static void spec(
+        rawio::Queue& queue, const rawstd::URI& target,
+        std::function<void(const RawstorObjectSpec&, int)>&& cb
+    );
 
     explicit Connection(rawio::Queue& queue);
     Connection(const Connection&) = delete;

--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -29,6 +29,16 @@ private:
     std::vector<std::shared_ptr<Session>> _sessions;
     size_t _session_index;
 
+    /*
+     * Expires on close()/destruction; async open/reopen completions check
+     * it before touching the connection, which may be gone by then.
+     */
+    std::shared_ptr<int> _alive;
+
+    /* In-flight session reopens and operations waiting for them. */
+    unsigned int _reopens;
+    std::vector<std::function<void(int)>> _reopen_waiters;
+
     static void _open_attempt(const std::shared_ptr<OpenState>& st);
     static void _open_next(const std::shared_ptr<OpenState>& st);
     static void _open_set_object(const std::shared_ptr<OpenState>& st);

--- a/src/file_session.cpp
+++ b/src/file_session.cpp
@@ -2,6 +2,7 @@
 
 #include "object.hpp"
 #include "opts.h"
+#include "worker.hpp"
 
 #include <rawio/queue.hpp>
 
@@ -101,107 +102,127 @@ void Session::create(
     const RawstdUUID& id, const RawstorObjectSpec& sp,
     std::function<void(int)>&& cb
 ) {
-    std::string ost_path = get_ost_path(location());
-    if (mkdir(ost_path.c_str(), 0755) == -1) {
-        if (errno == EEXIST) {
-            errno = 0;
-        } else {
-            RAWSTD_THROW_ERRNO();
-        }
-    }
+    run_in_worker(
+        _queue,
+        [location = location(), id, sp]() -> int {
+            std::string ost_path = get_ost_path(location);
+            if (mkdir(ost_path.c_str(), 0755) == -1) {
+                if (errno == EEXIST) {
+                    errno = 0;
+                } else {
+                    RAWSTD_THROW_ERRNO();
+                }
+            }
 
-    RawstdUUIDString uuid_string;
-    rawstd_uuid_to_string(&id, &uuid_string);
+            RawstdUUIDString uuid_string;
+            rawstd_uuid_to_string(&id, &uuid_string);
 
-    std::string spec_path;
-    spec_path = get_object_spec_path(ost_path, uuid_string);
+            std::string spec_path;
+            spec_path = get_object_spec_path(ost_path, uuid_string);
 
-    int fd = ::open(
-        spec_path.c_str(), O_EXCL | O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR
+            int fd = ::open(
+                spec_path.c_str(), O_EXCL | O_CREAT | O_WRONLY,
+                S_IRUSR | S_IWUSR
+            );
+            if (fd == -1) {
+                RAWSTD_THROW_ERRNO();
+            }
+
+            try {
+                ssize_t res = ::write(fd, &sp, sizeof(sp));
+                if (res == -1) {
+                    RAWSTD_THROW_ERRNO();
+                }
+
+                write_dat(ost_path, sp, id);
+
+                if (::close(fd) == -1) {
+                    RAWSTD_THROW_ERRNO();
+                }
+            } catch (...) {
+                unlink(spec_path.c_str());
+                ::close(fd);
+                throw;
+            }
+
+            return 0;
+        },
+        std::move(cb)
     );
-    if (fd == -1) {
-        RAWSTD_THROW_ERRNO();
-    }
-
-    try {
-        ssize_t res = ::write(fd, &sp, sizeof(sp));
-        if (res == -1) {
-            RAWSTD_THROW_ERRNO();
-        }
-
-        write_dat(ost_path, sp, id);
-
-        if (::close(fd) == -1) {
-            RAWSTD_THROW_ERRNO();
-        }
-    } catch (...) {
-        unlink(spec_path.c_str());
-        ::close(fd);
-        throw;
-    }
-
-    cb(0);
 }
 
 void Session::remove(const RawstdUUID& id, std::function<void(int)>&& cb) {
-    std::string ost_path = get_ost_path(location());
+    run_in_worker(
+        _queue,
+        [location = location(), id]() -> int {
+            std::string ost_path = get_ost_path(location);
 
-    RawstdUUIDString uuid_string;
-    rawstd_uuid_to_string(&id, &uuid_string);
+            RawstdUUIDString uuid_string;
+            rawstd_uuid_to_string(&id, &uuid_string);
 
-    std::string dat_path = get_object_dat_path(ost_path, uuid_string);
-    if (unlink(dat_path.c_str()) == -1) {
-        if (errno == ENOENT) {
-            errno = 0;
-        } else {
-            RAWSTD_THROW_ERRNO();
-        }
-    }
+            std::string dat_path = get_object_dat_path(ost_path, uuid_string);
+            if (unlink(dat_path.c_str()) == -1) {
+                if (errno == ENOENT) {
+                    errno = 0;
+                } else {
+                    RAWSTD_THROW_ERRNO();
+                }
+            }
 
-    std::string spec_path = get_object_spec_path(ost_path, uuid_string);
-    if (unlink(spec_path.c_str()) == -1) {
-        if (errno == ENOENT) {
-            errno = 0;
-        } else {
-            RAWSTD_THROW_ERRNO();
-        }
-    }
+            std::string spec_path = get_object_spec_path(ost_path, uuid_string);
+            if (unlink(spec_path.c_str()) == -1) {
+                if (errno == ENOENT) {
+                    errno = 0;
+                } else {
+                    RAWSTD_THROW_ERRNO();
+                }
+            }
 
-    cb(0);
+            return 0;
+        },
+        std::move(cb)
+    );
 }
 
 void Session::spec(
     const RawstdUUID& id,
     std::function<void(const RawstorObjectSpec&, int)>&& cb
 ) {
-    std::string ost_path = get_ost_path(location());
+    auto ret = std::make_shared<RawstorObjectSpec>();
 
-    RawstdUUIDString uuid_string;
-    rawstd_uuid_to_string(&id, &uuid_string);
+    run_in_worker(
+        _queue,
+        [location = location(), id, ret]() -> int {
+            std::string ost_path = get_ost_path(location);
 
-    std::string spec_path = get_object_spec_path(ost_path, uuid_string);
+            RawstdUUIDString uuid_string;
+            rawstd_uuid_to_string(&id, &uuid_string);
 
-    int fd = ::open(spec_path.c_str(), O_RDONLY);
-    if (fd == -1) {
-        RAWSTD_THROW_ERRNO();
-    }
+            std::string spec_path = get_object_spec_path(ost_path, uuid_string);
 
-    RawstorObjectSpec ret;
-    try {
-        ssize_t rval = ::read(fd, &ret, sizeof(ret));
-        if (rval == -1) {
-            RAWSTD_THROW_ERRNO();
-        }
+            int fd = ::open(spec_path.c_str(), O_RDONLY);
+            if (fd == -1) {
+                RAWSTD_THROW_ERRNO();
+            }
 
-        if (::close(fd) == -1) {
-            RAWSTD_THROW_ERRNO();
-        }
-    } catch (...) {
-        ::close(fd);
-        throw;
-    }
+            try {
+                ssize_t rval = ::read(fd, ret.get(), sizeof(*ret));
+                if (rval == -1) {
+                    RAWSTD_THROW_ERRNO();
+                }
 
-    cb(ret, 0);
+                if (::close(fd) == -1) {
+                    RAWSTD_THROW_ERRNO();
+                }
+            } catch (...) {
+                ::close(fd);
+                throw;
+            }
+
+            return 0;
+        },
+        [ret, cb = std::move(cb)](int error) { cb(*ret, error); }
+    );
 }
 
 void Session::set_object(Object* object, std::function<void(int)>&& cb) {

--- a/src/file_session.cpp
+++ b/src/file_session.cpp
@@ -97,22 +97,6 @@ Session::Session(rawio::Queue& queue, const rawstd::URI& location) :
     rawstor::Session(queue, location) {
 }
 
-int Session::_connect(const RawstdUUID& id) {
-    std::string ost_path = get_ost_path(location());
-
-    RawstdUUIDString id_string;
-    rawstd_uuid_to_string(&id, &id_string);
-    std::string dat_path = get_object_dat_path(ost_path, id_string);
-
-    rawstd_info("Connecting to %s...\n", location().str().c_str());
-    int fd = open(dat_path.c_str(), O_RDWR | O_NONBLOCK);
-    if (fd == -1) {
-        RAWSTD_THROW_ERRNO();
-    }
-    rawstd_info("fd %d: Connected\n", fd);
-    return fd;
-}
-
 void Session::create(
     const RawstdUUID& id, const RawstorObjectSpec& sp,
     std::function<void(int)>&& cb
@@ -220,17 +204,38 @@ void Session::spec(
     cb(ret, 0);
 }
 
-void Session::set_object(Object* object) {
+void Session::set_object(Object* object, std::function<void(int)>&& cb) {
     if (fd() != -1) {
         throw std::runtime_error("Object already set");
     }
 
-    int fd = _connect(object->id());
-    if (fd == -1) {
-        RAWSTD_THROW_ERRNO();
-    }
+    std::string ost_path = get_ost_path(location());
 
-    set_fd(fd);
+    RawstdUUIDString id_string;
+    rawstd_uuid_to_string(&object->id(), &id_string);
+
+    /*
+     * The path buffer is kept alive by the callback capture: io_uring reads
+     * the string when the openat operation is executed, not when submitted.
+     */
+    auto dat_path =
+        std::make_shared<std::string>(get_object_dat_path(ost_path, id_string));
+
+    rawstd_info("Connecting to %s...\n", location().str().c_str());
+
+    _queue.open(
+        dat_path->c_str(), O_RDWR | O_NONBLOCK, 0,
+        [this, dat_path, cb = std::move(cb)](int result) {
+            if (result < 0) {
+                cb(-result);
+                return;
+            }
+
+            rawstd_info("fd %d: Connected\n", result);
+            set_fd(result);
+            cb(0);
+        }
+    );
 }
 
 void Session::pread(

--- a/src/file_session.hpp
+++ b/src/file_session.hpp
@@ -15,8 +15,6 @@ namespace file {
 
 class Session final : public rawstor::Session {
 private:
-    int _connect(const RawstdUUID& id);
-
 public:
     Session(rawio::Queue& queue, const rawstd::URI& location);
 
@@ -32,7 +30,7 @@ public:
         std::function<void(const RawstorObjectSpec&, int)>&& cb
     ) override;
 
-    void set_object(Object* object) override;
+    void set_object(Object* object, std::function<void(int)>&& cb) override;
 
     void pread(
         void* buf, size_t size, off_t offset,

--- a/src/lvm_session.cpp
+++ b/src/lvm_session.cpp
@@ -1,0 +1,110 @@
+#include "lvm_session.hpp"
+
+#include <rawstd/gpp.hpp>
+#include <rawstd/logging.h>
+#include <rawstd/uuid.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+namespace rawstor {
+namespace lvm {
+
+static std::string parse_vg_path(const rawstd::URI& location) {
+    if (location.scheme() != "lvm") {
+        rawstd_error("Unexpected URI scheme: %s\n", location.str().c_str());
+        RAWSTD_THROW_SYSTEM_ERROR(EINVAL);
+    }
+    if (!location.host().empty()) {
+        rawstd_error("Empty host expected: %s\n", location.str().c_str());
+        RAWSTD_THROW_SYSTEM_ERROR(EINVAL);
+    }
+    std::string path = location.path().str();
+    if (path.empty() || path == "/") {
+        rawstd_error("VG path is empty in URI: %s\n", location.str().c_str());
+        RAWSTD_THROW_SYSTEM_ERROR(EINVAL);
+    }
+    return path;
+}
+
+static std::string basename_of(const std::string& path) {
+    size_t pos = path.rfind('/');
+    if (pos == std::string::npos) {
+        return path;
+    }
+    return path.substr(pos + 1);
+}
+
+Session::Session(rawio::Queue& queue, const rawstd::URI& location) :
+    BlkdevSession(queue, location),
+    _vg_path(parse_vg_path(location)),
+    _vg_name(basename_of(_vg_path)) {
+}
+
+std::string Session::device_path(const RawstdUUID& id) const {
+    RawstdUUIDString uuid_str;
+    rawstd_uuid_to_string(&id, &uuid_str);
+
+    std::ostringstream oss;
+    oss << _vg_path << "/" << uuid_str;
+    return oss.str();
+}
+
+void Session::create(
+    const RawstdUUID& id, const RawstorObjectSpec& sp,
+    std::function<void(int)>&& cb
+) {
+    RawstdUUIDString uuid_str;
+    rawstd_uuid_to_string(&id, &uuid_str);
+
+    char size_arg[64];
+    snprintf(size_arg, sizeof(size_arg), "%zub", sp.size);
+
+    rawstd_info(
+        "lvm: creating LV %s in VG %s, size %s\n",
+        uuid_str, _vg_name.c_str(), size_arg
+    );
+
+    const char* argv[] = {
+        "lvcreate", "--yes", "-L", size_arg, "-n", uuid_str,
+        _vg_name.c_str(), nullptr
+    };
+
+    int res = run_command(argv);
+    if (res != 0) {
+        rawstd_error("lvm: lvcreate failed: %s\n", strerror(-res));
+        RAWSTD_THROW_SYSTEM_ERROR(-res);
+    }
+
+    std::string path = device_path(id);
+    res = wait_for_device(path);
+    if (res != 0) {
+        rawstd_error("lvm: device %s did not appear\n", path.c_str());
+        RAWSTD_THROW_SYSTEM_ERROR(-res);
+    }
+
+    cb(0);
+}
+
+void Session::remove(const RawstdUUID& id, std::function<void(int)>&& cb) {
+    std::string path = device_path(id);
+
+    rawstd_info("lvm: removing LV %s\n", path.c_str());
+
+    const char* argv[] = {"lvremove", "-f", path.c_str(), nullptr};
+
+    int res = run_command(argv);
+    if (res != 0) {
+        rawstd_error("lvm: lvremove failed: %s\n", strerror(-res));
+        RAWSTD_THROW_SYSTEM_ERROR(-res);
+    }
+
+    cb(0);
+}
+
+} // namespace lvm
+} // namespace rawstor

--- a/src/lvm_session.cpp
+++ b/src/lvm_session.cpp
@@ -4,11 +4,9 @@
 #include <rawstd/logging.h>
 #include <rawstd/uuid.h>
 
-#include <cerrno>
 #include <cstdio>
 #include <cstring>
 #include <sstream>
-#include <stdexcept>
 #include <string>
 
 namespace rawstor {
@@ -61,31 +59,28 @@ void Session::create(
     RawstdUUIDString uuid_str;
     rawstd_uuid_to_string(&id, &uuid_str);
 
-    char size_arg[64];
-    snprintf(size_arg, sizeof(size_arg), "%zub", sp.size);
+    char size_buf[64];
+    snprintf(size_buf, sizeof(size_buf), "%zub", sp.size);
 
     rawstd_info(
         "lvm: creating LV %s in VG %s, size %s\n", uuid_str, _vg_name.c_str(),
-        size_arg
+        size_buf
     );
 
-    const char* argv[] = {"lvcreate", "--yes",          "-L",   size_arg, "-n",
-                          uuid_str,   _vg_name.c_str(), nullptr};
-
-    int res = run_command(argv);
-    if (res != 0) {
-        rawstd_error("lvm: lvcreate failed: %s\n", strerror(-res));
-        RAWSTD_THROW_SYSTEM_ERROR(-res);
-    }
-
-    std::string path = device_path(id);
-    res = wait_for_device(path);
-    if (res != 0) {
-        rawstd_error("lvm: device %s did not appear\n", path.c_str());
-        RAWSTD_THROW_SYSTEM_ERROR(-res);
-    }
-
-    cb(0);
+    run_async(
+        {"lvcreate", "--yes", "-L", size_buf, "-n", uuid_str, _vg_name},
+        device_path(id),
+        [name = std::string(uuid_str), vg = _vg_name,
+         cb = std::move(cb)](int error) mutable {
+            if (error != 0) {
+                rawstd_error(
+                    "lvm: failed to create LV %s in VG %s: %s\n", name.c_str(),
+                    vg.c_str(), strerror(error)
+                );
+            }
+            cb(error);
+        }
+    );
 }
 
 void Session::remove(const RawstdUUID& id, std::function<void(int)>&& cb) {
@@ -93,15 +88,18 @@ void Session::remove(const RawstdUUID& id, std::function<void(int)>&& cb) {
 
     rawstd_info("lvm: removing LV %s\n", path.c_str());
 
-    const char* argv[] = {"lvremove", "-f", path.c_str(), nullptr};
-
-    int res = run_command(argv);
-    if (res != 0) {
-        rawstd_error("lvm: lvremove failed: %s\n", strerror(-res));
-        RAWSTD_THROW_SYSTEM_ERROR(-res);
-    }
-
-    cb(0);
+    run_async(
+        {"lvremove", "-f", path}, "",
+        [path, cb = std::move(cb)](int error) mutable {
+            if (error != 0) {
+                rawstd_error(
+                    "lvm: failed to remove LV %s: %s\n", path.c_str(),
+                    strerror(error)
+                );
+            }
+            cb(error);
+        }
+    );
 }
 
 } // namespace lvm

--- a/src/lvm_session.cpp
+++ b/src/lvm_session.cpp
@@ -65,14 +65,12 @@ void Session::create(
     snprintf(size_arg, sizeof(size_arg), "%zub", sp.size);
 
     rawstd_info(
-        "lvm: creating LV %s in VG %s, size %s\n",
-        uuid_str, _vg_name.c_str(), size_arg
+        "lvm: creating LV %s in VG %s, size %s\n", uuid_str, _vg_name.c_str(),
+        size_arg
     );
 
-    const char* argv[] = {
-        "lvcreate", "--yes", "-L", size_arg, "-n", uuid_str,
-        _vg_name.c_str(), nullptr
-    };
+    const char* argv[] = {"lvcreate", "--yes",          "-L",   size_arg, "-n",
+                          uuid_str,   _vg_name.c_str(), nullptr};
 
     int res = run_command(argv);
     if (res != 0) {

--- a/src/lvm_session.cpp
+++ b/src/lvm_session.cpp
@@ -4,6 +4,7 @@
 #include <rawstd/logging.h>
 #include <rawstd/uuid.h>
 
+#include <cinttypes>
 #include <cstdio>
 #include <cstring>
 #include <sstream>
@@ -60,7 +61,7 @@ void Session::create(
     rawstd_uuid_to_string(&id, &uuid_str);
 
     char size_buf[64];
-    snprintf(size_buf, sizeof(size_buf), "%zub", sp.size);
+    snprintf(size_buf, sizeof(size_buf), "%" PRIu64 "b", sp.size);
 
     rawstd_info(
         "lvm: creating LV %s in VG %s, size %s\n", uuid_str, _vg_name.c_str(),

--- a/src/lvm_session.hpp
+++ b/src/lvm_session.hpp
@@ -1,0 +1,47 @@
+#ifndef RAWSTOR_LVM_SESSION_HPP
+#define RAWSTOR_LVM_SESSION_HPP
+
+#include "blkdev_session.hpp"
+
+#include <rawstd/uri.hpp>
+#include <rawstd/uuid.h>
+
+#include <string>
+
+namespace rawstor {
+namespace lvm {
+
+/*
+ * LVM storage backend.
+ *
+ * Location URI: lvm:///dev/<vg>
+ *   Example:    lvm:///dev/rawstor_vg
+ *
+ * Each object is a Logical Volume named after its UUID inside the Volume Group.
+ * Device path: /dev/<vg>/<uuid>
+ *
+ * Requires lvcreate/lvremove to be available in PATH and sufficient privileges.
+ */
+class Session final : public BlkdevSession {
+private:
+    std::string _vg_path;
+    std::string _vg_name;
+
+protected:
+    std::string device_path(const RawstdUUID& id) const override;
+
+public:
+    Session(rawio::Queue& queue, const rawstd::URI& location);
+
+    void create(
+        const RawstdUUID& id, const RawstorObjectSpec& sp,
+        std::function<void(int)>&& cb
+    ) override;
+
+    void remove(const RawstdUUID& id, std::function<void(int)>&& cb) override;
+};
+
+} // namespace lvm
+} // namespace rawstor
+
+#endif // RAWSTOR_LVM_SESSION_HPP

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -82,6 +82,155 @@ void validate_different_uris(const std::vector<rawstd::URI>& uris) {
     }
 }
 
+/**
+ * TODO: Remove this class.
+ */
+class Queue final {
+private:
+    unsigned int _operations;
+    std::unique_ptr<rawio::Queue> _q;
+
+public:
+    Queue(unsigned int operations) :
+        _operations(operations),
+        _q(rawio::Queue::create(256)) {}
+
+    Queue(const Queue&) = delete;
+
+    Queue& operator=(const Queue&) = delete;
+
+    inline void sub_operation() noexcept { --_operations; }
+
+    inline rawio::Queue& queue() noexcept { return *_q; }
+
+    void wait() {
+        while (_operations > 0) {
+            _q->wait_timeout(rawstor_opts_tcp_user_timeout());
+        }
+    }
+};
+
+/*
+ * Async multi-target create: targets are provisioned one by one; on the
+ * first failure every target created so far is removed (in reverse order)
+ * and cb is invoked with the original error.
+ */
+struct CreateState {
+    rawio::Queue& queue;
+    std::vector<rawstd::URI> targets;
+    RawstorObjectSpec sp;
+    std::function<void(int)> cb;
+    size_t next;
+    size_t created;
+    int error;
+};
+
+void create_next(const std::shared_ptr<CreateState>& st);
+void create_rollback(const std::shared_ptr<CreateState>& st);
+
+void create_next(const std::shared_ptr<CreateState>& st) {
+    if (st->next == st->targets.size()) {
+        st->cb(0);
+        return;
+    }
+
+    try {
+        rawstor::Connection::create(
+            st->queue, st->targets[st->next], st->sp, [st](int error) {
+                if (error) {
+                    st->error = error;
+                    create_rollback(st);
+                    return;
+                }
+                st->created = ++st->next;
+                create_next(st);
+            }
+        );
+    } catch (const std::system_error& e) {
+        st->error = e.code().value();
+        create_rollback(st);
+    } catch (const std::bad_alloc& e) {
+        st->error = ENOMEM;
+        create_rollback(st);
+    } catch (const std::exception& e) {
+        rawstd_error("%s\n", e.what());
+        st->error = EINVAL;
+        create_rollback(st);
+    }
+}
+
+void create_rollback(const std::shared_ptr<CreateState>& st) {
+    if (st->created == 0) {
+        st->cb(st->error);
+        return;
+    }
+
+    --st->created;
+
+    try {
+        rawstor::Connection::remove(
+            st->queue, st->targets[st->created], [st](int error) {
+                if (error) {
+                    rawstd_error(
+                        "Failed to rollback create operation: %s\n",
+                        strerror(error)
+                    );
+                }
+                create_rollback(st);
+            }
+        );
+    } catch (const std::exception& e) {
+        rawstd_error("Failed to rollback create operation: %s\n", e.what());
+        create_rollback(st);
+    }
+}
+
+/*
+ * Async multi-target remove: every target is removed even if some of them
+ * fail; cb is invoked with the first error encountered, if any.
+ */
+struct RemoveState {
+    rawio::Queue& queue;
+    std::vector<rawstd::URI> targets;
+    std::function<void(int)> cb;
+    size_t next;
+    int error;
+};
+
+void remove_next(const std::shared_ptr<RemoveState>& st);
+
+void remove_done(const std::shared_ptr<RemoveState>& st, int error) {
+    if (error) {
+        rawstd_error("%s\n", strerror(error));
+        if (st->error == 0) {
+            st->error = error;
+        }
+    }
+    ++st->next;
+    remove_next(st);
+}
+
+void remove_next(const std::shared_ptr<RemoveState>& st) {
+    if (st->next == st->targets.size()) {
+        st->cb(st->error);
+        return;
+    }
+
+    try {
+        rawstor::Connection::remove(
+            st->queue, st->targets[st->next],
+            [st](int error) { remove_done(st, error); }
+        );
+    } catch (const std::system_error& e) {
+        remove_done(st, e.code().value());
+    } catch (const std::bad_alloc& e) {
+        remove_done(st, ENOMEM);
+    } catch (const std::exception& e) {
+        rawstd_error("%s\n", e.what());
+        remove_done(st, EINVAL);
+    }
+}
+
 } // namespace
 
 namespace rawstor {
@@ -109,57 +258,36 @@ Object::Object(rawio::Queue& queue, const std::vector<rawstd::URI>& targets) :
 }
 
 void Object::create(
-    const std::vector<rawstd::URI>& targets, const RawstorObjectSpec& sp
+    rawio::Queue& queue, const std::vector<rawstd::URI>& targets,
+    const RawstorObjectSpec& sp, std::function<void(int)>&& cb
 ) {
     validate_not_empty(targets);
     validate_different_uris(targets);
     validate_same_uuid(targets);
 
-    std::vector<rawstd::URI> created;
-    created.reserve(targets.size());
-    try {
-        for (const auto& target : targets) {
-            rawstor::Connection::create(target, sp);
-            created.push_back(target);
-        }
-    } catch (...) {
-        if (!created.empty()) {
-            try {
-                remove(created);
-            } catch (const std::exception& e) {
-                rawstd_error(
-                    "Failed to rollback create operation: %s\n", e.what()
-                );
-            }
-        }
-        throw;
-    }
+    std::shared_ptr<CreateState> st = std::make_shared<CreateState>(
+        CreateState{queue, targets, sp, std::move(cb), 0, 0, 0}
+    );
+    create_next(st);
 }
 
-void Object::remove(const std::vector<rawstd::URI>& targets) {
+void Object::remove(
+    rawio::Queue& queue, const std::vector<rawstd::URI>& targets,
+    std::function<void(int)>&& cb
+) {
     validate_not_empty(targets);
     validate_different_uris(targets);
     validate_same_uuid(targets);
 
-    std::exception_ptr eptr;
-    for (const auto& target : targets) {
-        try {
-            rawstor::Connection::remove(target);
-        } catch (const std::exception& e) {
-            rawstd_error("%s\n", e.what());
-
-            if (!eptr) {
-                eptr = std::current_exception();
-            }
-        }
-    }
-    if (eptr) {
-        std::rethrow_exception(eptr);
-    }
+    std::shared_ptr<RemoveState> st = std::make_shared<RemoveState>(
+        RemoveState{queue, targets, std::move(cb), 0, 0}
+    );
+    remove_next(st);
 }
 
 void Object::spec(
-    const std::vector<rawstd::URI>& targets, RawstorObjectSpec* sp
+    rawio::Queue& queue, const std::vector<rawstd::URI>& targets,
+    RawstorObjectSpec* sp, std::function<void(int)>&& cb
 ) {
     /**
      * TODO: Should we read all specs and compare them here?
@@ -168,7 +296,67 @@ void Object::spec(
     validate_different_uris(targets);
     validate_same_uuid(targets);
 
-    rawstor::Connection::spec(targets.front(), sp);
+    rawstor::Connection::spec(
+        queue, targets.front(),
+        [sp, cb = std::move(cb)](const RawstorObjectSpec& spec, int error) {
+            if (!error) {
+                *sp = spec;
+            }
+            cb(error);
+        }
+    );
+}
+
+void Object::create(
+    const std::vector<rawstd::URI>& targets, const RawstorObjectSpec& sp
+) {
+    Queue q(1);
+    int result = 0;
+
+    create(q.queue(), targets, sp, [&q, &result](int error) {
+        q.sub_operation();
+        result = error;
+    });
+
+    q.wait();
+
+    if (result) {
+        RAWSTD_THROW_SYSTEM_ERROR(result);
+    }
+}
+
+void Object::remove(const std::vector<rawstd::URI>& targets) {
+    Queue q(1);
+    int result = 0;
+
+    remove(q.queue(), targets, [&q, &result](int error) {
+        q.sub_operation();
+        result = error;
+    });
+
+    q.wait();
+
+    if (result) {
+        RAWSTD_THROW_SYSTEM_ERROR(result);
+    }
+}
+
+void Object::spec(
+    const std::vector<rawstd::URI>& targets, RawstorObjectSpec* sp
+) {
+    Queue q(1);
+    int result = 0;
+
+    spec(q.queue(), targets, sp, [&q, &result](int error) {
+        q.sub_operation();
+        result = error;
+    });
+
+    q.wait();
+
+    if (result) {
+        RAWSTD_THROW_SYSTEM_ERROR(result);
+    }
 }
 
 std::vector<rawstd::URI> Object::locations() const {
@@ -385,6 +573,75 @@ int rawstor_object_create_at(
         }
 
         return res;
+    } catch (const std::system_error& e) {
+        return -e.code().value();
+    } catch (const std::bad_alloc& e) {
+        return -ENOMEM;
+    } catch (const std::exception& e) {
+        rawstd_error("%s\n", e.what());
+        return -EINVAL;
+    } catch (...) {
+        rawstd_error("Unexpected error\n");
+        return -EINVAL;
+    }
+}
+
+int rawstor_object_spec_async(
+    RawIOQueue* queue, const char* target, RawstorObjectSpec* spec,
+    int (*cb)(int result, void* data), void* data
+) noexcept {
+    try {
+        rawstor::Object::spec(
+            *static_cast<rawio::Queue*>(queue), rawstd::URI::uriv(target), spec,
+            [cb, data](int error) { cb(error ? -error : 0, data); }
+        );
+        return 0;
+    } catch (const std::system_error& e) {
+        return -e.code().value();
+    } catch (const std::bad_alloc& e) {
+        return -ENOMEM;
+    } catch (const std::exception& e) {
+        rawstd_error("%s\n", e.what());
+        return -EINVAL;
+    } catch (...) {
+        rawstd_error("Unexpected error\n");
+        return -EINVAL;
+    }
+}
+
+int rawstor_object_create_async(
+    RawIOQueue* queue, const char* target, const RawstorObjectSpec* spec,
+    int (*cb)(int result, void* data), void* data
+) noexcept {
+    try {
+        rawstor::Object::create(
+            *static_cast<rawio::Queue*>(queue), rawstd::URI::uriv(target),
+            *spec, [cb, data](int error) { cb(error ? -error : 0, data); }
+        );
+        return 0;
+    } catch (const std::system_error& e) {
+        return -e.code().value();
+    } catch (const std::bad_alloc& e) {
+        return -ENOMEM;
+    } catch (const std::exception& e) {
+        rawstd_error("%s\n", e.what());
+        return -EINVAL;
+    } catch (...) {
+        rawstd_error("Unexpected error\n");
+        return -EINVAL;
+    }
+}
+
+int rawstor_object_remove_async(
+    RawIOQueue* queue, const char* target, int (*cb)(int result, void* data),
+    void* data
+) noexcept {
+    try {
+        rawstor::Object::remove(
+            *static_cast<rawio::Queue*>(queue), rawstd::URI::uriv(target),
+            [cb, data](int error) { cb(error ? -error : 0, data); }
+        );
+        return 0;
     } catch (const std::system_error& e) {
         return -e.code().value();
     } catch (const std::bad_alloc& e) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -247,13 +247,64 @@ Object::Object(rawio::Queue& queue, const std::vector<rawstd::URI>& targets) :
     if (res < 0) {
         RAWSTD_THROW_SYSTEM_ERROR(-res);
     }
+}
 
-    _cns.reserve(targets.size());
-    for (const auto& target : targets) {
+/*
+ * Async object opening: one connection per target, opened sequentially.
+ * The object owns itself through the state until the last connection is
+ * bound; on failure the object is destroyed (closing every connection
+ * opened so far) and cb receives nullptr.
+ */
+struct Object::OpenState {
+    std::vector<rawstd::URI> targets;
+    std::function<void(Object*, int)> cb;
+    std::unique_ptr<Object> object;
+    size_t next;
+};
+
+void Object::open(
+    rawio::Queue& queue, const std::vector<rawstd::URI>& targets,
+    std::function<void(Object*, int)>&& cb
+) {
+    std::unique_ptr<Object> object(new Object(queue, targets));
+    Object* raw = object.get();
+
+    std::shared_ptr<OpenState> st = std::make_shared<OpenState>(
+        OpenState{targets, std::move(cb), std::move(object), 0}
+    );
+    raw->_open_next(st);
+}
+
+void Object::_open_next(const std::shared_ptr<OpenState>& st) {
+    if (st->next == st->targets.size()) {
+        st->cb(st->object.release(), 0);
+        return;
+    }
+
+    try {
         std::unique_ptr<rawstor::Connection> cn =
             std::make_unique<rawstor::Connection>(_queue);
-        cn->open(target.parent(), this, rawstor_opts_sessions());
+        Connection* raw = cn.get();
         _cns.push_back(std::move(cn));
+
+        raw->open(
+            st->targets[st->next].parent(), this, rawstor_opts_sessions(),
+            [this, st](int error) {
+                if (error) {
+                    st->cb(nullptr, error);
+                    return;
+                }
+                ++st->next;
+                _open_next(st);
+            }
+        );
+    } catch (const std::system_error& e) {
+        st->cb(nullptr, e.code().value());
+    } catch (const std::bad_alloc& e) {
+        st->cb(nullptr, ENOMEM);
+    } catch (const std::exception& e) {
+        rawstd_error("%s\n", e.what());
+        st->cb(nullptr, EINVAL);
     }
 }
 
@@ -693,15 +744,58 @@ int rawstor_object_open(
     RawIOQueue* queue, const char* target, RawstorObject** object
 ) noexcept {
     try {
-        std::unique_ptr<rawstor::Object> ret =
-            std::make_unique<rawstor::Object>(
-                *static_cast<rawio::Queue*>(queue), rawstd::URI::uriv(target)
-            );
+        rawio::Queue& q = *static_cast<rawio::Queue*>(queue);
 
-        *object = ret.get();
+        *object = nullptr;
 
-        ret.release();
+        rawstor::Object* ret = nullptr;
+        int result = 0;
+        bool done = false;
 
+        rawstor::Object::open(
+            q, rawstd::URI::uriv(target),
+            [&ret, &result, &done](rawstor::Object* obj, int error) {
+                ret = obj;
+                result = error;
+                done = true;
+            }
+        );
+
+        while (!done) {
+            q.wait_timeout(rawstor_opts_tcp_user_timeout());
+        }
+
+        if (result) {
+            return -result;
+        }
+
+        *object = ret;
+
+        return 0;
+    } catch (const std::system_error& e) {
+        return -e.code().value();
+    } catch (const std::bad_alloc& e) {
+        return -ENOMEM;
+    } catch (const std::exception& e) {
+        rawstd_error("%s\n", e.what());
+        return -EINVAL;
+    } catch (...) {
+        rawstd_error("Unexpected error\n");
+        return -EINVAL;
+    }
+}
+
+int rawstor_object_open_async(
+    RawIOQueue* queue, const char* target,
+    int (*cb)(RawstorObject* object, int result, void* data), void* data
+) noexcept {
+    try {
+        rawstor::Object::open(
+            *static_cast<rawio::Queue*>(queue), rawstd::URI::uriv(target),
+            [cb, data](rawstor::Object* object, int error) {
+                cb(object, error ? -error : 0, data);
+            }
+        );
         return 0;
     } catch (const std::system_error& e) {
         return -e.code().value();

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -26,6 +26,19 @@ private:
 
 public:
     static void create(
+        rawio::Queue& queue, const std::vector<rawstd::URI>& targets,
+        const RawstorObjectSpec& sp, std::function<void(int)>&& cb
+    );
+    static void remove(
+        rawio::Queue& queue, const std::vector<rawstd::URI>& targets,
+        std::function<void(int)>&& cb
+    );
+    static void spec(
+        rawio::Queue& queue, const std::vector<rawstd::URI>& targets,
+        RawstorObjectSpec* sp, std::function<void(int)>&& cb
+    );
+
+    static void create(
         const std::vector<rawstd::URI>& targets, const RawstorObjectSpec& sp
     );
     static void remove(const std::vector<rawstd::URI>& targets);

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -20,11 +20,22 @@ class Connection;
 
 class Object final : public RawstorObject {
 private:
+    struct OpenState;
+
     rawio::Queue& _queue;
     RawstdUUID _id;
     std::vector<std::unique_ptr<rawstor::Connection>> _cns;
 
+    Object(rawio::Queue& queue, const std::vector<rawstd::URI>& targets);
+
+    void _open_next(const std::shared_ptr<OpenState>& st);
+
 public:
+    static void open(
+        rawio::Queue& queue, const std::vector<rawstd::URI>& targets,
+        std::function<void(Object*, int)>&& cb
+    );
+
     static void create(
         rawio::Queue& queue, const std::vector<rawstd::URI>& targets,
         const RawstorObjectSpec& sp, std::function<void(int)>&& cb
@@ -45,7 +56,6 @@ public:
     static void
     spec(const std::vector<rawstd::URI>& targets, RawstorObjectSpec* sp);
 
-    Object(rawio::Queue& queue, const std::vector<rawstd::URI>& targets);
     Object(const Object&) = delete;
     Object(Object&&) = delete;
     Object& operator=(const Object&) = delete;

--- a/src/opts.c
+++ b/src/opts.c
@@ -9,6 +9,7 @@
 #define RAWSTOR_OPTS_SO_SNDTIMEO 5000
 #define RAWSTOR_OPTS_SO_RCVTIMEO 5000
 #define RAWSTOR_OPTS_TCP_USER_TIMEOUT 5000
+#define RAWSTOR_OPTS_WAIT_DEVICE_TIMEOUT 5000
 
 static struct RawstorOpts _rawstor_opts = {};
 
@@ -60,6 +61,14 @@ int rawstor_opts_initialize(const struct RawstorOpts* opts) {
                   "RAWSTOR_OPTS_TCP_USER_TIMEOUT", RAWSTOR_OPTS_TCP_USER_TIMEOUT
               );
 
+    _rawstor_opts.wait_device_timeout =
+        (opts != NULL && opts->wait_device_timeout != 0)
+            ? opts->wait_device_timeout
+            : get_env_uint(
+                  "RAWSTOR_OPTS_WAIT_DEVICE_TIMEOUT",
+                  RAWSTOR_OPTS_WAIT_DEVICE_TIMEOUT
+              );
+
     return 0;
 }
 
@@ -87,4 +96,8 @@ unsigned int rawstor_opts_so_rcvtimeo(void) {
 
 unsigned int rawstor_opts_tcp_user_timeout(void) {
     return _rawstor_opts.tcp_user_timeout;
+}
+
+unsigned int rawstor_opts_wait_device_timeout(void) {
+    return _rawstor_opts.wait_device_timeout;
 }

--- a/src/opts.h
+++ b/src/opts.h
@@ -14,6 +14,7 @@ extern "C" {
 //     unsigned int so_sndtimeo;
 //     unsigned int so_rcvtimeo;
 //     unsigned int tcp_user_timeout;
+//     unsigned int wait_device_timeout;
 // };
 
 int rawstor_opts_initialize(const struct RawstorOpts* opts);
@@ -29,6 +30,8 @@ unsigned int rawstor_opts_so_sndtimeo(void);
 unsigned int rawstor_opts_so_rcvtimeo(void);
 
 unsigned int rawstor_opts_tcp_user_timeout(void);
+
+unsigned int rawstor_opts_wait_device_timeout(void);
 
 #ifdef __cplusplus
 }

--- a/src/ost_session.cpp
+++ b/src/ost_session.cpp
@@ -776,32 +776,34 @@ int Session::_connect() {
 }
 
 void Session::_basic(
-    RawstorOSTCommandType cmd, const RawstdUUID& id, uint64_t val
+    RawstorOSTCommandType cmd, const RawstdUUID& id, uint64_t val,
+    std::function<void(int)>&& cb
 ) {
     rawstd::TraceEvent trace_event =
         RAWSTD_TRACE_EVENT('s', "basic cmd %d\n", cmd);
 
-    bool completed = false;
-    RawstorOSTFrameResponse response;
-    std::unique_ptr<rawio::Queue> queue = rawio::Queue::create(2);
-
-    RawstorOSTFrameBasic request = {
-        .head =
-            {
-                .magic = RAWSTOR_MAGIC,
-                .cmd = cmd,
-                .cid = _cid_counter++,
+    auto request =
+        std::make_shared<RawstorOSTFrameBasic>((RawstorOSTFrameBasic){
+            .head =
+                {
+                    .magic = RAWSTOR_MAGIC,
+                    .cmd = cmd,
+                    .cid = _cid_counter++,
+                },
+            .body = {
+                .obj_id = {},
+                .offset = 0,
+                .val = val,
             },
-        .body = {
-            .obj_id = {},
-            .offset = 0,
-            .val = val,
-        },
-    };
-    memcpy(request.body.obj_id, id.bytes, sizeof(request.body.obj_id));
-    queue->write(
-        fd(), &request, sizeof(request),
-        [fd = fd(), trace_event](size_t result, int error) {
+        });
+    memcpy(request->body.obj_id, id.bytes, sizeof(request->body.obj_id));
+
+    auto cb_sp = std::make_shared<std::function<void(int)>>(std::move(cb));
+
+    _queue.write(
+        fd(), request.get(), sizeof(*request),
+        [q = &_queue, fd = fd(), cmd, request, cb_sp,
+         trace_event](size_t result, int error) {
             RAWSTD_TRACE_EVENT_MESSAGE(
                 trace_event, "%zu of %zu, error = %d\n", result,
                 sizeof(RawstorOSTFrameBasic), error
@@ -813,78 +815,57 @@ void Session::_basic(
             }
 
             if (error) {
-                RAWSTD_THROW_SYSTEM_ERROR(error);
+                (*cb_sp)(error);
+                return;
             }
-        }
-    );
 
-    queue->read(
-        fd(), &response, sizeof(response),
-        [fd = fd(), cmd, &response, &completed,
-         trace_event](size_t result, int error) {
-            RAWSTD_TRACE_EVENT_MESSAGE(trace_event, "error = %d\n", error);
+            auto response = std::make_shared<RawstorOSTFrameResponse>();
 
-            completed = true;
+            try {
+                q->read(
+                    fd, response.get(), sizeof(*response),
+                    [fd, cmd, response, cb_sp,
+                     trace_event](size_t result, int error) {
+                        RAWSTD_TRACE_EVENT_MESSAGE(
+                            trace_event, "%zu of %zu, error = %d\n", result,
+                            sizeof(RawstorOSTFrameResponse), error
+                        );
 
-            RAWSTD_TRACE_EVENT_MESSAGE(
-                trace_event, "%zu of %zu, error = %d\n", result,
-                sizeof(RawstorOSTFrameResponse), error
-            );
+                        if (!error) {
+                            error = validate_result(
+                                fd, sizeof(RawstorOSTFrameResponse), result
+                            );
+                        }
 
-            if (!error) {
-                error = validate_result(
-                    fd, sizeof(RawstorOSTFrameResponse), result
+                        if (!error) {
+                            error = validate_response(fd, response.get());
+                        }
+
+                        if (!error) {
+                            error = validate_cmd(fd, response->head.cmd, cmd);
+                        }
+
+                        (*cb_sp)(error);
+                    }
                 );
-            }
-
-            if (!error) {
-                error = validate_response(fd, &response);
-            }
-
-            if (!error) {
-                error = validate_cmd(fd, response.head.cmd, cmd);
-            }
-
-            if (error) {
-                RAWSTD_THROW_SYSTEM_ERROR(error);
+            } catch (const std::system_error& e) {
+                (*cb_sp)(e.code().value());
+            } catch (const std::bad_alloc& e) {
+                (*cb_sp)(ENOMEM);
             }
         }
     );
-
-    while (!completed) {
-        queue->wait_timeout(5000);
-    }
-}
-
-void Session::_set_object(Object* object) {
-    _basic(RAWSTOR_CMD_SET_OBJECT, object->id(), 0);
 }
 
 void Session::create(
     const RawstdUUID& id, const RawstorObjectSpec& spec,
     std::function<void(int)>&& cb
 ) {
-    int error = 0;
-    try {
-        _basic(RAWSTOR_CMD_ALLOCATE, id, spec.size);
-    } catch (const std::system_error& e) {
-        error = e.code().value();
-    } catch (...) {
-        error = EIO;
-    }
-    cb(error);
+    _basic(RAWSTOR_CMD_ALLOCATE, id, spec.size, std::move(cb));
 }
 
 void Session::remove(const RawstdUUID& id, std::function<void(int)>&& cb) {
-    int error = 0;
-    try {
-        _basic(RAWSTOR_CMD_RELEASE, id, 0);
-    } catch (const std::system_error& e) {
-        error = e.code().value();
-    } catch (...) {
-        error = EIO;
-    }
-    cb(error);
+    _basic(RAWSTOR_CMD_RELEASE, id, 0, std::move(cb));
 }
 
 void Session::spec(
@@ -907,10 +888,29 @@ void Session::spec(
     cb(ret, 0);
 }
 
-void Session::set_object(Object* object) {
-    _set_object(object);
-    _context = std::make_shared<Context>(_queue, fd());
-    _context->setup_recv();
+void Session::set_object(Object* object, std::function<void(int)>&& cb) {
+    _basic(
+        RAWSTOR_CMD_SET_OBJECT, object->id(), 0,
+        [this, cb = std::move(cb)](int error) {
+            if (error) {
+                cb(error);
+                return;
+            }
+
+            try {
+                _context = std::make_shared<Context>(_queue, fd());
+                _context->setup_recv();
+            } catch (const std::system_error& e) {
+                cb(e.code().value());
+                return;
+            } catch (const std::bad_alloc& e) {
+                cb(ENOMEM);
+                return;
+            }
+
+            cb(0);
+        }
+    );
 }
 
 void Session::pread(

--- a/src/ost_session.cpp
+++ b/src/ost_session.cpp
@@ -17,8 +17,6 @@
 
 #include <arpa/inet.h>
 
-#include <poll.h>
-
 #include <algorithm>
 #include <iterator>
 #include <memory>
@@ -642,8 +640,6 @@ void Context::register_op(const std::shared_ptr<SessionOp>& op) {
 Session::Session(rawio::Queue& queue, const rawstd::URI& location) :
     rawstor::Session(queue, location),
     _cid_counter(0) {
-    int fd = _connect();
-    set_fd(fd);
 }
 
 Session::~Session() {
@@ -652,7 +648,7 @@ Session::~Session() {
     }
 }
 
-int Session::_connect() {
+void Session::connect(std::function<void(int)>&& cb) {
     if (!location().path().str().empty() && location().path().str() != "/") {
         rawstd_error("Empty path expected: %s\n", location().str().c_str());
         RAWSTD_THROW_SYSTEM_ERROR(EINVAL);
@@ -690,12 +686,19 @@ int Session::_connect() {
             }
         }
 
-        sockaddr_in servaddr = {};
-        servaddr.sin_family = AF_INET;
-        servaddr.sin_port = htons(location().port());
+        /*
+         * The address is kept alive by the callback capture: io_uring reads
+         * it when the connect operation is executed, not when submitted.
+         * The socket stays blocking, so SO_SNDTIMEO still bounds the
+         * connect; io_uring runs it in a worker thread without stalling
+         * the event loop.
+         */
+        auto servaddr = std::make_shared<sockaddr_in>();
+        servaddr->sin_family = AF_INET;
+        servaddr->sin_port = htons(location().port());
 
         res = inet_pton(
-            AF_INET, location().hostname().c_str(), &servaddr.sin_addr
+            AF_INET, location().hostname().c_str(), &servaddr->sin_addr
         );
         if (res == 0) {
             RAWSTD_THROW_SYSTEM_ERROR(EINVAL);
@@ -706,73 +709,38 @@ int Session::_connect() {
         rawstd_info(
             "fd %d: Connecting to %s...\n", fd, location().str().c_str()
         );
-        int res = connect(fd, (sockaddr*)&servaddr, sizeof(servaddr));
-        if (res == -1) {
-            if (errno == EINTR) {
-                errno = 0;
 
-                pollfd fds = {
-                    .fd = fd,
-                    .events = POLLOUT,
-                    .revents = 0,
-                };
-                rawstd_warning("Connect interrupted; polling...\n");
-                for (unsigned int attempt = 1;
-                     attempt <= rawstor_opts_io_attempts(); ++attempt) {
-                    try {
-                        res = poll(&fds, 1, so_sndtimeo);
-                        if (res == -1) {
-                            RAWSTD_THROW_ERRNO();
-                        }
-                        if (res == 0) {
-                            RAWSTD_THROW_SYSTEM_ERROR(ETIMEDOUT);
-                        }
-                        break;
-                    } catch (const std::exception& e) {
-                        if (attempt != rawstor_opts_io_attempts()) {
-                            rawstd_warning(
-                                "Poll failed; error: %s; "
-                                "attempt: %d of %d; retrying...\n",
-                                e.what(), attempt, rawstor_opts_io_attempts()
-                            );
-                        } else {
-                            rawstd_warning(
-                                "Poll failed; error: %s; "
-                                "attempt: %d of %d; failing...\n",
-                                e.what(), attempt, rawstor_opts_io_attempts()
-                            );
-                            throw;
-                        }
-                    }
+        _queue.connect(
+            fd, reinterpret_cast<const sockaddr*>(servaddr.get()),
+            sizeof(*servaddr),
+            [this, fd, servaddr, cb = std::move(cb)](int result) {
+                if (result < 0) {
+                    ::close(fd);
+                    rawstd_info("fd %d: Closed\n", fd);
+                    cb(-result);
+                    return;
                 }
 
-                int value = 0;
-                socklen_t value_len = sizeof(value);
-                res = getsockopt(fd, SOL_SOCKET, SO_ERROR, &value, &value_len);
-                if (res == -1) {
-                    RAWSTD_THROW_ERRNO();
-                }
-                if (value) {
-                    RAWSTD_THROW_SYSTEM_ERROR(value);
+                rawstd_info("fd %d: Connected\n", fd);
+
+                try {
+                    rawio::Queue::setup_fd(fd);
+                } catch (const std::system_error& e) {
+                    ::close(fd);
+                    rawstd_info("fd %d: Closed\n", fd);
+                    cb(e.code().value());
+                    return;
                 }
 
-                if (!(fds.revents & POLLOUT)) {
-                    RAWSTD_THROW_SYSTEM_ERROR(ENOTCONN);
-                }
-            } else {
-                RAWSTD_THROW_ERRNO();
+                set_fd(fd);
+                cb(0);
             }
-        }
-        rawstd_info("fd %d: Connected\n", fd);
-
-        rawio::Queue::setup_fd(fd);
+        );
     } catch (...) {
         ::close(fd);
         rawstd_info("fd %d: Closed\n", fd);
         throw;
     }
-
-    return fd;
 }
 
 void Session::_basic(

--- a/src/ost_session.cpp
+++ b/src/ost_session.cpp
@@ -603,17 +603,26 @@ void Context::setup_recv() {
                     }
                 } catch (const std::system_error& e) {
                     error = e.code().value();
+                    context->_read_event = nullptr;
                     context->_fail_in_flight(error, &is_head, &size);
                     RAWSTD_THROW_SYSTEM_ERROR(error);
                 } catch (const std::exception& e) {
                     rawstd_error("%s\n", e.what());
                     error = EPROTO;
+                    context->_read_event = nullptr;
                     context->_fail_in_flight(error, &is_head, &size);
                     RAWSTD_THROW_SYSTEM_ERROR(error);
                 }
             }
 
             if (error) {
+                /*
+                 * A terminal error ends the multishot event: the queue
+                 * releases it, so it must not be cancelled in
+                 * teardown_recv() - the stale pointer could alias an event
+                 * of another session by then.
+                 */
+                context->_read_event = nullptr;
                 context->_fail_in_flight(error, &is_head, &size);
             }
 

--- a/src/ost_session.hpp
+++ b/src/ost_session.hpp
@@ -30,7 +30,6 @@ private:
 
     std::shared_ptr<Context> _context;
 
-    int _connect();
     void _basic(
         RawstorOSTCommandType cmd, const RawstdUUID& id, uint64_t val,
         std::function<void(int)>&& cb
@@ -39,6 +38,8 @@ private:
 public:
     Session(rawio::Queue& queue, const rawstd::URI& location);
     ~Session();
+
+    void connect(std::function<void(int)>&& cb) override;
 
     void create(
         const RawstdUUID& id, const RawstorObjectSpec& sp,

--- a/src/ost_session.hpp
+++ b/src/ost_session.hpp
@@ -31,8 +31,10 @@ private:
     std::shared_ptr<Context> _context;
 
     int _connect();
-    void _basic(RawstorOSTCommandType cmd, const RawstdUUID& id, uint64_t val);
-    void _set_object(Object* object);
+    void _basic(
+        RawstorOSTCommandType cmd, const RawstdUUID& id, uint64_t val,
+        std::function<void(int)>&& cb
+    );
 
 public:
     Session(rawio::Queue& queue, const rawstd::URI& location);
@@ -50,7 +52,7 @@ public:
         std::function<void(const RawstorObjectSpec&, int)>&& cb
     ) override;
 
-    void set_object(Object* object) override;
+    void set_object(Object* object, std::function<void(int)>&& cb) override;
 
     void pread(
         void* buf, size_t size, off_t offset,

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -2,7 +2,9 @@
 
 #include "config.h"
 #include "file_session.hpp"
+#include "lvm_session.hpp"
 #include "ost_session.hpp"
+#include "zfs_session.hpp"
 
 #include <rawstd/logging.h>
 #include <rawstd/uri.hpp>
@@ -44,6 +46,12 @@ Session::create(rawio::Queue& queue, const rawstd::URI& location) {
     }
     if (location.scheme() == "file") {
         return std::make_unique<rawstor::file::Session>(queue, location);
+    }
+    if (location.scheme() == "lvm") {
+        return std::make_unique<rawstor::lvm::Session>(queue, location);
+    }
+    if (location.scheme() == "zfs") {
+        return std::make_unique<rawstor::zfs::Session>(queue, location);
     }
     rawstd_error("Unexpected URI scheme: %s\n", location.str().c_str());
     RAWSTD_THROW_SYSTEM_ERROR(EINVAL);

--- a/src/session.hpp
+++ b/src/session.hpp
@@ -44,6 +44,12 @@ public:
 
     inline int fd() const noexcept { return _fd; }
 
+    /*
+     * Establishes the backend connection. Local backends have nothing to
+     * connect and complete immediately.
+     */
+    virtual void connect(std::function<void(int)>&& cb) { cb(0); }
+
     virtual void create(
         const RawstdUUID& id, const RawstorObjectSpec& sp,
         std::function<void(int)>&& cb

--- a/src/session.hpp
+++ b/src/session.hpp
@@ -57,7 +57,7 @@ public:
         std::function<void(const RawstorObjectSpec&, int)>&& cb
     ) = 0;
 
-    virtual void set_object(Object* object) = 0;
+    virtual void set_object(Object* object, std::function<void(int)>&& cb) = 0;
 
     virtual void pread(
         void* buf, size_t size, off_t offset,

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -1,0 +1,86 @@
+#include "worker.hpp"
+
+#include <rawstd/logging.h>
+
+#include <rawio/queue.hpp>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <memory>
+#include <system_error>
+#include <thread>
+#include <utility>
+
+namespace rawstor {
+
+void run_in_worker(
+    rawio::Queue& queue, std::function<int()>&& work,
+    std::function<void(int)>&& cb
+) {
+    int pipe_fds[2];
+    if (pipe2(pipe_fds, O_CLOEXEC) != 0) {
+        cb(errno);
+        return;
+    }
+
+    int rfd = pipe_fds[0];
+    int wfd = pipe_fds[1];
+
+    /*
+     * Register an async read on the pipe's read end. When the worker thread
+     * finishes and writes the result, the queue completion fires cb without
+     * ever having blocked the event loop.
+     */
+    auto result = std::make_shared<int>(0);
+    try {
+        queue.read(
+            rfd, result.get(), sizeof(*result),
+            [rfd, result, cb = std::move(cb)](size_t bytes, int error) {
+                close(rfd);
+                cb(error || bytes != sizeof(*result) ? (error ? error : EIO)
+                                                     : *result);
+            }
+        );
+    } catch (...) {
+        close(rfd);
+        close(wfd);
+        throw;
+    }
+
+    /*
+     * Worker thread: runs the work and writes the errno result (0 = success,
+     * positive = errno) to the pipe write end. Closing the write end is the
+     * only cleanup needed; the read end is owned by the queue completion
+     * above. If the thread cannot be spawned, the result is written here so
+     * the pending read always completes.
+     */
+    try {
+        std::thread([work = std::move(work), wfd]() {
+            int res;
+            try {
+                res = work();
+            } catch (const std::system_error& e) {
+                res = e.code().value();
+            } catch (const std::exception& e) {
+                rawstd_error("%s\n", e.what());
+                res = EIO;
+            } catch (...) {
+                rawstd_error("Unexpected error\n");
+                res = EIO;
+            }
+
+            ssize_t n = write(wfd, &res, sizeof(res));
+            (void)n;
+            close(wfd);
+        }).detach();
+    } catch (const std::system_error& e) {
+        int res = e.code().value();
+        ssize_t n = write(wfd, &res, sizeof(res));
+        (void)n;
+        close(wfd);
+    }
+}
+
+} // namespace rawstor

--- a/src/worker.hpp
+++ b/src/worker.hpp
@@ -1,0 +1,26 @@
+#ifndef RAWSTOR_WORKER_HPP
+#define RAWSTOR_WORKER_HPP
+
+#include <rawio/queue.hpp>
+
+#include <functional>
+
+namespace rawstor {
+
+/*
+ * Runs blocking work in a detached thread without stalling the event loop.
+ *
+ * work is executed in the thread and returns 0 on success or a positive
+ * errno value on failure; a thrown std::system_error is converted to its
+ * code. The result is delivered back through a pipe registered on queue,
+ * and cb is invoked from the queue completion context with 0 on success
+ * or a positive errno value on failure.
+ */
+void run_in_worker(
+    rawio::Queue& queue, std::function<int()>&& work,
+    std::function<void(int)>&& cb
+);
+
+} // namespace rawstor
+
+#endif // RAWSTOR_WORKER_HPP

--- a/src/zfs_session.cpp
+++ b/src/zfs_session.cpp
@@ -1,0 +1,112 @@
+#include "zfs_session.hpp"
+
+#include <rawstd/gpp.hpp>
+#include <rawstd/logging.h>
+#include <rawstd/uuid.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+namespace rawstor {
+namespace zfs {
+
+static std::string parse_parent_dataset(const rawstd::URI& location) {
+    if (location.scheme() != "zfs") {
+        rawstd_error("Unexpected URI scheme: %s\n", location.str().c_str());
+        RAWSTD_THROW_SYSTEM_ERROR(EINVAL);
+    }
+    if (!location.host().empty()) {
+        rawstd_error("Empty host expected: %s\n", location.str().c_str());
+        RAWSTD_THROW_SYSTEM_ERROR(EINVAL);
+    }
+    std::string path = location.path().str();
+    if (path.empty() || path == "/") {
+        rawstd_error(
+            "Parent dataset is empty in URI: %s\n", location.str().c_str()
+        );
+        RAWSTD_THROW_SYSTEM_ERROR(EINVAL);
+    }
+    /* Strip leading slash: /tank/rawstor → tank/rawstor */
+    if (path.front() == '/') {
+        path = path.substr(1);
+    }
+    return path;
+}
+
+Session::Session(rawio::Queue& queue, const rawstd::URI& location) :
+    BlkdevSession(queue, location),
+    _parent_dataset(parse_parent_dataset(location)) {
+}
+
+std::string Session::device_path(const RawstdUUID& id) const {
+    RawstdUUIDString uuid_str;
+    rawstd_uuid_to_string(&id, &uuid_str);
+
+    std::ostringstream oss;
+    oss << "/dev/zvol/" << _parent_dataset << "/" << uuid_str;
+    return oss.str();
+}
+
+void Session::create(
+    const RawstdUUID& id, const RawstorObjectSpec& sp,
+    std::function<void(int)>&& cb
+) {
+    RawstdUUIDString uuid_str;
+    rawstd_uuid_to_string(&id, &uuid_str);
+
+    std::string dataset = _parent_dataset + "/" + uuid_str;
+
+    char size_arg[64];
+    snprintf(size_arg, sizeof(size_arg), "%zu", sp.size);
+
+    rawstd_info(
+        "zfs: creating zvol %s, size %s bytes\n", dataset.c_str(), size_arg
+    );
+
+    const char* argv[] = {
+        "zfs", "create", "-V", size_arg, dataset.c_str(), nullptr
+    };
+
+    int res = run_command(argv);
+    if (res != 0) {
+        rawstd_error("zfs: create failed for dataset %s\n", dataset.c_str());
+        RAWSTD_THROW_SYSTEM_ERROR(-res);
+    }
+
+    std::string path = device_path(id);
+    res = wait_for_device(path);
+    if (res != 0) {
+        rawstd_error("zfs: device %s did not appear\n", path.c_str());
+        RAWSTD_THROW_SYSTEM_ERROR(-res);
+    }
+
+    cb(0);
+}
+
+void Session::remove(const RawstdUUID& id, std::function<void(int)>&& cb) {
+    RawstdUUIDString uuid_str;
+    rawstd_uuid_to_string(&id, &uuid_str);
+
+    std::string dataset = _parent_dataset + "/" + uuid_str;
+
+    rawstd_info("zfs: destroying zvol %s\n", dataset.c_str());
+
+    const char* argv[] = {"zfs", "destroy", dataset.c_str(), nullptr};
+
+    int res = run_command(argv);
+    if (res != 0) {
+        rawstd_error(
+            "zfs: destroy failed for dataset %s\n", dataset.c_str()
+        );
+        RAWSTD_THROW_SYSTEM_ERROR(-res);
+    }
+
+    cb(0);
+}
+
+} // namespace zfs
+} // namespace rawstor

--- a/src/zfs_session.cpp
+++ b/src/zfs_session.cpp
@@ -4,11 +4,9 @@
 #include <rawstd/logging.h>
 #include <rawstd/uuid.h>
 
-#include <cerrno>
 #include <cstdio>
 #include <cstring>
 #include <sstream>
-#include <stdexcept>
 #include <string>
 
 namespace rawstor {
@@ -60,30 +58,25 @@ void Session::create(
 
     std::string dataset = _parent_dataset + "/" + uuid_str;
 
-    char size_arg[64];
-    snprintf(size_arg, sizeof(size_arg), "%zu", sp.size);
+    char size_buf[64];
+    snprintf(size_buf, sizeof(size_buf), "%zu", sp.size);
 
     rawstd_info(
-        "zfs: creating zvol %s, size %s bytes\n", dataset.c_str(), size_arg
+        "zfs: creating zvol %s, size %s bytes\n", dataset.c_str(), size_buf
     );
 
-    const char* argv[] = {"zfs",    "create",        "-V",
-                          size_arg, dataset.c_str(), nullptr};
-
-    int res = run_command(argv);
-    if (res != 0) {
-        rawstd_error("zfs: create failed for dataset %s\n", dataset.c_str());
-        RAWSTD_THROW_SYSTEM_ERROR(-res);
-    }
-
-    std::string path = device_path(id);
-    res = wait_for_device(path);
-    if (res != 0) {
-        rawstd_error("zfs: device %s did not appear\n", path.c_str());
-        RAWSTD_THROW_SYSTEM_ERROR(-res);
-    }
-
-    cb(0);
+    run_async(
+        {"zfs", "create", "-V", size_buf, dataset}, device_path(id),
+        [dataset, cb = std::move(cb)](int error) mutable {
+            if (error != 0) {
+                rawstd_error(
+                    "zfs: failed to create zvol %s: %s\n", dataset.c_str(),
+                    strerror(error)
+                );
+            }
+            cb(error);
+        }
+    );
 }
 
 void Session::remove(const RawstdUUID& id, std::function<void(int)>&& cb) {
@@ -94,15 +87,18 @@ void Session::remove(const RawstdUUID& id, std::function<void(int)>&& cb) {
 
     rawstd_info("zfs: destroying zvol %s\n", dataset.c_str());
 
-    const char* argv[] = {"zfs", "destroy", dataset.c_str(), nullptr};
-
-    int res = run_command(argv);
-    if (res != 0) {
-        rawstd_error("zfs: destroy failed for dataset %s\n", dataset.c_str());
-        RAWSTD_THROW_SYSTEM_ERROR(-res);
-    }
-
-    cb(0);
+    run_async(
+        {"zfs", "destroy", dataset}, "",
+        [dataset, cb = std::move(cb)](int error) mutable {
+            if (error != 0) {
+                rawstd_error(
+                    "zfs: failed to destroy zvol %s: %s\n", dataset.c_str(),
+                    strerror(error)
+                );
+            }
+            cb(error);
+        }
+    );
 }
 
 } // namespace zfs

--- a/src/zfs_session.cpp
+++ b/src/zfs_session.cpp
@@ -67,9 +67,8 @@ void Session::create(
         "zfs: creating zvol %s, size %s bytes\n", dataset.c_str(), size_arg
     );
 
-    const char* argv[] = {
-        "zfs", "create", "-V", size_arg, dataset.c_str(), nullptr
-    };
+    const char* argv[] = {"zfs",    "create",        "-V",
+                          size_arg, dataset.c_str(), nullptr};
 
     int res = run_command(argv);
     if (res != 0) {
@@ -99,9 +98,7 @@ void Session::remove(const RawstdUUID& id, std::function<void(int)>&& cb) {
 
     int res = run_command(argv);
     if (res != 0) {
-        rawstd_error(
-            "zfs: destroy failed for dataset %s\n", dataset.c_str()
-        );
+        rawstd_error("zfs: destroy failed for dataset %s\n", dataset.c_str());
         RAWSTD_THROW_SYSTEM_ERROR(-res);
     }
 

--- a/src/zfs_session.cpp
+++ b/src/zfs_session.cpp
@@ -4,6 +4,7 @@
 #include <rawstd/logging.h>
 #include <rawstd/uuid.h>
 
+#include <cinttypes>
 #include <cstdio>
 #include <cstring>
 #include <sstream>
@@ -59,7 +60,7 @@ void Session::create(
     std::string dataset = _parent_dataset + "/" + uuid_str;
 
     char size_buf[64];
-    snprintf(size_buf, sizeof(size_buf), "%zu", sp.size);
+    snprintf(size_buf, sizeof(size_buf), "%" PRIu64, sp.size);
 
     rawstd_info(
         "zfs: creating zvol %s, size %s bytes\n", dataset.c_str(), size_buf

--- a/src/zfs_session.hpp
+++ b/src/zfs_session.hpp
@@ -1,0 +1,48 @@
+#ifndef RAWSTOR_ZFS_SESSION_HPP
+#define RAWSTOR_ZFS_SESSION_HPP
+
+#include "blkdev_session.hpp"
+
+#include <rawstd/uri.hpp>
+#include <rawstd/uuid.h>
+
+#include <string>
+
+namespace rawstor {
+namespace zfs {
+
+/*
+ * ZFS zvol storage backend.
+ *
+ * Location URI: zfs:///<pool>[/<dataset>]
+ *   Example:    zfs:///tank/rawstor
+ *
+ * Each object is a zvol created under the parent dataset, named after its UUID.
+ * Zvol dataset:  <parent_dataset>/<uuid>
+ * Device path:   /dev/zvol/<parent_dataset>/<uuid>
+ *
+ * Requires 'zfs' CLI to be available in PATH and sufficient privileges
+ * (typically root or CAP_SYS_ADMIN + ZFS delegation).
+ */
+class Session final : public BlkdevSession {
+private:
+    std::string _parent_dataset;
+
+protected:
+    std::string device_path(const RawstdUUID& id) const override;
+
+public:
+    Session(rawio::Queue& queue, const rawstd::URI& location);
+
+    void create(
+        const RawstdUUID& id, const RawstorObjectSpec& sp,
+        std::function<void(int)>&& cb
+    ) override;
+
+    void remove(const RawstdUUID& id, std::function<void(int)>&& cb) override;
+};
+
+} // namespace zfs
+} // namespace rawstor
+
+#endif // RAWSTOR_ZFS_SESSION_HPP

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -18,8 +18,11 @@ test_all_SOURCES = main.cpp \
                    server.hpp \
                    session.cpp \
                    session.hpp \
+                   test_async_api.cpp \
+                   test_blkdev.cpp \
                    test_io.cpp \
-                   test_lifecycle.cpp
+                   test_lifecycle.cpp \
+                   test_worker.cpp
 test_all_LDADD = $(top_builddir)/src/librawstor.la
 
 

--- a/tests/test_async_api.cpp
+++ b/tests/test_async_api.cpp
@@ -1,0 +1,274 @@
+#include "server.hpp"
+#include "session.hpp"
+
+#include <rawstd/gpp.hpp>
+
+#include <rawstor/object.h>
+#include <rawstor/protocol.h>
+#include <rawstor/rawio.h>
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include <cerrno>
+
+namespace {
+
+class Queue {
+private:
+    RawIOQueue* _queue;
+
+public:
+    Queue(unsigned int size) : _queue(nullptr) {
+        int res = rawio_queue_create(size, &_queue);
+        if (res < 0) {
+            RAWSTD_THROW_SYSTEM_ERROR(-res);
+        }
+    }
+    Queue(const Queue&) = delete;
+    Queue(Queue&&) = delete;
+
+    ~Queue() { rawio_queue_delete(_queue); }
+
+    Queue& operator=(const Queue&) = delete;
+    Queue& operator=(Queue&&) = delete;
+    operator RawIOQueue*() noexcept { return _queue; }
+
+    void wait() {
+        int res = rawio_wait(_queue);
+        if (res < 0) {
+            RAWSTD_THROW_SYSTEM_ERROR(-res);
+        }
+    }
+};
+
+struct AsyncResult {
+    int result = 1;
+    int calls = 0;
+};
+
+int async_cb(int result, void* data) {
+    AsyncResult* r = static_cast<AsyncResult*>(data);
+    r->result = result;
+    ++r->calls;
+    return 0;
+}
+
+struct AsyncOpenResult {
+    RawstorObject* object = nullptr;
+    int result = 1;
+    int calls = 0;
+};
+
+int async_open_cb(RawstorObject* object, int result, void* data) {
+    AsyncOpenResult* r = static_cast<AsyncOpenResult*>(data);
+    r->object = object;
+    r->result = result;
+    ++r->calls;
+    return 0;
+}
+
+void wait_calls(Queue& q, const int& calls) {
+    while (calls == 0) {
+        q.wait();
+    }
+}
+
+std::string file_target(const char* dir, const char* uuid) {
+    std::filesystem::path path =
+        std::filesystem::temp_directory_path() / dir / uuid;
+    std::ostringstream oss;
+    oss << "file://" << path.string();
+    return oss.str();
+}
+
+TEST(FileAsyncLifecycleTest, create_spec_open_remove) {
+    std::string target = file_target(
+        "test_objects_async", "00000000-0000-7000-8000-000000000001"
+    );
+
+    Queue q(64);
+
+    {
+        RawstorObjectSpec spec{.size = 1ull << 20};
+        AsyncResult r;
+        ASSERT_EQ(
+            rawstor_object_create_async(q, target.c_str(), &spec, async_cb, &r),
+            0
+        );
+        wait_calls(q, r.calls);
+        EXPECT_EQ(r.calls, 1);
+        EXPECT_EQ(r.result, 0);
+    }
+
+    {
+        RawstorObjectSpec read_spec{};
+        AsyncResult r;
+        ASSERT_EQ(
+            rawstor_object_spec_async(
+                q, target.c_str(), &read_spec, async_cb, &r
+            ),
+            0
+        );
+        wait_calls(q, r.calls);
+        EXPECT_EQ(r.calls, 1);
+        EXPECT_EQ(r.result, 0);
+        EXPECT_EQ(read_spec.size, 1ull << 20);
+    }
+
+    {
+        AsyncOpenResult r;
+        ASSERT_EQ(
+            rawstor_object_open_async(q, target.c_str(), async_open_cb, &r), 0
+        );
+        wait_calls(q, r.calls);
+        EXPECT_EQ(r.calls, 1);
+        EXPECT_EQ(r.result, 0);
+        ASSERT_NE(r.object, nullptr);
+        EXPECT_EQ(rawstor_object_close(r.object), 0);
+    }
+
+    {
+        AsyncResult r;
+        ASSERT_EQ(
+            rawstor_object_remove_async(q, target.c_str(), async_cb, &r), 0
+        );
+        wait_calls(q, r.calls);
+        EXPECT_EQ(r.calls, 1);
+        EXPECT_EQ(r.result, 0);
+    }
+
+    {
+        RawstorObjectSpec read_spec{};
+        AsyncResult r;
+        ASSERT_EQ(
+            rawstor_object_spec_async(
+                q, target.c_str(), &read_spec, async_cb, &r
+            ),
+            0
+        );
+        wait_calls(q, r.calls);
+        EXPECT_EQ(r.result, -ENOENT);
+    }
+}
+
+TEST(FileAsyncLifecycleTest, open_missing_object) {
+    std::string target = file_target(
+        "test_objects_async", "00000000-0000-7000-8000-0000000000ff"
+    );
+
+    Queue q(64);
+
+    AsyncOpenResult r;
+    ASSERT_EQ(
+        rawstor_object_open_async(q, target.c_str(), async_open_cb, &r), 0
+    );
+    wait_calls(q, r.calls);
+    EXPECT_EQ(r.calls, 1);
+    EXPECT_LT(r.result, 0);
+    EXPECT_EQ(r.object, nullptr);
+}
+
+TEST(FileAsyncLifecycleTest, invalid_target_reports_immediately) {
+    Queue q(64);
+
+    /* The target filename is not a valid UUID. */
+    RawstorObjectSpec spec{.size = 1ull << 20};
+    AsyncResult r;
+    EXPECT_LT(
+        rawstor_object_create_async(
+            q, "file:///tmp/not-a-uuid", &spec, async_cb, &r
+        ),
+        0
+    );
+    EXPECT_EQ(r.calls, 0);
+}
+
+TEST(FileAsyncCreateTest, rollback_on_partial_failure) {
+    namespace fs = std::filesystem;
+
+    const char* uuid = "00000000-0000-7000-8000-00000000abcd";
+    fs::path base = fs::temp_directory_path() / "test_rollback_async";
+    fs::remove_all(base);
+    fs::create_directories(base);
+
+    /*
+     * The second target cannot be created: its backing directory path goes
+     * through a regular file, so mkdir() fails with ENOTDIR. The first
+     * target must be rolled back.
+     */
+    fs::path good = base / "good";
+    fs::path blocker = base / "blocker";
+    std::ofstream(blocker.string()) << "not a directory";
+
+    std::ostringstream oss;
+    oss << "file://" << good.string() << "/" << uuid << ",file://"
+        << (blocker / "sub").string() << "/" << uuid;
+    std::string target = oss.str();
+
+    Queue q(64);
+
+    RawstorObjectSpec spec{.size = 1ull << 20};
+    AsyncResult r;
+    ASSERT_EQ(
+        rawstor_object_create_async(q, target.c_str(), &spec, async_cb, &r), 0
+    );
+    wait_calls(q, r.calls);
+    EXPECT_EQ(r.calls, 1);
+    EXPECT_LT(r.result, 0);
+
+    std::ostringstream dat;
+    dat << uuid << ".dat";
+    std::ostringstream spec_file;
+    spec_file << uuid << ".spec";
+    EXPECT_FALSE(fs::exists(good / dat.str()));
+    EXPECT_FALSE(fs::exists(good / spec_file.str()));
+
+    fs::remove_all(base);
+}
+
+TEST(OstAsyncLifecycleTest, create_remove) {
+    rawstor::tests::Server server(8753, 256);
+    std::string target =
+        "ost://127.0.0.1:8753/00000000-0000-7000-8000-000000000000";
+
+    {
+        rawstor::tests::Session s(server);
+        s.cmd_allocate(RAWSTOR_MAGIC, 0, 0);
+    }
+
+    {
+        rawstor::tests::Session s(server);
+        s.cmd_release(RAWSTOR_MAGIC, 0, 0);
+    }
+
+    Queue q(256);
+
+    {
+        RawstorObjectSpec spec{.size = 1ull << 20};
+        AsyncResult r;
+        ASSERT_EQ(
+            rawstor_object_create_async(q, target.c_str(), &spec, async_cb, &r),
+            0
+        );
+        wait_calls(q, r.calls);
+        EXPECT_EQ(r.calls, 1);
+        EXPECT_EQ(r.result, 0);
+    }
+
+    {
+        AsyncResult r;
+        ASSERT_EQ(
+            rawstor_object_remove_async(q, target.c_str(), async_cb, &r), 0
+        );
+        wait_calls(q, r.calls);
+        EXPECT_EQ(r.calls, 1);
+        EXPECT_EQ(r.result, 0);
+    }
+}
+
+} // unnamed namespace

--- a/tests/test_blkdev.cpp
+++ b/tests/test_blkdev.cpp
@@ -1,0 +1,125 @@
+#include "blkdev_session.hpp"
+
+#include <rawio/queue.hpp>
+
+#include <rawstd/uri.hpp>
+#include <rawstd/uuid.h>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include <cerrno>
+
+namespace {
+
+/*
+ * Exposes the protected run_async() command machinery without requiring an
+ * actual LVM/ZFS setup.
+ */
+class CmdSession final : public rawstor::BlkdevSession {
+protected:
+    std::string device_path(const RawstdUUID&) const override { return ""; }
+
+public:
+    CmdSession(rawio::Queue& queue, const rawstd::URI& location) :
+        BlkdevSession(queue, location) {}
+
+    void create(
+        const RawstdUUID&, const RawstorObjectSpec&, std::function<void(int)>&&
+    ) override {}
+
+    void remove(const RawstdUUID&, std::function<void(int)>&&) override {}
+
+    void
+    run(std::vector<std::string> cmd, std::string wait_path,
+        std::function<void(int)>&& cb) {
+        run_async(std::move(cmd), std::move(wait_path), std::move(cb));
+    }
+};
+
+class BlkdevCmdTest : public ::testing::Test {
+protected:
+    std::unique_ptr<rawio::Queue> _queue;
+    std::unique_ptr<CmdSession> _session;
+
+    void SetUp() override {
+        _queue = rawio::Queue::create(64);
+        rawstd::URI location(std::string("lvm:///dev/test_vg"));
+        _session = std::make_unique<CmdSession>(*_queue, location);
+    }
+
+    int run(std::vector<std::string> cmd, std::string wait_path) {
+        bool done = false;
+        int result = -1;
+
+        _session->run(
+            std::move(cmd), std::move(wait_path), [&done, &result](int error) {
+                result = error;
+                done = true;
+            }
+        );
+
+        while (!done) {
+            _queue->wait_timeout(1000);
+        }
+
+        return result;
+    }
+};
+
+std::string find_block_device() {
+    std::error_code ec;
+    for (const auto& entry :
+         std::filesystem::directory_iterator("/sys/block", ec)) {
+        std::filesystem::path dev = "/dev" / entry.path().filename();
+        if (std::filesystem::exists(dev, ec)) {
+            return dev.string();
+        }
+    }
+    return "";
+}
+
+TEST_F(BlkdevCmdTest, success) {
+    EXPECT_EQ(run({"true"}, ""), 0);
+}
+
+TEST_F(BlkdevCmdTest, nonzero_exit) {
+    EXPECT_EQ(run({"false"}, ""), EIO);
+}
+
+TEST_F(BlkdevCmdTest, missing_binary) {
+    EXPECT_EQ(run({"/no/such/binary"}, ""), ENOENT);
+}
+
+TEST_F(BlkdevCmdTest, slow_child) {
+    EXPECT_EQ(run({"sleep", "0.3"}, ""), 0);
+}
+
+TEST_F(BlkdevCmdTest, wait_existing_device) {
+    std::string dev = find_block_device();
+    if (dev.empty()) {
+        GTEST_SKIP() << "no block devices available";
+    }
+
+    EXPECT_EQ(run({"true"}, dev), 0);
+}
+
+TEST_F(BlkdevCmdTest, wait_missing_device_times_out) {
+    auto start = std::chrono::steady_clock::now();
+
+    EXPECT_EQ(run({"true"}, "/dev/no_such_rawstor_device"), ETIMEDOUT);
+
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::steady_clock::now() - start
+    )
+                       .count();
+    EXPECT_GE(elapsed, 4500);
+    EXPECT_LT(elapsed, 10000);
+}
+
+} // unnamed namespace

--- a/tests/test_worker.cpp
+++ b/tests/test_worker.cpp
@@ -1,0 +1,110 @@
+#include "worker.hpp"
+
+#include <rawio/queue.hpp>
+
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <system_error>
+#include <thread>
+
+#include <cerrno>
+
+namespace {
+
+int run_work(rawio::Queue& q, std::function<int()>&& work) {
+    bool done = false;
+    int result = -1;
+
+    rawstor::run_in_worker(q, std::move(work), [&done, &result](int error) {
+        result = error;
+        done = true;
+    });
+
+    while (!done) {
+        q.wait_timeout(1000);
+    }
+
+    return result;
+}
+
+TEST(WorkerTest, success) {
+    std::unique_ptr<rawio::Queue> q = rawio::Queue::create(64);
+
+    EXPECT_EQ(run_work(*q, []() { return 0; }), 0);
+}
+
+TEST(WorkerTest, error) {
+    std::unique_ptr<rawio::Queue> q = rawio::Queue::create(64);
+
+    EXPECT_EQ(run_work(*q, []() { return EACCES; }), EACCES);
+}
+
+TEST(WorkerTest, thrown_system_error) {
+    std::unique_ptr<rawio::Queue> q = rawio::Queue::create(64);
+
+    EXPECT_EQ(
+        run_work(
+            *q,
+            []() -> int {
+                throw std::system_error(ENOSPC, std::generic_category());
+            }
+        ),
+        ENOSPC
+    );
+}
+
+TEST(WorkerTest, thrown_exception) {
+    std::unique_ptr<rawio::Queue> q = rawio::Queue::create(64);
+
+    EXPECT_EQ(
+        run_work(*q, []() -> int { throw std::runtime_error("boom"); }), EIO
+    );
+}
+
+TEST(WorkerTest, runs_off_the_calling_thread) {
+    std::unique_ptr<rawio::Queue> q = rawio::Queue::create(64);
+
+    std::thread::id worker_id;
+    EXPECT_EQ(
+        run_work(
+            *q,
+            [&worker_id]() {
+                worker_id = std::this_thread::get_id();
+                return 0;
+            }
+        ),
+        0
+    );
+
+    EXPECT_NE(worker_id, std::this_thread::get_id());
+}
+
+TEST(WorkerTest, many_concurrent) {
+    std::unique_ptr<rawio::Queue> q = rawio::Queue::create(256);
+
+    const int n = 32;
+    int completed = 0;
+    int failures = 0;
+
+    for (int i = 0; i < n; ++i) {
+        int expected = (i % 3 == 0) ? EIO : 0;
+        rawstor::run_in_worker(
+            *q, [expected]() { return expected; },
+            [&completed, &failures, expected](int error) {
+                if (error != expected) {
+                    ++failures;
+                }
+                ++completed;
+            }
+        );
+    }
+
+    while (completed < n) {
+        q->wait_timeout(1000);
+    }
+
+    EXPECT_EQ(failures, 0);
+}
+
+} // unnamed namespace


### PR DESCRIPTION
Connection::create/remove/spec now take an external queue and complete via a callback instead of spinning a private queue and blocking in wait(). Object gains async multi-target chains on top of them: create rolls back already created targets on failure, remove visits every target and reports the first error. The synchronous methods remain as thin wrappers around the async versions.

New public API: rawstor_object_create_async(),
rawstor_object_remove_async() and rawstor_object_spec_async().

rawstor-ost now serves RAWSTOR_CMD_ALLOCATE and RAWSTOR_CMD_RELEASE without blocking its event loop: the response is sent from the operation completion callback. A per-session liveness token prevents writing a response into a session destroyed (and an fd possibly reused) while the operation was in flight.