### PR TITLE
fix: python versioning (#454)

### DIFF
--- a/pyrawstor/config.py.in
+++ b/pyrawstor/config.py.in
@@ -1,1 +1,1 @@
-package_version = '@PACKAGE_VERSION@'.replace("-0-", "+")
+package_version = '@PACKAGE_VERSION@'.replace('-', '+', 1).replace('-', '.')


### PR DESCRIPTION
This pull request updates the version string generation logic in the configuration file to ensure better compatibility with PEP 440. By refining how hyphens are replaced in the version string, the change preserves necessary build metadata for development versions, which improves version tracking and dependency resolution.

### Highlights

* **PEP 440 Compliance**: Updated the package version string manipulation to correctly format development builds by replacing hyphens with '+' and '.' separators.

(cherry picked from commit a41777813cac7d97a39b496f039041fc2e165f1b)