### PR TITLE
add: list objects (#460)

### DIFF
--- a/.github/workflows/perftest.yml
+++ b/.github/workflows/perftest.yml
@@ -96,7 +96,7 @@ jobs:
       if: "${{ matrix.backend == 'ost' }}"
       run: |
         mkdir ${GITHUB_WORKSPACE}/objects
-        rawstor-ost --bind 127.0.0.1:8080 --location file://${GITHUB_WORKSPACE}/objects &
+        rawstor-ost --bind 127.0.0.1:8080 --location=file://${GITHUB_WORKSPACE}/objects &
         sleep 10
     - name: (ost-legacy) start rawstor_ost
       if: "${{ matrix.backend == 'ost-legacy' }}"
@@ -110,6 +110,7 @@ jobs:
       run: |
         target=$(rawstor-cli create --location=${{ matrix.location }} --size=1G)
         echo "TARGET=${target}" >> $GITHUB_ENV
+        rawstor-cli list --location=${{ matrix.location }}
         rawstor-cli testio --target=${target} --block-size=4K --io-depth=1 --count=1
     - name: (ost-legacy) create object
       if: "${{ matrix.backend == 'ost-legacy' }}"

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -94,21 +94,23 @@ jobs:
     - name: start rawstor-ost
       run: |
         mkdir /tmp/ost_objects
-        rawstor-ost --bind 127.0.0.1:8080 --location file:///tmp/ost_objects/ &
+        rawstor-ost --bind 127.0.0.1:8080 --location=file:///tmp/ost_objects/ &
         sleep 10
     - name: create object file,ost
       run: |
         mkdir /tmp/file_objects
-        target=$(rawstor-cli create --location file:///tmp/file_objects,ost://127.0.0.1:8080 --size=1G)
+        target=$(rawstor-cli create --location=file:///tmp/file_objects,ost://127.0.0.1:8080 --size=1G)
         echo "TARGET=${target}" >> $GITHUB_ENV
+        rawstor-cli list --location=file:///tmp/file_objects,ost://127.0.0.1:8080
     - name: testio file,ost
       run: |
         rawstor-cli testio --target=${TARGET} --block-size=4K --io-depth=1 --count=10
         rawstor-cli testio --target=${TARGET} --block-size=4K --io-depth=1 --count=10 --vector-mode
     - name: create object ost,file
       run: |
-        target=$(rawstor-cli create --location ost://127.0.0.1:8080,file:///tmp/objects --size=1G)
+        target=$(rawstor-cli create --location=ost://127.0.0.1:8080,file:///tmp/file_objects --size=1G)
         echo "TARGET=${target}" >> $GITHUB_ENV
+        rawstor-cli list --location=ost://127.0.0.1:8080,file:///tmp/file_objects
     - name: testio ost,file
       run: |
         rawstor-cli testio --target=${TARGET} --block-size=4K --io-depth=1 --count=10

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - Unreleased
+
+### Added
+
+- List objects.
+
 ## [0.2.0] - 2026-06-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Default values are shown below.
 | `RAWSTOR_OPTS_SO_SNDTIMEO` | `5000` | Socket send timeout. Sets `SO_SNDTIMEO` for network sockets. |
 | `RAWSTOR_OPTS_SO_RCVTIMEO` | `5000` | Socket receive timeout. Sets `SO_RCVTIMEO` for network sockets. |
 | `RAWSTOR_OPTS_TCP_USER_TIMEOUT` | `5000` | TCP user timeout (Linux `TCP_USER_TIMEOUT`). Defines how long transmitted data may remain unacknowledged before the connection is closed. |
+| `RAWSTOR_OPTS_LIST_LIMIT` | `10` | The maximum number of rows that can be returned in list functions. |
 
 > **Note:** All timeout values are expressed in milliseconds unless stated otherwise.
 

--- a/cli/Makefile.am
+++ b/cli/Makefile.am
@@ -11,6 +11,8 @@ AM_LDFLAGS = $(ASAN_LDFLAGS)
 
 rawstor_cli_SOURCES = create.c \
                       create.h \
+                      list.c \
+                      list.h \
                       main.c \
                       remove.c \
                       remove.h \

--- a/cli/list.c
+++ b/cli/list.c
@@ -1,0 +1,28 @@
+#include "list.h"
+
+#include <rawstor.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int rawstor_cli_list(const char* location) {
+    RawstorStringList* targets;
+    RawstorPaginationToken token = {};
+    do {
+        int res = rawstor_object_list(location, 0, &targets, &token);
+        if (res < 0) {
+            fprintf(
+                stderr, "rawstor_object_list() failed: %s\n", strerror(-res)
+            );
+            return EXIT_FAILURE;
+        }
+        for (const char** it = rawstor_string_list_iter(targets); it != NULL;
+             it = rawstor_string_list_next(it)) {
+            printf("%s\n", *it);
+        }
+        rawstor_string_list_delete(targets);
+    } while (!rawstor_pagination_token_empty(&token));
+
+    return EXIT_SUCCESS;
+}

--- a/cli/list.h
+++ b/cli/list.h
@@ -1,0 +1,16 @@
+#ifndef RAWSTOR_CLI_LIST_H
+#define RAWSTOR_CLI_LIST_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int rawstor_cli_list(const char* location);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RAWSTOR_CLI_LIST_H

--- a/cli/main.c
+++ b/cli/main.c
@@ -1,4 +1,5 @@
 #include "create.h"
+#include "list.h"
 #include "remove.h"
 #include "show.h"
 #include "testio.h"
@@ -34,6 +35,7 @@ static void usage(void) {
         "  -v, --version         Rawstor version\n"
         "\n"
         "command:\n"
+        "  list                  List rawstor objects\n"
         "  create                Create rawstor object\n"
         "  remove                Remove rawstor object\n"
         "  show                  Show rawstor object\n"
@@ -231,6 +233,66 @@ static int command_remove(int argc, char** argv) {
     }
 
     return rawstor_cli_remove(target_arg);
+}
+
+static void command_list_usage(void) {
+    fprintf(
+        stdout,
+        "Rawstor CLI " PACKAGE_VERSION "\n"
+        "\n"
+        "usage: rawstor-cli [options] list -l LOCATION [command_options]\n"
+        "\n"
+        "list objects stored at the given location(s):\n"
+        "  -l, --location LOCATION\n"
+        "                        Comma-separated list of rawstor backend "
+        "locations.\n"
+        "\n"
+        "command options:\n"
+        "  -h, --help            Show this help message and exit\n"
+    );
+}
+
+static int command_list(int argc, char** argv) {
+    const char* optstring = "hl:";
+    struct option longopts[] = {
+        {"help", no_argument, NULL, 'h'},
+        {"location", required_argument, NULL, 'l'},
+        {},
+    };
+
+    char* location_arg = NULL;
+    optind = 1;
+    while (1) {
+        int c = getopt_long(argc, argv, optstring, longopts, NULL);
+        if (c == -1) {
+            break;
+        }
+
+        switch (c) {
+        case 'h':
+            command_list_usage();
+            return EXIT_SUCCESS;
+
+        case 'l':
+            location_arg = optarg;
+            break;
+
+        default:
+            return EXIT_FAILURE;
+        }
+    }
+
+    if (optind < argc) {
+        fprintf(stderr, "Unexpected argument: %s\n", argv[optind]);
+        return EXIT_FAILURE;
+    }
+
+    if (location_arg == NULL) {
+        fprintf(stderr, "location required\n");
+        return EXIT_FAILURE;
+    }
+
+    return rawstor_cli_list(location_arg);
 }
 
 static void command_show_usage(void) {
@@ -445,6 +507,8 @@ static int run_command(
         ret = command_create(argc, argv);
     } else if (strcmp(command, "remove") == 0) {
         ret = command_remove(argc, argv);
+    } else if (strcmp(command, "list") == 0) {
+        ret = command_list(argc, argv);
     } else if (strcmp(command, "show") == 0) {
         ret = command_show(argc, argv);
     } else if (strcmp(command, "testio") == 0) {

--- a/cli/remove.c
+++ b/cli/remove.c
@@ -2,8 +2,6 @@
 
 #include <rawstor.h>
 
-#include <assert.h>
-#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/cli/show.c
+++ b/cli/show.c
@@ -4,8 +4,6 @@
 
 #include <rawstor.h>
 
-#include <assert.h>
-#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/include/rawstor.h
+++ b/include/rawstor.h
@@ -7,6 +7,7 @@
 #ifndef RAWSTOR_H
 #define RAWSTOR_H
 
+#include <rawstor/list.h>
 #include <rawstor/object.h>
 #include <rawstor/protocol.h>
 #include <rawstor/rawio.h>

--- a/include/rawstor/list.h
+++ b/include/rawstor/list.h
@@ -1,0 +1,116 @@
+/**
+ * Copyright (C) 2025-2026, Vasily Stepanov (vasily.stepanov@gmail.com)
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+ */
+
+#ifndef RAWSTOR_LIST_H
+#define RAWSTOR_LIST_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Opaque handle to a list of strings.
+ *
+ * Instances of this type are created and managed internally by the library.
+ * The user must never allocate or free such objects directly.
+ * All strings stored in the list are immutable and are freed when the list is
+ * destroyed.
+ */
+typedef struct RawstorStringList RawstorStringList;
+
+/**
+ * @brief Destroys the string list and frees all associated memory.
+ *
+ * This function releases both the list container and all strings it contains.
+ * After this call, any iterators obtained from this list become invalid and
+ * must not be used.
+ *
+ * @param list      Pointer to the list to be destroyed. May be NULL – in that
+ *                  case the function does nothing.
+ *
+ * @warning Iterators previously obtained from this list are invalidated.
+ */
+void rawstor_string_list_delete(RawstorStringList* list);
+
+/**
+ * @brief Returns an iterator to the first string in the list.
+ *
+ * The returned iterator points to the first element of the list. The element
+ * itself is a pointer to a null‑terminated string (const char*). To obtain the
+ * actual string, the iterator must be dereferenced.
+ *
+ * @param list      Pointer to the list. Must not be NULL.
+ *
+ * @return          Iterator pointing to the first string, or NULL if the list
+ *                  is empty.
+ *
+ * @note The iterator is read‑only; modifying the pointed data is not allowed.
+ * @note The iterator remains valid as long as the list is not destroyed.
+ *       It is not invalidated by calling any of the non‑modifying functions
+ *       (empty, size, next, iter).
+ *
+ * @warning Passing NULL results in undefined behaviour.
+ *
+ * @see rawstor_string_list_next
+ */
+const char** rawstor_string_list_iter(RawstorStringList* list);
+
+/**
+ * @brief Advances an iterator to the next string in the list.
+ *
+ * Given a valid iterator previously obtained from @ref rawstor_string_list_iter
+ * or from a previous call to this function, it returns an iterator to the
+ * subsequent element. Dereferencing the returned iterator yields the next
+ * string.
+ *
+ * @param iter      Current iterator. Must not be NULL.
+ *
+ * @return          Iterator to the next string, or NULL if the current iterator
+ *                  pointed to the last element.
+ *
+ * @note The iterator is read‑only; modifying the pointed data is not allowed.
+ * @note The returned iterator is valid only if the list has not been destroyed.
+ *
+ * @warning Passing NULL results in undefined behaviour.
+ *
+ * @see rawstor_string_list_iter
+ */
+const char** rawstor_string_list_next(const char** iter);
+
+/**
+ * @brief Checks whether the list is empty.
+ *
+ * @param list      Pointer to the list. Must not be NULL.
+ *
+ * @return          Non‑zero (true) if the list contains no elements, zero
+ *                  (false) otherwise.
+ *
+ * @note This operation has O(1) complexity.
+ *
+ * @warning Passing NULL results in undefined behaviour.
+ */
+int rawstor_string_list_empty(RawstorStringList* list);
+
+/**
+ * @brief Returns the number of strings in the list.
+ *
+ * @param list      Pointer to the list. Must not be NULL.
+ *
+ * @return          Number of elements in the list.
+ *
+ * @note This operation has O(1) complexity.
+ *
+ * @warning Passing NULL results in undefined behaviour.
+ */
+size_t rawstor_string_list_size(RawstorStringList* list);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RAWSTOR_LIST_H

--- a/include/rawstor/object.h
+++ b/include/rawstor/object.h
@@ -7,6 +7,7 @@
 #ifndef RAWSTOR_OBJECT_H
 #define RAWSTOR_OBJECT_H
 
+#include <rawstor/list.h>
 #include <rawstor/rawio.h>
 #include <rawstor/rawstor.h>
 
@@ -81,6 +82,116 @@ typedef int(RawstorCallback)(
  */
 int rawstor_object_spec(
     const char* target, struct RawstorObjectSpec* spec
+) RAWSTOR_NOEXCEPT;
+
+/**
+ * @brief List objects stored at the given location.
+ *
+ * This function retrieves a list of object identifiers (full target strings)
+ * stored at the specified @p location. The location must be a comma separated
+ * list of valid backend URI as described in the Locations and Targets
+ * documentation. The function supports pagination via the @p token parameter,
+ * allowing the caller to iterate over large sets of objects.
+ *
+ * The objects are returned in lexicographic order by their UUID. The
+ * @p limit parameter restricts the maximum number of objects returned in a
+ * single call. If @p limit is 0, the backend chooses an appropriate number
+ * of objects to return. The backend may enforce its own maximum limit
+ * (e.g., via the @c RAWSTOR_OPTS_LIST_LIMIT environment variable on the
+ * server side) that caps the actual number of strings returned, regardless
+ * of the @p limit value specified by the caller. If the number of objects
+ * available exceeds the effective limit (either specified by the caller or
+ * chosen by the backend), the function fills the @p token with an opaque
+ * pagination token that must be passed in the subsequent call to continue
+ * iteration. When the end of the list is reached, the token is set to an
+ * empty state (as determined by @ref rawstor_pagination_token_empty).
+ *
+ * The caller is responsible for freeing the returned string list using
+ * @ref rawstor_string_list_delete. The pagination token is a plain structure
+ * of fixed size (16 bytes) and does not require explicit deallocation;
+ * it should be zero‑initialized before the first call.
+ *
+ * @param location  Location string specifying the backend and endpoint
+ *                  (e.g., "ost://host:port" or "file:///path"). Must not be
+ *                  NULL and must be a valid location as per the library's
+ *                  format. The behaviour is identical to the @p location
+ *                  parameter of @ref rawstor_object_create_at.
+ * @param limit     Maximum number of objects to return in this call. If 0, the
+ *                  backend chooses the number of objects to return. The actual
+ *                  number of objects returned may also be limited by the
+ *                  backend's internal configuration (e.g., the
+ *                  @c RAWSTOR_OPTS_LIST_LIMIT environment variable on the
+ *                  server side).
+ * @param targets   Output parameter. On success, a pointer to a newly
+ *                  allocated @ref RawstorStringList is stored here. The list
+ *                  contains full target strings (e.g.,
+ *                  "ost://host:port/<uuid>") for each object. The caller must
+ *                  destroy the list using @ref rawstor_string_list_delete when
+ *                  it is no longer needed. The list is owned by the caller
+ *                  after a successful return. On error, the content of this
+ *                  parameter is undefined.
+ * @param token     Input/Output parameter for pagination. On the first call,
+ *                  the caller must zero‑initialize the structure (e.g.,
+ *                  `RawstorPaginationToken token = {};`). On success, if more
+ *                  objects are available, the function fills the token with an
+ *                  opaque value; otherwise, the token is set to an empty state
+ *                  (checkable via @ref rawstor_pagination_token_empty). The
+ *                  caller must pass the same token structure (with the value
+ *                  returned from the previous call) in subsequent calls to
+ *                  retrieve the next page. The token is opaque and must not be
+ *                  modified by the caller.
+ *
+ * @return 0 on success, negative errno on error.
+ * @retval 0         Success. The @p targets list and @p token are valid.
+ * @retval -EINVAL   Invalid input: @p location is NULL or malformed.
+ * @retval -ENOMEM   Memory allocation failed (for the list).
+ * @retval -ENOENT   The specified @p location does not exist or is unreachable.
+ * @retval -EIO      I/O error while reading the backend.
+ * @retval -EACCES   Permission denied for the specified location.
+ *
+ * @note If an invalid or corrupted token is passed (e.g., from a previous
+ *       session or after modifications to the storage), the behaviour is
+ *       undefined; the function may return incomplete or inconsistent results.
+ *
+ * @note The function may return a partial list even if an error occurs
+ *       (e.g., if the backend becomes unavailable mid‑iteration); however,
+ *       in such cases a negative error code is returned and the contents of
+ *       @p targets and @p token are unspecified. Callers should not rely on
+ *       partial data when an error is returned.
+ *
+ * @note Objects inserted into the already‑retrieved portion of the list
+ *       between calls will not be visible in subsequent iterations; the
+ *       token‑based pagination ensures consistency within the current
+ *       iteration session.
+ *
+ * @see rawstor_string_list_delete
+ * @see rawstor_pagination_token_empty
+ * @see rawstor_object_create_at
+ * @see Locations and Targets:
+ * https://github.com/rawstor/librawstor/blob/main/docs/locations_and_targets.md
+ *
+ * @par Example: Iterating over all objects
+ * @code
+ * RawstorPaginationToken token = {}; // zero‑initialized
+ *
+ * do {
+ *     RawstorStringList* page;
+ *     int ret = rawstor_object_list("ost://localhost:9090", 0, &page, &token);
+ *     if (ret < 0) {
+ *         // handle error
+ *         break;
+ *     }
+ *     for (const char** it = rawstor_string_list_iter(page); it != NULL;
+ *          it = rawstor_string_list_next(it)) {
+ *         // Process strings in list using *it.
+ *     }
+ *     rawstor_string_list_delete(page);
+ * } while (!rawstor_pagination_token_empty(&token));
+ * @endcode
+ */
+int rawstor_object_list(
+    const char* location, unsigned int limit, RawstorStringList** targets,
+    RawstorPaginationToken* token
 ) RAWSTOR_NOEXCEPT;
 
 /**

--- a/include/rawstor/protocol.h
+++ b/include/rawstor/protocol.h
@@ -25,6 +25,7 @@ extern "C" {
 #define RAWSTOR_CMD_DISCARD 3
 #define RAWSTOR_CMD_ALLOCATE 4
 #define RAWSTOR_CMD_RELEASE 5
+#define RAWSTOR_CMD_LIST 6
 typedef uint16_t RawstorOSTCommandType;
 
 struct RawstorOSTFrameHead {

--- a/include/rawstor/rawstor.h
+++ b/include/rawstor/rawstor.h
@@ -7,6 +7,8 @@
 #ifndef RAWSTOR_RAWSTOR_H
 #define RAWSTOR_RAWSTOR_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -23,7 +25,39 @@ struct RawstorOpts {
     unsigned int so_sndtimeo;
     unsigned int so_rcvtimeo;
     unsigned int tcp_user_timeout;
+    unsigned int list_limit;
 };
+
+typedef struct {
+    uint8_t bytes[16];
+} RawstorPaginationToken;
+
+/**
+ * @brief Check whether a pagination token is empty.
+ *
+ * This function tests if the given @p token represents an empty state,
+ * indicating that no more objects are available in the listing operation.
+ * An empty token is typically returned by @ref rawstor_object_list when
+ * the end of the object list has been reached.
+ *
+ * The token is considered empty if all its bytes are zero. Callers can
+ * zero‑initialize a token before the first invocation of
+ * @ref rawstor_object_list and then use this function in a loop to
+ * determine when to stop pagination.
+ *
+ * @param token     Pointer to a RawstorPaginationToken structure to check.
+ *                  Must not be NULL.
+ *
+ * @return Non‑zero (true) if the token is empty (all bytes zero), zero
+ *         (false) otherwise.
+ *
+ * @warning Passing NULL results in undefined behaviour.
+ *
+ * @see rawstor_object_list
+ */
+int rawstor_pagination_token_empty(
+    const RawstorPaginationToken* token
+) RAWSTOR_NOEXCEPT;
 
 int rawstor_initialize(const struct RawstorOpts* opts) RAWSTOR_NOEXCEPT;
 

--- a/librawstd/include/rawstd/uuid.h
+++ b/librawstd/include/rawstd/uuid.h
@@ -19,6 +19,8 @@ int rawstd_uuid_from_string(struct RawstdUUID* uuid, const char* s);
 
 void rawstd_uuid_to_string(const struct RawstdUUID* uuid, RawstdUUIDString* s);
 
+int rawstd_uuid_cmp(const struct RawstdUUID* lhs, const struct RawstdUUID* rhs);
+
 #ifdef __cplusplus
 }
 #endif

--- a/librawstd/src/list.c
+++ b/librawstd/src/list.c
@@ -36,6 +36,10 @@ RawstdList* rawstd_list_create(size_t object_size) {
 }
 
 void rawstd_list_delete(RawstdList* list) {
+    if (list == NULL) {
+        return;
+    }
+
     RawstdListItem* item = list->head;
     while (item != NULL) {
         RawstdListItem* next = item->next;

--- a/librawstd/src/uuid.c
+++ b/librawstd/src/uuid.c
@@ -5,6 +5,7 @@
 
 #include <errno.h>
 #include <stdint.h>
+#include <string.h>
 #include <time.h>
 
 static inline uint64_t uuid7_get_timestamp(const struct RawstdUUID* uuid) {
@@ -208,4 +209,10 @@ void rawstd_uuid_to_string(const struct RawstdUUID* uuid, RawstdUUIDString* s) {
         }
     }
     *p = '\0';
+}
+
+int rawstd_uuid_cmp(
+    const struct RawstdUUID* lhs, const struct RawstdUUID* rhs
+) {
+    return memcmp(lhs->bytes, rhs->bytes, sizeof(lhs->bytes));
 }

--- a/librawstd/tests/test_uuid.cpp
+++ b/librawstd/tests/test_uuid.cpp
@@ -86,6 +86,25 @@ TEST(UUIDTest, from_string) {
     EXPECT_EQ(rawstd_uuid7_get_counter(&uuid), 1131440955435ul);
 }
 
+TEST(UUIDTest, cmp) {
+    RawstdUUID uuid1 = {};
+    rawstd_uuid7_init(&uuid1);
+
+    RawstdUUID uuid2 = uuid1;
+
+    RawstdUUID uuid3 = {};
+    rawstd_uuid7_init(&uuid3);
+
+    EXPECT_EQ(rawstd_uuid_cmp(&uuid1, &uuid2), 0);
+    EXPECT_EQ(rawstd_uuid_cmp(&uuid2, &uuid1), 0);
+
+    EXPECT_LT(rawstd_uuid_cmp(&uuid1, &uuid3), 0);
+    EXPECT_GT(rawstd_uuid_cmp(&uuid3, &uuid1), 0);
+
+    EXPECT_LT(rawstd_uuid_cmp(&uuid2, &uuid3), 0);
+    EXPECT_GT(rawstd_uuid_cmp(&uuid3, &uuid2), 0);
+}
+
 TEST(UUIDTest, from_string_errors) {
     RawstdUUID uuid;
     EXPECT_EQ(

--- a/ost/session.cpp
+++ b/ost/session.cpp
@@ -264,6 +264,7 @@ Session::_recv_head(const iovec* iov, unsigned int niov, size_t result) {
     case RAWSTOR_CMD_SET_OBJECT:
     case RAWSTOR_CMD_ALLOCATE:
     case RAWSTOR_CMD_RELEASE:
+    case RAWSTOR_CMD_LIST:
         return sizeof(RawstorOSTFrameBasicBody);
     }
 
@@ -351,6 +352,24 @@ Session::_recv_body(const iovec* iov, unsigned int niov, size_t result) {
 
         return sizeof(RawstorOSTFrameHead);
 
+    case RAWSTOR_CMD_LIST:
+        if (result != sizeof(_request_body.basic)) {
+            rawstd_error(
+                "fd %d: Unexpected request body size: %zu != %zu\n", _fd,
+                result, sizeof(_request_body.basic)
+            );
+
+            RAWSTD_THROW_SYSTEM_ERROR(EPROTO);
+        }
+
+        rawstd_iovec_to_buf(
+            iov, niov, 0, &_request_body.basic, sizeof(_request_body.basic)
+        );
+
+        _list(_request_head, _request_body.basic);
+
+        return sizeof(RawstorOSTFrameHead);
+
     case RAWSTOR_CMD_ALLOCATE:
         if (result != sizeof(_request_body.basic)) {
             rawstd_error(
@@ -411,6 +430,57 @@ Session::_recv_data(const iovec* iov, unsigned int niov, size_t result) {
     _write(_request_head, _request_body.io, iov, niov, result);
 
     return sizeof(RawstorOSTFrameHead);
+}
+
+void Session::_list(
+    const RawstorOSTFrameHead& head, const RawstorOSTFrameBasicBody& body
+) {
+    if (_object != nullptr) {
+        int res = rawstor_object_close(_object);
+        if (res < 0) {
+            RAWSTD_THROW_SYSTEM_ERROR(-res);
+        }
+        _object = nullptr;
+    }
+
+    RawstorPaginationToken token;
+    memcpy(token.bytes, body.obj_id, sizeof(body.obj_id));
+
+    RawstorStringList* targets;
+    int result = rawstor_object_list(
+        rawstd::URI::uris(_server.locations()).c_str(), body.val, &targets,
+        &token
+    );
+    if (result < 0) {
+        send_response(_queue, _fd, RAWSTOR_CMD_LIST, head.cid, -result, 0);
+        return;
+    }
+
+    try {
+        auto data = std::make_shared<std::vector<unsigned char>>(
+            sizeof(RawstdUUID) * (rawstor_string_list_size(targets) + 1)
+        );
+        RawstdUUID* out_it =
+            static_cast<RawstdUUID*>(static_cast<void*>(data->data()));
+        for (const char** in_it = rawstor_string_list_iter(targets);
+             in_it != NULL; in_it = rawstor_string_list_next(in_it), ++out_it) {
+            rawstd::URI target(*in_it);
+            int res = rawstd_uuid_from_string(
+                out_it, target.path().filename().c_str()
+            );
+            if (res < 0) {
+                RAWSTD_THROW_SYSTEM_ERROR(-res);
+            }
+        }
+        memcpy(out_it, &token, sizeof(token));
+        send_response(
+            _queue, _fd, RAWSTOR_CMD_LIST, head.cid, data->size(), 0, data
+        );
+    } catch (...) {
+        rawstor_string_list_delete(targets);
+        throw;
+    }
+    rawstor_string_list_delete(targets);
 }
 
 void Session::_allocate(

--- a/ost/session.hpp
+++ b/ost/session.hpp
@@ -38,6 +38,9 @@ private:
     ssize_t _recv_head(const iovec* iov, unsigned int niov, size_t result);
     ssize_t _recv_body(const iovec* iov, unsigned int niov, size_t result);
     ssize_t _recv_data(const iovec* iov, unsigned int niov, size_t result);
+    void _list(
+        const RawstorOSTFrameHead& head, const RawstorOSTFrameBasicBody& body
+    );
     void _allocate(
         const RawstorOSTFrameHead& head, const RawstorOSTFrameBasicBody& body
     );

--- a/pyrawstor/Makefile.am
+++ b/pyrawstor/Makefile.am
@@ -46,7 +46,7 @@ $(builddir)/sources-stamp:
 	fi
 	touch $@
 
-$(builddir)/build-stamp: $(C_SOURCES) $(builddir)/sources-stamp setup.py
+$(builddir)/build-stamp: $(C_SOURCES) $(builddir)/sources-stamp setup.py ../src/.libs/librawstor.la
 	CFLAGS="$(CFLAGS) $(AM_CFLAGS)" \
 	LDFLAGS="$(LDFLAGS) $(AM_LDFLAGS)" \
 	$(PYTHON) -m pip install --no-deps --no-build-isolation -e $(builddir)

--- a/pyrawstor/rawstor/librawstor/module.c
+++ b/pyrawstor/rawstor/librawstor/module.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 static PyMethodDef librawstor_methods[] = {
+    {"object_list", py_rawstor_object_list, METH_VARARGS, NULL},
     {"object_create", py_rawstor_object_create, METH_VARARGS, NULL},
     {"object_create_at", py_rawstor_object_create_at, METH_VARARGS, NULL},
     {"object_spec", py_rawstor_object_spec, METH_VARARGS, NULL},

--- a/pyrawstor/rawstor/librawstor/object_bindings.c
+++ b/pyrawstor/rawstor/librawstor/object_bindings.c
@@ -86,6 +86,109 @@ PyTypeObject PyObjectSpecType = {
     .tp_getset = PyObjectSpec_getset,
 };
 
+static void free_pagination_token(PyObject* capsule) {
+    if (!PyCapsule_CheckExact(capsule)) {
+        return;
+    }
+    if (!PyCapsule_IsValid(capsule, "pagination_token")) {
+        return;
+    }
+    RawstorPaginationToken* token = (RawstorPaginationToken*)
+        PyCapsule_GetPointer(capsule, "pagination_token");
+    free(token);
+}
+
+PyObject* py_rawstor_object_list(PyObject* Py_UNUSED(self), PyObject* args) {
+    const char* location;
+    unsigned int limit;
+    PyObject* py_token;
+    if (!PyArg_ParseTuple(args, "sIO", &location, &limit, &py_token)) {
+        return NULL;
+    }
+
+    PyObject* py_ret_token = NULL;
+    RawstorStringList* list = NULL;
+    PyObject* py_list = NULL;
+
+    RawstorPaginationToken token = {};
+    if (py_token != Py_None) {
+        if (!PyCapsule_CheckExact(py_token)) {
+            PyErr_SetString(PyExc_TypeError, "token must be None or a capsule");
+            goto error;
+        }
+        if (!PyCapsule_IsValid(py_token, "pagination_token")) {
+            PyErr_SetString(
+                PyExc_ValueError, "invalid token capsule (wrong name)"
+            );
+            goto error;
+        }
+        RawstorPaginationToken* token_ptr = (RawstorPaginationToken*)
+            PyCapsule_GetPointer(py_token, "pagination_token");
+        if (token_ptr == NULL) {
+            goto error;
+        }
+        token = *token_ptr;
+    }
+
+    int res = rawstor_object_list(location, limit, &list, &token);
+    if (res < 0) {
+        set_os_error(-res);
+        goto error;
+    }
+
+    py_list = PyList_New(0);
+    if (!py_list) {
+        goto error;
+    }
+    for (const char** it = rawstor_string_list_iter(list); it != NULL;
+         it = rawstor_string_list_next(it)) {
+        PyObject* py_target = PyUnicode_FromString(*it);
+        if (!py_target) {
+            goto error;
+        }
+        if (PyList_Append(py_list, py_target) < 0) {
+            Py_DECREF(py_target);
+            goto error;
+        }
+        Py_DECREF(py_target);
+    }
+    rawstor_string_list_delete(list);
+    list = NULL;
+
+    if (rawstor_pagination_token_empty(&token)) {
+        py_ret_token = Py_None;
+        Py_INCREF(Py_None);
+    } else {
+        RawstorPaginationToken* ret_token =
+            (RawstorPaginationToken*)malloc(sizeof(RawstorPaginationToken));
+        if (ret_token == NULL) {
+            PyErr_NoMemory();
+            goto error;
+        }
+        *ret_token = token;
+        py_ret_token =
+            PyCapsule_New(ret_token, "pagination_token", free_pagination_token);
+        if (py_ret_token == NULL) {
+            free(ret_token);
+            goto error;
+        }
+    }
+
+    PyObject* tuple = PyTuple_New(2);
+    if (!tuple) {
+        goto error;
+    }
+    PyTuple_SET_ITEM(tuple, 0, py_list);
+    PyTuple_SET_ITEM(tuple, 1, py_ret_token);
+    return tuple;
+
+error:
+    Py_XDECREF(py_ret_token);
+    rawstor_string_list_delete(list);
+    Py_XDECREF(py_list);
+    return NULL;
+}
+
 PyObject* py_rawstor_object_create(PyObject* Py_UNUSED(self), PyObject* args) {
     const char* target;
     PyObject* spec_obj;

--- a/pyrawstor/rawstor/librawstor/object_bindings.h
+++ b/pyrawstor/rawstor/librawstor/object_bindings.h
@@ -10,6 +10,8 @@ extern "C" {
 
 extern PyTypeObject PyObjectSpecType;
 
+PyObject* py_rawstor_object_list(PyObject* self, PyObject* args);
+
 PyObject* py_rawstor_object_create(PyObject* self, PyObject* args);
 
 PyObject* py_rawstor_object_create_at(PyObject* self, PyObject* args);

--- a/pyrawstor/rawstor/object.py
+++ b/pyrawstor/rawstor/object.py
@@ -1,7 +1,19 @@
+from collections.abc import Iterator
+
 from . import librawstor
 
 
 class Object:
+    @staticmethod
+    def list(location: str, limit: int = 0) -> Iterator[str]:
+        token = None
+        while True:
+            page, token = librawstor.object_list(location, limit, token)
+            for target in page:
+                yield target
+            if token is None:
+                break
+
     @staticmethod
     def create(target: str, spec: librawstor.ObjectSpec) -> None:
         librawstor.object_create(target, spec)

--- a/pyrawstor/tests/test_basics.py
+++ b/pyrawstor/tests/test_basics.py
@@ -3,14 +3,39 @@ import rawstor
 import unittest
 import tempfile
 
+
 class TestBasics(unittest.TestCase):
-    def test_hello(self):
+    def test_basics(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            spec = rawstor.ObjectSpec(size=1 << 20)
             location = f'file://{temp_dir}'
 
+            spec = rawstor.ObjectSpec(size=1 << 20)
             target = rawstor.Object.create_at(location, spec)
             self.addCleanup(rawstor.Object.remove, target)
 
             read_spec = rawstor.Object.spec(target)
             self.assertEqual(read_spec.size, 1 << 20)
+
+            read_targets = rawstor.Object.list(location)
+            self.assertEqual(list(read_targets), [target])
+
+    def test_empty(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            location = f'file://{temp_dir}'
+            targets = rawstor.Object.list(location)
+            self.assertEqual(list(targets), [])
+
+    def test_list(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            location = f'file://{temp_dir}'
+
+            targets = []
+            for _ in range(10):
+                spec = rawstor.ObjectSpec(size=1 << 20)
+                target = rawstor.Object.create_at(location, spec)
+                self.addCleanup(rawstor.Object.remove, target)
+                targets.append(target)
+            targets.sort()
+
+            read_targets = rawstor.Object.list(location)
+            self.assertEqual(list(read_targets), targets)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,7 +24,8 @@ librawstor_base_la_HEADERS = $(top_srcdir)/include/rawstor.h
 
 librawstor_ladir = $(includedir)/rawstor
 
-librawstor_la_HEADERS = $(top_srcdir)/include/rawstor/object.h \
+librawstor_la_HEADERS = $(top_srcdir)/include/rawstor/list.h \
+                        $(top_srcdir)/include/rawstor/object.h \
                         $(top_srcdir)/include/rawstor/protocol.h \
                         $(top_srcdir)/include/rawstor/rawio.h \
                         $(top_srcdir)/include/rawstor/rawstor.h \
@@ -34,6 +35,7 @@ librawstor_la_SOURCES = connection.cpp \
                         connection.hpp \
                         file_session.cpp \
                         file_session.hpp \
+                        list.c \
                         object.cpp \
                         object.hpp \
                         ost_session.cpp \

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -11,8 +11,10 @@
 #include <rawstd/gpp.hpp>
 #include <rawstd/iovec.h>
 #include <rawstd/logging.hpp>
+#include <rawstd/uuid.h>
 
 #include <algorithm>
+#include <list>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -218,6 +220,39 @@ const rawstd::URI* Connection::location() const noexcept {
     }
 
     return &_sessions.front()->location();
+}
+
+void Connection::list(
+    const rawstd::URI& location, unsigned int limit,
+    std::vector<RawstdUUID>& targets, RawstdUUID& token
+) {
+    Queue q(1);
+
+    std::vector<RawstdUUID> ret;
+    RawstdUUID ret_token;
+
+    std::unique_ptr<Session> s = Session::create(q.queue(), location);
+    s->list(
+        limit, token,
+        [&q, &ret, &ret_token](
+            std::vector<RawstdUUID>&& uuids, const RawstdUUID& next_token,
+            int error
+        ) {
+            q.sub_operation();
+
+            if (error) {
+                RAWSTD_THROW_SYSTEM_ERROR(error);
+            }
+
+            ret = std::move(uuids);
+            ret_token = next_token;
+        }
+    );
+
+    q.wait();
+
+    targets.swap(ret);
+    token = ret_token;
 }
 
 void Connection::create(

--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -8,8 +8,10 @@
 #include <rawio/queue.hpp>
 
 #include <rawstd/uri.hpp>
+#include <rawstd/uuid.h>
 
 #include <functional>
+#include <list>
 #include <memory>
 #include <vector>
 
@@ -39,6 +41,11 @@ private:
         unsigned int attempt);
 
 public:
+    static void list(
+        const rawstd::URI& location, unsigned int limit,
+        std::vector<RawstdUUID>& uuids, RawstdUUID& token
+    );
+
     static void create(const rawstd::URI& target, const RawstorObjectSpec& sp);
 
     static void remove(const rawstd::URI& target);

--- a/src/file_session.cpp
+++ b/src/file_session.cpp
@@ -17,10 +17,12 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <cerrno>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -28,7 +30,7 @@
 
 namespace {
 
-std::string get_ost_path(const rawstd::URI& location) {
+std::string get_location_path(const rawstd::URI& location) {
     if (location.scheme() != "file") {
         rawstd_error("Unexpected URI scheme: %s\n", location.str().c_str());
         RAWSTD_THROW_SYSTEM_ERROR(EINVAL);
@@ -41,32 +43,33 @@ std::string get_ost_path(const rawstd::URI& location) {
 }
 
 std::string get_object_spec_path(
-    const std::string& ost_path, const RawstdUUIDString& uuid
+    const std::string& location_path, const RawstdUUIDString& uuid
 ) {
     std::ostringstream oss;
 
-    oss << ost_path << "/" << uuid << ".spec";
+    oss << location_path << "/" << uuid << ".spec";
 
     return oss.str();
 }
 
-std::string
-get_object_dat_path(const std::string& ost_path, const RawstdUUIDString& uuid) {
+std::string get_object_dat_path(
+    const std::string& location_path, const RawstdUUIDString& uuid
+) {
     std::ostringstream oss;
 
-    oss << ost_path << "/" << uuid << ".dat";
+    oss << location_path << "/" << uuid << ".dat";
 
     return oss.str();
 }
 
 void write_dat(
-    const std::string& ost_path, const RawstorObjectSpec& spec,
+    const std::string& location_path, const RawstorObjectSpec& spec,
     const RawstdUUID& id
 ) {
     RawstdUUIDString uuid_string;
     rawstd_uuid_to_string(&id, &uuid_string);
 
-    std::string dat_path = get_object_dat_path(ost_path, uuid_string);
+    std::string dat_path = get_object_dat_path(location_path, uuid_string);
 
     int fd = open(dat_path.c_str(), O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
     if (fd == -1) {
@@ -98,11 +101,11 @@ Session::Session(rawio::Queue& queue, const rawstd::URI& location) :
 }
 
 int Session::_connect(const RawstdUUID& id) {
-    std::string ost_path = get_ost_path(location());
+    std::string location_path = get_location_path(location());
 
     RawstdUUIDString id_string;
     rawstd_uuid_to_string(&id, &id_string);
-    std::string dat_path = get_object_dat_path(ost_path, id_string);
+    std::string dat_path = get_object_dat_path(location_path, id_string);
 
     rawstd_info("Connecting to %s...\n", location().str().c_str());
     int fd = open(dat_path.c_str(), O_RDWR | O_NONBLOCK);
@@ -113,12 +116,84 @@ int Session::_connect(const RawstdUUID& id) {
     return fd;
 }
 
+void Session::list(
+    unsigned int limit, const RawstdUUID& token,
+    std::function<void(std::vector<RawstdUUID>&&, const RawstdUUID&, int)>&& cb
+) {
+    std::vector<RawstdUUID> ret_uuids;
+    RawstdUUID ret_token = {};
+    try {
+        std::string location_path = get_location_path(location());
+
+        for (const auto& entry :
+             std::filesystem::directory_iterator(location_path)) {
+            if (entry.path().extension().string() != ".dat") {
+                continue;
+            }
+
+            std::string filename = entry.path().stem().string();
+
+            RawstdUUID uuid;
+            int res = rawstd_uuid_from_string(&uuid, filename.c_str());
+            if (res < 0) {
+                rawstd_warning(
+                    "%s: %s\n", strerror(-res), entry.path().string().c_str()
+                );
+                continue;
+            }
+
+            ret_uuids.push_back(uuid);
+        }
+
+        std::sort(
+            ret_uuids.begin(), ret_uuids.end(),
+            [](const RawstdUUID& lhs, const RawstdUUID& rhs) {
+                return rawstd_uuid_cmp(&lhs, &rhs) < 0;
+            }
+        );
+
+        ret_uuids.erase(
+            ret_uuids.begin(),
+            std::upper_bound(
+                ret_uuids.begin(), ret_uuids.end(), token,
+                [](const RawstdUUID& lhs, const RawstdUUID& rhs) {
+                    return rawstd_uuid_cmp(&lhs, &rhs) < 0;
+                }
+            )
+        );
+
+        if (limit == 0) {
+            limit = rawstor_opts_list_limit();
+        } else {
+            limit = std::min(limit, rawstor_opts_list_limit());
+        }
+
+        if (ret_uuids.size() > limit) {
+            ret_uuids.resize(limit);
+            ret_token = ret_uuids.back();
+        }
+    } catch (const std::system_error& e) {
+        rawstd_error("Unexpected error: %s\n", e.what());
+        cb({}, {}, e.code().value());
+        return;
+    } catch (const std::exception& e) {
+        rawstd_error("Unexpected error: %s\n", e.what());
+        cb({}, {}, EIO);
+        return;
+    } catch (...) {
+        cb({}, {}, EIO);
+        return;
+    }
+
+    cb(std::move(ret_uuids), ret_token, 0);
+}
+
 void Session::create(
     const RawstdUUID& id, const RawstorObjectSpec& sp,
     std::function<void(int)>&& cb
 ) {
-    std::string ost_path = get_ost_path(location());
-    if (mkdir(ost_path.c_str(), 0755) == -1) {
+    std::string location_path = get_location_path(location());
+    if (mkdir(location_path.c_str(), 0755) == -1) {
         if (errno == EEXIST) {
             errno = 0;
         } else {
@@ -130,7 +205,7 @@ void Session::create(
     rawstd_uuid_to_string(&id, &uuid_string);
 
     std::string spec_path;
-    spec_path = get_object_spec_path(ost_path, uuid_string);
+    spec_path = get_object_spec_path(location_path, uuid_string);
 
     int fd = ::open(
         spec_path.c_str(), O_EXCL | O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR
@@ -145,7 +220,7 @@ void Session::create(
             RAWSTD_THROW_ERRNO();
         }
 
-        write_dat(ost_path, sp, id);
+        write_dat(location_path, sp, id);
 
         if (::close(fd) == -1) {
             RAWSTD_THROW_ERRNO();
@@ -160,12 +235,12 @@ void Session::create(
 }
 
 void Session::remove(const RawstdUUID& id, std::function<void(int)>&& cb) {
-    std::string ost_path = get_ost_path(location());
+    std::string location_path = get_location_path(location());
 
     RawstdUUIDString uuid_string;
     rawstd_uuid_to_string(&id, &uuid_string);
 
-    std::string dat_path = get_object_dat_path(ost_path, uuid_string);
+    std::string dat_path = get_object_dat_path(location_path, uuid_string);
     if (unlink(dat_path.c_str()) == -1) {
         if (errno == ENOENT) {
             errno = 0;
@@ -174,7 +249,7 @@ void Session::remove(const RawstdUUID& id, std::function<void(int)>&& cb) {
         }
     }
 
-    std::string spec_path = get_object_spec_path(ost_path, uuid_string);
+    std::string spec_path = get_object_spec_path(location_path, uuid_string);
     if (unlink(spec_path.c_str()) == -1) {
         if (errno == ENOENT) {
             errno = 0;
@@ -190,12 +265,12 @@ void Session::spec(
     const RawstdUUID& id,
     std::function<void(const RawstorObjectSpec&, int)>&& cb
 ) {
-    std::string ost_path = get_ost_path(location());
+    std::string location_path = get_location_path(location());
 
     RawstdUUIDString uuid_string;
     rawstd_uuid_to_string(&id, &uuid_string);
 
-    std::string spec_path = get_object_spec_path(ost_path, uuid_string);
+    std::string spec_path = get_object_spec_path(location_path, uuid_string);
 
     int fd = ::open(spec_path.c_str(), O_RDONLY);
     if (fd == -1) {

--- a/src/file_session.hpp
+++ b/src/file_session.hpp
@@ -10,6 +10,9 @@
 
 #include <rawstor/object.h>
 
+#include <functional>
+#include <list>
+
 namespace rawstor {
 namespace file {
 
@@ -19,6 +22,12 @@ private:
 
 public:
     Session(rawio::Queue& queue, const rawstd::URI& location);
+
+    void list(
+        unsigned int limit, const RawstdUUID& token,
+        std::function<void(std::vector<RawstdUUID>&&, const RawstdUUID&, int)>&&
+            cb
+    ) override;
 
     void create(
         const RawstdUUID& id, const RawstorObjectSpec& sp,

--- a/src/list.c
+++ b/src/list.c
@@ -1,0 +1,31 @@
+#include <rawstor/list.h>
+
+#include <rawstd/list.h>
+
+#include <stdlib.h>
+
+void rawstor_string_list_delete(RawstorStringList* list) {
+    if (list != NULL) {
+        for (const char** it = rawstor_string_list_iter(list); it != NULL;
+             it = rawstor_string_list_next(it)) {
+            free((char*)*it);
+        }
+    }
+    rawstd_list_delete((RawstdList*)list);
+}
+
+const char** rawstor_string_list_iter(RawstorStringList* list) {
+    return (const char**)rawstd_list_iter((RawstdList*)list);
+}
+
+const char** rawstor_string_list_next(const char** iter) {
+    return (const char**)rawstd_list_next(iter);
+}
+
+int rawstor_string_list_empty(RawstorStringList* list) {
+    return rawstd_list_empty((RawstdList*)list);
+}
+
+size_t rawstor_string_list_size(RawstorStringList* list) {
+    return rawstd_list_size((RawstdList*)list);
+}

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1,4 +1,5 @@
 #include "object.hpp"
+#include <rawstor/list.h>
 #include <rawstor/object.h>
 
 #include "config.h"
@@ -8,6 +9,7 @@
 #include "ost_session.hpp"
 
 #include <rawstd/gpp.hpp>
+#include <rawstd/list.h>
 #include <rawstd/logging.hpp>
 #include <rawstd/uri.hpp>
 #include <rawstd/uuid.h>
@@ -15,6 +17,8 @@
 #include <unistd.h>
 
 #include <exception>
+#include <list>
+#include <map>
 #include <memory>
 #include <new>
 #include <set>
@@ -106,6 +110,68 @@ Object::Object(rawio::Queue& queue, const std::vector<rawstd::URI>& targets) :
         cn->open(target.parent(), this, rawstor_opts_sessions());
         _cns.push_back(std::move(cn));
     }
+}
+
+void Object::list(
+    const std::vector<rawstd::URI>& locations, unsigned int limit,
+    std::list<std::vector<rawstd::URI>>& targets, RawstorPaginationToken& token
+) {
+    validate_not_empty(locations);
+
+    RawstdUUID token_uuid = {};
+    memcpy(token_uuid.bytes, token.bytes, sizeof(token.bytes));
+
+    auto cmp = [](const RawstdUUID& lhs, const RawstdUUID& rhs) -> bool {
+        return rawstd_uuid_cmp(&lhs, &rhs) < 0;
+    };
+    std::map<RawstdUUID, std::vector<rawstd::URI>, decltype(cmp)> targets_map(
+        cmp
+    );
+    RawstdUUID empty_uuid = {};
+    RawstdUUID next_token_uuid = empty_uuid;
+    for (const auto& location : locations) {
+        std::vector<RawstdUUID> loc_uuids;
+        RawstdUUID loc_token_uuid = token_uuid;
+        rawstor::Connection::list(location, limit, loc_uuids, loc_token_uuid);
+        for (const auto& uuid : loc_uuids) {
+            RawstdUUIDString uuid_string;
+            rawstd_uuid_to_string(&uuid, &uuid_string);
+            targets_map[uuid].emplace_back(location, uuid_string);
+        }
+        if (rawstd_uuid_cmp(&loc_token_uuid, &empty_uuid) != 0) {
+            if (rawstd_uuid_cmp(&next_token_uuid, &empty_uuid) == 0 ||
+                rawstd_uuid_cmp(&loc_token_uuid, &next_token_uuid) < 0) {
+                next_token_uuid = loc_token_uuid;
+            }
+        }
+    }
+
+    if (limit == 0) {
+        limit = rawstor_opts_list_limit();
+    } else {
+        limit = std::min(limit, rawstor_opts_list_limit());
+    }
+
+    std::list<std::vector<rawstd::URI>> ret;
+    const RawstdUUID* last_uuid = nullptr;
+    bool capped = false;
+    for (const auto& it : targets_map) {
+        if (ret.size() >= limit) {
+            capped = true;
+            break;
+        }
+        last_uuid = &it.first;
+        ret.push_back(it.second);
+    }
+    if (last_uuid != nullptr) {
+        if (capped && (rawstd_uuid_cmp(&next_token_uuid, &empty_uuid) == 0 ||
+                       rawstd_uuid_cmp(last_uuid, &next_token_uuid) < 0)) {
+            next_token_uuid = *last_uuid;
+        }
+    }
+
+    targets.swap(ret);
+    memcpy(token.bytes, next_token_uuid.bytes, sizeof(next_token_uuid.bytes));
 }
 
 void Object::create(
@@ -325,6 +391,57 @@ void Object::pwritev(
 }
 
 } // namespace rawstor
+
+int rawstor_object_list(
+    const char* location, unsigned int limit, RawstorStringList** targets,
+    RawstorPaginationToken* token
+) noexcept {
+    RawstorStringList* list = nullptr;
+    try {
+        std::vector<rawstd::URI> locations = rawstd::URI::uriv(location);
+        std::list<std::vector<rawstd::URI>> ret;
+
+        rawstor::Object::list(locations, limit, ret, *token);
+
+        list = (RawstorStringList*)rawstd_list_create(sizeof(const char*));
+        if (list == nullptr) {
+            throw std::bad_alloc();
+        }
+        for (const auto& t : ret) {
+            std::string target = rawstd::URI::uris(t);
+
+            char* str = (char*)malloc(target.length() + 1);
+            if (str == nullptr) {
+                RAWSTD_THROW_ERRNO();
+            }
+            memcpy(str, target.c_str(), target.length() + 1);
+
+            char** it = (char**)rawstd_list_append((RawstdList*)list);
+            if (it == nullptr) {
+                free(str);
+                RAWSTD_THROW_ERRNO();
+            }
+            *it = str;
+        }
+
+        *targets = (RawstorStringList*)list;
+        return 0;
+    } catch (const std::system_error& e) {
+        rawstor_string_list_delete(list);
+        return -e.code().value();
+    } catch (const std::bad_alloc& e) {
+        rawstor_string_list_delete(list);
+        return -ENOMEM;
+    } catch (const std::exception& e) {
+        rawstd_error("%s\n", e.what());
+        rawstor_string_list_delete(list);
+        return -EINVAL;
+    } catch (...) {
+        rawstd_error("Unexpected error\n");
+        rawstor_string_list_delete(list);
+        return -EINVAL;
+    }
+}
 
 int rawstor_object_create(
     const char* target, const RawstorObjectSpec* spec

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -9,6 +9,7 @@
 #include <rawstd/uuid.h>
 
 #include <functional>
+#include <list>
 #include <memory>
 #include <vector>
 
@@ -25,6 +26,11 @@ private:
     std::vector<std::unique_ptr<rawstor::Connection>> _cns;
 
 public:
+    static void list(
+        const std::vector<rawstd::URI>& locations, unsigned int limit,
+        std::list<std::vector<rawstd::URI>>& targets,
+        RawstorPaginationToken& token
+    );
     static void create(
         const std::vector<rawstd::URI>& targets, const RawstorObjectSpec& sp
     );

--- a/src/opts.c
+++ b/src/opts.c
@@ -9,6 +9,7 @@
 #define RAWSTOR_OPTS_SO_SNDTIMEO 5000
 #define RAWSTOR_OPTS_SO_RCVTIMEO 5000
 #define RAWSTOR_OPTS_TCP_USER_TIMEOUT 5000
+#define RAWSTOR_OPTS_LIST_LIMIT 10
 
 static struct RawstorOpts _rawstor_opts = {};
 
@@ -60,6 +61,11 @@ int rawstor_opts_initialize(const struct RawstorOpts* opts) {
                   "RAWSTOR_OPTS_TCP_USER_TIMEOUT", RAWSTOR_OPTS_TCP_USER_TIMEOUT
               );
 
+    _rawstor_opts.list_limit =
+        (opts != NULL && opts->list_limit != 0)
+            ? opts->list_limit
+            : get_env_uint("RAWSTOR_OPTS_LIST_LIMIT", RAWSTOR_OPTS_LIST_LIMIT);
+
     return 0;
 }
 
@@ -87,4 +93,8 @@ unsigned int rawstor_opts_so_rcvtimeo(void) {
 
 unsigned int rawstor_opts_tcp_user_timeout(void) {
     return _rawstor_opts.tcp_user_timeout;
+}
+
+unsigned int rawstor_opts_list_limit(void) {
+    return _rawstor_opts.list_limit;
 }

--- a/src/opts.h
+++ b/src/opts.h
@@ -14,6 +14,7 @@ extern "C" {
 //     unsigned int so_sndtimeo;
 //     unsigned int so_rcvtimeo;
 //     unsigned int tcp_user_timeout;
+//     unsigned int list_limit;
 // };
 
 int rawstor_opts_initialize(const struct RawstorOpts* opts);
@@ -29,6 +30,8 @@ unsigned int rawstor_opts_so_sndtimeo(void);
 unsigned int rawstor_opts_so_rcvtimeo(void);
 
 unsigned int rawstor_opts_tcp_user_timeout(void);
+
+unsigned int rawstor_opts_list_limit(void);
 
 #ifdef __cplusplus
 }

--- a/src/ost_session.cpp
+++ b/src/ost_session.cpp
@@ -542,6 +542,125 @@ public:
     }
 };
 
+template <typename T = char>
+std::vector<T> basic_request(
+    int fd, uint16_t cid, RawstorOSTCommandType cmd, const RawstdUUID& id,
+    uint64_t val
+) {
+    rawstd::TraceEvent trace_event =
+        RAWSTD_TRACE_EVENT('s', "basic cmd %d\n", cmd);
+
+    bool completed = false;
+    RawstorOSTFrameResponse response;
+    std::unique_ptr<rawio::Queue> queue = rawio::Queue::create(2);
+
+    RawstorOSTFrameBasic request = {
+        .head =
+            {
+                .magic = RAWSTOR_MAGIC,
+                .cmd = cmd,
+                .cid = cid,
+            },
+        .body = {
+            .obj_id = {},
+            .offset = 0,
+            .val = val,
+        },
+    };
+    memcpy(request.body.obj_id, id.bytes, sizeof(request.body.obj_id));
+    queue->write(
+        fd, &request, sizeof(request),
+        [fd, trace_event](size_t result, int error) {
+            RAWSTD_TRACE_EVENT_MESSAGE(
+                trace_event, "%zu of %zu, error = %d\n", result,
+                sizeof(RawstorOSTFrameBasic), error
+            );
+
+            if (!error) {
+                error =
+                    validate_result(fd, sizeof(RawstorOSTFrameBasic), result);
+            }
+
+            if (error) {
+                RAWSTD_THROW_SYSTEM_ERROR(error);
+            }
+        }
+    );
+
+    std::vector<T> ret;
+
+    queue->read(
+        fd, &response, sizeof(response),
+        [&queue, fd, cmd, &response, &completed, trace_event,
+         &ret](size_t result, int error) {
+            RAWSTD_TRACE_EVENT_MESSAGE(
+                trace_event, "%zu of %zu, error = %d\n", result,
+                sizeof(response), error
+            );
+
+            if (!error) {
+                error = validate_result(fd, sizeof(response), result);
+            }
+
+            if (!error) {
+                error = validate_response(fd, &response);
+            }
+
+            if (!error) {
+                error = validate_cmd(fd, response.head.cmd, cmd);
+            }
+
+            if (error) {
+                completed = true;
+                RAWSTD_THROW_SYSTEM_ERROR(error);
+            }
+
+            if (response.body.res > 0) {
+                queue->recv_multishot(
+                    fd, 1u << 17, 64 * 4, response.body.res, 0,
+                    [fd, &completed, &response, trace_event, &ret](
+                        const iovec* iov, unsigned int niov, size_t result,
+                        int error
+                    ) -> size_t {
+                        completed = true;
+
+                        RAWSTD_TRACE_EVENT_MESSAGE(
+                            trace_event, "%zu of %zu, error = %d\n", result,
+                            response.body.res, error
+                        );
+
+                        if (!error) {
+                            error =
+                                validate_result(fd, response.body.res, result);
+                        }
+
+                        if (error) {
+                            RAWSTD_THROW_SYSTEM_ERROR(error);
+                        }
+
+                        if (result % sizeof(T) != 0) {
+                            RAWSTD_THROW_SYSTEM_ERROR(EPROTO);
+                        }
+
+                        ret.resize(result / sizeof(T));
+                        rawstd_iovec_to_buf(iov, niov, 0, ret.data(), result);
+
+                        return 0;
+                    }
+                );
+            } else {
+                completed = true;
+            }
+        }
+    );
+
+    while (!completed) {
+        queue->wait_timeout(rawstor_opts_tcp_user_timeout());
+    }
+
+    return ret;
+}
+
 } // namespace
 
 namespace rawstor {
@@ -775,89 +894,33 @@ int Session::_connect() {
     return fd;
 }
 
-void Session::_basic(
-    RawstorOSTCommandType cmd, const RawstdUUID& id, uint64_t val
-) {
-    rawstd::TraceEvent trace_event =
-        RAWSTD_TRACE_EVENT('s', "basic cmd %d\n", cmd);
-
-    bool completed = false;
-    RawstorOSTFrameResponse response;
-    std::unique_ptr<rawio::Queue> queue = rawio::Queue::create(2);
-
-    RawstorOSTFrameBasic request = {
-        .head =
-            {
-                .magic = RAWSTOR_MAGIC,
-                .cmd = cmd,
-                .cid = _cid_counter++,
-            },
-        .body = {
-            .obj_id = {},
-            .offset = 0,
-            .val = val,
-        },
-    };
-    memcpy(request.body.obj_id, id.bytes, sizeof(request.body.obj_id));
-    queue->write(
-        fd(), &request, sizeof(request),
-        [fd = fd(), trace_event](size_t result, int error) {
-            RAWSTD_TRACE_EVENT_MESSAGE(
-                trace_event, "%zu of %zu, error = %d\n", result,
-                sizeof(RawstorOSTFrameBasic), error
-            );
-
-            if (!error) {
-                error =
-                    validate_result(fd, sizeof(RawstorOSTFrameBasic), result);
-            }
-
-            if (error) {
-                RAWSTD_THROW_SYSTEM_ERROR(error);
-            }
-        }
+void Session::_set_object(Object* object) {
+    basic_request(
+        fd(), _cid_counter++, RAWSTOR_CMD_SET_OBJECT, object->id(), 0
     );
-
-    queue->read(
-        fd(), &response, sizeof(response),
-        [fd = fd(), cmd, &response, &completed,
-         trace_event](size_t result, int error) {
-            RAWSTD_TRACE_EVENT_MESSAGE(trace_event, "error = %d\n", error);
-
-            completed = true;
-
-            RAWSTD_TRACE_EVENT_MESSAGE(
-                trace_event, "%zu of %zu, error = %d\n", result,
-                sizeof(RawstorOSTFrameResponse), error
-            );
-
-            if (!error) {
-                error = validate_result(
-                    fd, sizeof(RawstorOSTFrameResponse), result
-                );
-            }
-
-            if (!error) {
-                error = validate_response(fd, &response);
-            }
-
-            if (!error) {
-                error = validate_cmd(fd, response.head.cmd, cmd);
-            }
-
-            if (error) {
-                RAWSTD_THROW_SYSTEM_ERROR(error);
-            }
-        }
-    );
-
-    while (!completed) {
-        queue->wait_timeout(5000);
-    }
 }
 
-void Session::_set_object(Object* object) {
-    _basic(RAWSTOR_CMD_SET_OBJECT, object->id(), 0);
+void Session::list(
+    unsigned int limit, const RawstdUUID& token,
+    std::function<void(std::vector<RawstdUUID>&&, const RawstdUUID&, int)>&& cb
+) {
+    int error = 0;
+    std::vector<RawstdUUID> uuids;
+    try {
+        uuids = basic_request<RawstdUUID>(
+            fd(), _cid_counter++, RAWSTOR_CMD_LIST, token, limit
+        );
+    } catch (const std::system_error& e) {
+        error = e.code().value();
+    } catch (...) {
+        error = EIO;
+    }
+    RawstdUUID next_token = {};
+    if (!uuids.empty()) {
+        next_token = uuids.back();
+        uuids.resize(uuids.size() - 1);
+    }
+    cb(std::move(uuids), next_token, error);
 }
 
 void Session::create(
@@ -866,7 +929,9 @@ void Session::create(
 ) {
     int error = 0;
     try {
-        _basic(RAWSTOR_CMD_ALLOCATE, id, spec.size);
+        basic_request(
+            fd(), _cid_counter++, RAWSTOR_CMD_ALLOCATE, id, spec.size
+        );
     } catch (const std::system_error& e) {
         error = e.code().value();
     } catch (...) {
@@ -878,7 +943,7 @@ void Session::create(
 void Session::remove(const RawstdUUID& id, std::function<void(int)>&& cb) {
     int error = 0;
     try {
-        _basic(RAWSTOR_CMD_RELEASE, id, 0);
+        basic_request(fd(), _cid_counter++, RAWSTOR_CMD_RELEASE, id, 0);
     } catch (const std::system_error& e) {
         error = e.code().value();
     } catch (...) {

--- a/src/ost_session.hpp
+++ b/src/ost_session.hpp
@@ -13,9 +13,11 @@
 #include <rawstor/rawstor.h>
 
 #include <functional>
+#include <list>
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include <cstddef>
 
@@ -31,12 +33,17 @@ private:
     std::shared_ptr<Context> _context;
 
     int _connect();
-    void _basic(RawstorOSTCommandType cmd, const RawstdUUID& id, uint64_t val);
     void _set_object(Object* object);
 
 public:
     Session(rawio::Queue& queue, const rawstd::URI& location);
     ~Session();
+
+    void list(
+        unsigned int limit, const RawstdUUID& token,
+        std::function<void(std::vector<RawstdUUID>&&, const RawstdUUID&, int)>&&
+            cb
+    ) override;
 
     void create(
         const RawstdUUID& id, const RawstorObjectSpec& sp,

--- a/src/rawstor.cpp
+++ b/src/rawstor.cpp
@@ -22,6 +22,17 @@
 #include <cstdlib>
 #include <cstring>
 
+int rawstor_pagination_token_empty(
+    const RawstorPaginationToken* token
+) noexcept {
+    for (unsigned int i = 0; i < sizeof(token->bytes); ++i) {
+        if (token->bytes[i] != 0) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
 int rawstor_initialize(const RawstorOpts* opts) noexcept {
     try {
         int res = 0;

--- a/src/session.hpp
+++ b/src/session.hpp
@@ -6,10 +6,12 @@
 #include <rawio/queue.hpp>
 
 #include <rawstd/uri.hpp>
+#include <rawstd/uuid.h>
 
 #include <rawstor/object.h>
 
 #include <functional>
+#include <list>
 #include <memory>
 #include <string>
 
@@ -43,6 +45,12 @@ public:
     inline const rawstd::URI& location() const noexcept { return _location; }
 
     inline int fd() const noexcept { return _fd; }
+
+    virtual void list(
+        unsigned int limit, const RawstdUUID& token,
+        std::function<void(std::vector<RawstdUUID>&&, const RawstdUUID&, int)>&&
+            cb
+    ) = 0;
 
     virtual void create(
         const RawstdUUID& id, const RawstorObjectSpec& sp,

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -19,7 +19,9 @@ test_all_SOURCES = main.cpp \
                    session.cpp \
                    session.hpp \
                    test_io.cpp \
-                   test_lifecycle.cpp
+                   test_lifecycle.cpp \
+                   test_list.cpp \
+                   test_pagination_token.cpp
 test_all_LDADD = $(top_builddir)/src/librawstor.la
 
 

--- a/tests/test_lifecycle.cpp
+++ b/tests/test_lifecycle.cpp
@@ -4,6 +4,7 @@
 #include <rawstd/gpp.hpp>
 #include <rawstd/uri.hpp>
 
+#include <rawstor/list.h>
 #include <rawstor/object.h>
 #include <rawstor/protocol.h>
 
@@ -14,12 +15,13 @@
 
 namespace {
 
-TEST(FileLifecycleTest, create_spec_remove) {
+TEST(FileLifecycleTest, create_spec_list_remove) {
     std::filesystem::path location_path =
         std::filesystem::temp_directory_path() / "test_objects";
     std::ostringstream oss;
     oss << "file://" << location_path.string();
     rawstd::URI location_uri(oss.str());
+    std::string location = location_uri.str();
     std::string uuid = "00000000-0000-7000-8000-000000000001";
     std::string target = rawstd::URI(location_uri, uuid).str();
 
@@ -32,11 +34,31 @@ TEST(FileLifecycleTest, create_spec_remove) {
     EXPECT_EQ(res, 0);
     EXPECT_EQ(read_spec.size, (size_t)(1ull << 20));
 
+    RawstorStringList* targets;
+    RawstorPaginationToken token = {};
+    res = rawstor_object_list(location.c_str(), 0, &targets, &token);
+    EXPECT_EQ(res, 0);
+    if (res == 0) {
+        EXPECT_EQ(rawstor_string_list_size(targets), static_cast<size_t>(1));
+
+        const char** it = rawstor_string_list_iter(targets);
+        EXPECT_NE(it, nullptr);
+        if (it != nullptr) {
+            EXPECT_EQ(target, *it);
+
+            it = rawstor_string_list_next(it);
+            EXPECT_EQ(it, nullptr);
+        }
+
+        rawstor_string_list_delete(targets);
+    }
+    EXPECT_EQ(rawstor_pagination_token_empty(&token), 1);
+
     res = rawstor_object_remove(target.c_str());
     EXPECT_EQ(res, 0);
 }
 
-TEST(FileLifecycleTest, create_at_default_spec_remove) {
+TEST(FileLifecycleTest, create_at_default_spec_list_remove) {
     std::filesystem::path location_path =
         std::filesystem::temp_directory_path() / "test_objects";
     std::ostringstream oss;
@@ -58,11 +80,31 @@ TEST(FileLifecycleTest, create_at_default_spec_remove) {
     EXPECT_EQ(res, 0);
     EXPECT_EQ(read_spec.size, (size_t)(1ull << 20));
 
+    RawstorStringList* targets;
+    RawstorPaginationToken token = {};
+    res = rawstor_object_list(location.c_str(), 0, &targets, &token);
+    EXPECT_EQ(res, 0);
+    if (res == 0) {
+        EXPECT_EQ(rawstor_string_list_size(targets), static_cast<size_t>(1));
+
+        const char** it = rawstor_string_list_iter(targets);
+        EXPECT_NE(it, nullptr);
+        if (it != nullptr) {
+            EXPECT_EQ(target, *it);
+
+            it = rawstor_string_list_next(it);
+            EXPECT_EQ(it, nullptr);
+        }
+
+        rawstor_string_list_delete(targets);
+    }
+    EXPECT_EQ(rawstor_pagination_token_empty(&token), 1);
+
     res = rawstor_object_remove(target.c_str());
     EXPECT_EQ(res, 0);
 }
 
-TEST(FileLifecycleTest, create_at_spec_remove) {
+TEST(FileLifecycleTest, create_at_spec_list_remove) {
     std::filesystem::path location_path =
         std::filesystem::temp_directory_path() / "test_objects";
     std::ostringstream oss;
@@ -86,11 +128,31 @@ TEST(FileLifecycleTest, create_at_spec_remove) {
     EXPECT_EQ(res, 0);
     EXPECT_EQ(read_spec.size, (size_t)(1ull << 20));
 
+    RawstorStringList* targets;
+    RawstorPaginationToken token = {};
+    res = rawstor_object_list(location.c_str(), 0, &targets, &token);
+    EXPECT_EQ(res, 0);
+    if (res == 0) {
+        EXPECT_EQ(rawstor_string_list_size(targets), static_cast<size_t>(1));
+
+        const char** it = rawstor_string_list_iter(targets);
+        EXPECT_NE(it, nullptr);
+        if (it != nullptr) {
+            EXPECT_EQ(target, *it);
+
+            it = rawstor_string_list_next(it);
+            EXPECT_EQ(it, nullptr);
+        }
+
+        rawstor_string_list_delete(targets);
+    }
+    EXPECT_EQ(rawstor_pagination_token_empty(&token), 1);
+
     res = rawstor_object_remove(target.c_str());
     EXPECT_EQ(res, 0);
 }
 
-TEST(OstLifecycleTest, create_spec_remove) {
+TEST(OstLifecycleTest, create_spec_list_remove) {
     rawstor::tests::Server server(8753, 256);
 
     rawstd::URI location_uri("ost://127.0.0.1:8753");

--- a/tests/test_list.cpp
+++ b/tests/test_list.cpp
@@ -1,0 +1,201 @@
+#include "server.hpp"
+#include "session.hpp"
+
+#include "opts.h"
+
+#include <rawstd/gpp.hpp>
+#include <rawstd/uri.hpp>
+
+#include <rawstor/list.h>
+#include <rawstor/object.h>
+#include <rawstor/protocol.h>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstring>
+#include <filesystem>
+#include <string>
+
+namespace {
+
+rawstd::URI get_location_uri(const std::string& name) {
+    std::filesystem::path path = std::filesystem::temp_directory_path() / name;
+    if (!std::filesystem::exists(path)) {
+        std::filesystem::create_directories(path);
+    }
+
+    std::ostringstream oss;
+    oss << "file://" << path.string();
+    return rawstd::URI(oss.str());
+}
+
+TEST(ListTest, empty) {
+    rawstd::URI location = get_location_uri("test_objects");
+
+    RawstorStringList* targets;
+    RawstorPaginationToken token = {};
+    int res = rawstor_object_list(location.str().c_str(), 0, &targets, &token);
+    EXPECT_EQ(res, 0);
+    if (res == 0) {
+        EXPECT_EQ(rawstor_string_list_size(targets), static_cast<size_t>(0));
+
+        const char** it = rawstor_string_list_iter(targets);
+        EXPECT_EQ(it, nullptr);
+
+        rawstor_string_list_delete(targets);
+    }
+    EXPECT_TRUE(rawstor_pagination_token_empty(&token));
+}
+
+TEST(ListTest, merge) {
+    rawstd::URI location1 = get_location_uri("test_objects1");
+    rawstd::URI location2 = get_location_uri("test_objects2");
+
+    rawstd::URI target11 =
+        rawstd::URI(location1, "00000000-0000-7000-8000-000000000001");
+    rawstd::URI target12 =
+        rawstd::URI(location1, "00000000-0000-7000-8000-000000000002");
+    rawstd::URI target22 =
+        rawstd::URI(location2, "00000000-0000-7000-8000-000000000002");
+    rawstd::URI target23 =
+        rawstd::URI(location2, "00000000-0000-7000-8000-000000000003");
+
+    int res;
+    RawstorObjectSpec spec{.size = 1ull << 20};
+    res = rawstor_object_create(target11.str().c_str(), &spec);
+    ASSERT_EQ(res, 0);
+    res = rawstor_object_create(target12.str().c_str(), &spec);
+    ASSERT_EQ(res, 0);
+    res = rawstor_object_create(target22.str().c_str(), &spec);
+    ASSERT_EQ(res, 0);
+    res = rawstor_object_create(target23.str().c_str(), &spec);
+    ASSERT_EQ(res, 0);
+
+    std::string locations = rawstd::URI::uris({location1, location2});
+
+    RawstorStringList* targets;
+    RawstorPaginationToken token = {};
+    res = rawstor_object_list(locations.c_str(), 0, &targets, &token);
+    EXPECT_EQ(res, 0);
+    if (res == 0) {
+        EXPECT_EQ(rawstor_string_list_size(targets), static_cast<size_t>(3));
+
+        if (rawstor_string_list_size(targets) == 3) {
+            const char** it = rawstor_string_list_iter(targets);
+            EXPECT_NE(it, nullptr);
+            EXPECT_EQ(rawstd::URI::uris({target11}), *it);
+
+            it = rawstor_string_list_next(it);
+            EXPECT_NE(it, nullptr);
+            EXPECT_EQ(rawstd::URI::uris({target12, target22}), *it);
+
+            it = rawstor_string_list_next(it);
+            EXPECT_NE(it, nullptr);
+            EXPECT_EQ(rawstd::URI::uris({target23}), *it);
+
+            it = rawstor_string_list_next(it);
+            EXPECT_EQ(it, nullptr);
+        }
+
+        rawstor_string_list_delete(targets);
+    }
+    EXPECT_TRUE(rawstor_pagination_token_empty(&token));
+
+    res = rawstor_object_remove(target11.str().c_str());
+    EXPECT_EQ(res, 0);
+    res = rawstor_object_remove(target12.str().c_str());
+    EXPECT_EQ(res, 0);
+    res = rawstor_object_remove(target22.str().c_str());
+    EXPECT_EQ(res, 0);
+    res = rawstor_object_remove(target23.str().c_str());
+    EXPECT_EQ(res, 0);
+}
+
+TEST(ListTest, pagination) {
+    rawstd::URI location = get_location_uri("test_objects");
+
+    {
+        RawstorStringList* page;
+        RawstorPaginationToken token = {};
+        int res = rawstor_object_list(location.str().c_str(), 0, &page, &token);
+        EXPECT_EQ(res, 0);
+        if (res == 0) {
+            EXPECT_EQ(rawstor_string_list_size(page), static_cast<size_t>(0));
+            EXPECT_TRUE(rawstor_pagination_token_empty(&token));
+
+            rawstor_string_list_delete(page);
+        }
+    }
+
+    unsigned int total = rawstor_opts_list_limit() + 1;
+
+    std::vector<std::string> targets;
+    targets.reserve(total);
+    for (unsigned int i = 0; i < total; ++i) {
+        RawstorObjectSpec spec{.size = 1ull << 10};
+
+        char target[65536];
+        int res = rawstor_object_create_at(
+            location.str().c_str(), nullptr, &spec, target, sizeof(target)
+        );
+        EXPECT_GT(res, 0);
+
+        targets.push_back(target);
+    }
+    std::sort(targets.begin(), targets.end());
+
+    RawstorStringList* page;
+    RawstorPaginationToken token = {};
+    int res = rawstor_object_list(location.str().c_str(), 0, &page, &token);
+    EXPECT_EQ(res, 0);
+    if (res == 0) {
+        EXPECT_EQ(
+            rawstor_string_list_size(page),
+            static_cast<size_t>(rawstor_opts_list_limit())
+        );
+
+        size_t i = 0;
+        for (const char** it = rawstor_string_list_iter(page); it != NULL;
+             it = rawstor_string_list_next(it), ++i) {
+            EXPECT_LT(i, targets.size());
+            if (i < targets.size()) {
+                EXPECT_EQ(*it, targets[i]);
+            }
+        }
+
+        rawstor_string_list_delete(page);
+
+        EXPECT_FALSE(rawstor_pagination_token_empty(&token));
+        if (!rawstor_pagination_token_empty(&token)) {
+            int res =
+                rawstor_object_list(location.str().c_str(), 0, &page, &token);
+            EXPECT_EQ(res, 0);
+            if (res == 0) {
+                EXPECT_EQ(
+                    rawstor_string_list_size(page), static_cast<size_t>(1)
+                );
+
+                const char** it = rawstor_string_list_iter(page);
+                EXPECT_NE(it, nullptr);
+                if (it != nullptr) {
+                    EXPECT_EQ(*it, targets.back());
+                }
+
+                it = rawstor_string_list_next(it);
+                EXPECT_EQ(it, nullptr);
+
+                rawstor_string_list_delete(page);
+
+                EXPECT_TRUE(rawstor_pagination_token_empty(&token));
+            }
+        }
+    }
+
+    for (const auto& target : targets) {
+        int res = rawstor_object_remove(target.c_str());
+        EXPECT_EQ(res, 0);
+    }
+}
+
+} // unnamed namespace

--- a/tests/test_pagination_token.cpp
+++ b/tests/test_pagination_token.cpp
@@ -1,0 +1,18 @@
+#include <rawstor/rawstor.h>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+TEST(PaginationTokenTest, empty) {
+    RawstorPaginationToken token = {};
+    EXPECT_TRUE(rawstor_pagination_token_empty(&token));
+
+    token.bytes[1] = 1;
+    EXPECT_FALSE(rawstor_pagination_token_empty(&token));
+
+    memset(token.bytes, 0, sizeof(token.bytes));
+    EXPECT_TRUE(rawstor_pagination_token_empty(&token));
+}
+
+} // unnamed namespace


### PR DESCRIPTION
This pull request introduces a new mechanism to list objects stored in Rawstor backends. It adds the necessary C library functions, CLI command, and Python bindings to support paginated object retrieval. The changes include robust error handling, memory management for string lists, and comprehensive unit tests to ensure stability and correctness across the different interfaces.

* **New Object Listing Functionality**: Added a new `list` command to the CLI and corresponding library support to retrieve objects from specified locations.
* **Pagination Support**: Implemented pagination for object listing using opaque tokens to handle large datasets efficiently.
* **Configuration Updates**: Introduced `RAWSTOR_OPTS_LIST_LIMIT` to control the maximum number of rows returned in list operations.
* **Python Bindings**: Exposed the new listing functionality to Python via `Object.list` with an iterator-based interface.

(cherry picked from commit d6e345f17869fb60ebaec17c00faa02f90d0041f)

Conflicts:
	ChangeLog.md