### PR TITLE
add: lifecycle tests (#452)

### DIFF
--- a/pyrawstor/Makefile.am
+++ b/pyrawstor/Makefile.am
@@ -49,7 +49,7 @@ $(builddir)/sources-stamp:
 $(builddir)/build-stamp: $(C_SOURCES) $(builddir)/sources-stamp setup.py
 	CFLAGS="$(CFLAGS) $(AM_CFLAGS)" \
 	LDFLAGS="$(LDFLAGS) $(AM_LDFLAGS)" \
-	$(PYTHON) -m pip install --no-deps -e $(builddir)
+	$(PYTHON) -m pip install --no-deps --no-build-isolation -e $(builddir)
 	touch $@
 
 if WITH_PYTHON3

--- a/tests/test_lifecycle.cpp
+++ b/tests/test_lifecycle.cpp
@@ -2,6 +2,7 @@
 #include "session.hpp"
 
 #include <rawstd/gpp.hpp>
+#include <rawstd/uri.hpp>
 
 #include <rawstor/object.h>
 #include <rawstor/protocol.h>
@@ -14,12 +15,13 @@
 namespace {
 
 TEST(FileLifecycleTest, create_spec_remove) {
-    std::filesystem::path path = std::filesystem::temp_directory_path() /
-                                 "test_objects" /
-                                 "00000000-0000-7000-8000-000000000000";
+    std::filesystem::path location_path =
+        std::filesystem::temp_directory_path() / "test_objects";
     std::ostringstream oss;
-    oss << "file://" << path.string();
-    std::string target = oss.str();
+    oss << "file://" << location_path.string();
+    rawstd::URI location_uri(oss.str());
+    std::string uuid = "00000000-0000-7000-8000-000000000001";
+    std::string target = rawstd::URI(location_uri, uuid).str();
 
     RawstorObjectSpec spec{.size = 1ull << 20};
     int res = rawstor_object_create(target.c_str(), &spec);
@@ -34,10 +36,66 @@ TEST(FileLifecycleTest, create_spec_remove) {
     EXPECT_EQ(res, 0);
 }
 
+TEST(FileLifecycleTest, create_at_default_spec_remove) {
+    std::filesystem::path location_path =
+        std::filesystem::temp_directory_path() / "test_objects";
+    std::ostringstream oss;
+    oss << "file://" << location_path.string();
+    rawstd::URI location_uri(oss.str());
+    std::string location = location_uri.str();
+    std::string target(65536, '\0');
+
+    RawstorObjectSpec spec{.size = 1ull << 20};
+    int res = rawstor_object_create_at(
+        location.c_str(), nullptr, &spec, target.data(), target.size()
+    );
+    ASSERT_GT(res, 0);
+    ASSERT_LT((size_t)res, target.size());
+    target.resize(res);
+
+    RawstorObjectSpec read_spec = {};
+    res = rawstor_object_spec(target.c_str(), &read_spec);
+    EXPECT_EQ(res, 0);
+    EXPECT_EQ(read_spec.size, (size_t)(1ull << 20));
+
+    res = rawstor_object_remove(target.c_str());
+    EXPECT_EQ(res, 0);
+}
+
+TEST(FileLifecycleTest, create_at_spec_remove) {
+    std::filesystem::path location_path =
+        std::filesystem::temp_directory_path() / "test_objects";
+    std::ostringstream oss;
+    oss << "file://" << location_path.string();
+    rawstd::URI location_uri(oss.str());
+    std::string location = location_uri.str();
+    std::string uuid = "00000000-0000-7000-8000-000000000002";
+    std::string target(65536, '\0');
+
+    RawstorObjectSpec spec{.size = 1ull << 20};
+    int res = rawstor_object_create_at(
+        location.c_str(), uuid.c_str(), &spec, target.data(), target.size()
+    );
+    ASSERT_GT(res, 0);
+    ASSERT_LT((size_t)res, target.size());
+    target.resize(res);
+    EXPECT_EQ(target, rawstd::URI(location_uri, uuid).str());
+
+    RawstorObjectSpec read_spec = {};
+    res = rawstor_object_spec(target.c_str(), &read_spec);
+    EXPECT_EQ(res, 0);
+    EXPECT_EQ(read_spec.size, (size_t)(1ull << 20));
+
+    res = rawstor_object_remove(target.c_str());
+    EXPECT_EQ(res, 0);
+}
+
 TEST(OstLifecycleTest, create_spec_remove) {
     rawstor::tests::Server server(8753, 256);
-    std::string target =
-        "ost://127.0.0.1:8753/00000000-0000-7000-8000-000000000000";
+
+    rawstd::URI location_uri("ost://127.0.0.1:8753");
+    std::string uuid = "00000000-0000-7000-8000-000000000003";
+    std::string target = rawstd::URI(location_uri, uuid).str();
 
     {
         rawstor::tests::Session s(server);
@@ -62,6 +120,100 @@ TEST(OstLifecycleTest, create_spec_remove) {
 
     {
         RawstorObjectSpec read_spec;
+        int res = rawstor_object_spec(target.c_str(), &read_spec);
+        EXPECT_EQ(res, 0);
+        // rawstor_object_spec emulated
+        EXPECT_EQ(read_spec.size, (size_t)(1ull << 30));
+    }
+
+    {
+        int res = rawstor_object_remove(target.c_str());
+        EXPECT_EQ(res, 0);
+    }
+}
+
+TEST(OstLifecycleTest, create_at_default_spec_remove) {
+    rawstor::tests::Server server(8753, 256);
+
+    rawstd::URI location_uri("ost://127.0.0.1:8753");
+    std::string location = location_uri.str();
+    std::string target(65536, '\0');
+
+    {
+        rawstor::tests::Session s(server);
+        s.cmd_allocate(RAWSTOR_MAGIC, 0, 0);
+    }
+
+    {
+        rawstor::tests::Session s(server);
+    }
+
+    {
+        rawstor::tests::Session s(server);
+        s.cmd_release(RAWSTOR_MAGIC, 0, 0);
+    }
+
+    {
+        RawstorObjectSpec spec{.size = 1ull << 20};
+
+        int res = rawstor_object_create_at(
+            location.c_str(), nullptr, &spec, target.data(), target.size()
+        );
+        ASSERT_GT(res, 0);
+        ASSERT_LT((size_t)res, target.size());
+        target.resize(res);
+    }
+
+    {
+        RawstorObjectSpec read_spec = {};
+        int res = rawstor_object_spec(target.c_str(), &read_spec);
+        EXPECT_EQ(res, 0);
+        // rawstor_object_spec emulated
+        EXPECT_EQ(read_spec.size, (size_t)(1ull << 30));
+    }
+
+    {
+        int res = rawstor_object_remove(target.c_str());
+        EXPECT_EQ(res, 0);
+    }
+}
+
+TEST(OstLifecycleTest, create_at_spec_remove) {
+    rawstor::tests::Server server(8753, 256);
+
+    rawstd::URI location_uri("ost://127.0.0.1:8753");
+    std::string location = location_uri.str();
+    std::string uuid = "00000000-0000-7000-8000-000000000004";
+    std::string target(65536, '\0');
+
+    {
+        rawstor::tests::Session s(server);
+        s.cmd_allocate(RAWSTOR_MAGIC, 0, 0);
+    }
+
+    {
+        rawstor::tests::Session s(server);
+    }
+
+    {
+        rawstor::tests::Session s(server);
+        s.cmd_release(RAWSTOR_MAGIC, 0, 0);
+    }
+
+    {
+        RawstorObjectSpec spec{.size = 1ull << 20};
+
+        int res = rawstor_object_create_at(
+            location.c_str(), uuid.c_str(), &spec, target.data(), target.size()
+        );
+        ASSERT_GT(res, 0);
+        ASSERT_LT((size_t)res, target.size());
+        target.resize(res);
+        EXPECT_EQ(target, rawstd::URI(location_uri, uuid).str());
+    }
+
+    {
+        RawstorObjectSpec read_spec = {};
         int res = rawstor_object_spec(target.c_str(), &read_spec);
         EXPECT_EQ(res, 0);
         // rawstor_object_spec emulated


### PR DESCRIPTION
This pull request introduces comprehensive lifecycle tests for the storage system, ensuring that object creation, specification verification, and removal processes function correctly across different storage backends. The changes also include minor adjustments to the build process to ensure consistent environment handling and refactor test code for better maintainability and robustness.

### Highlights

* **Test Coverage Expansion**: Added multiple lifecycle test cases for both file and OST storage backends to verify object creation, specification retrieval, and removal.
* **Build Configuration**: Updated the Makefile to include the --no-build-isolation flag during pip installation to improve build reliability.
* **Code Refactoring**: Improved URI handling in tests by utilizing the rawstd::URI class for cleaner target string construction.

(cherry picked from commit bf8c1c7e87c78c5e3207f81a64efc8626a9abade)