### PR TITLE
add: use 7777 as default rawstor port (#464)

### DIFF
--- a/.github/workflows/perftest.yml
+++ b/.github/workflows/perftest.yml
@@ -32,9 +32,9 @@ jobs:
           without-liburing: --without-liburing
         - location: file:///tmp/objects
           backend: file
-        - location: ost://127.0.0.1:8080
+        - location: ost://127.0.0.1:7777
           backend: ost
-        - location: ost://127.0.0.1:8080
+        - location: ost://127.0.0.1:7777
           backend: ost-legacy
 
     steps:
@@ -96,14 +96,14 @@ jobs:
       if: "${{ matrix.backend == 'ost' }}"
       run: |
         mkdir ${GITHUB_WORKSPACE}/objects
-        rawstor-ost --bind 127.0.0.1:8080 --location=file://${GITHUB_WORKSPACE}/objects &
+        rawstor-ost --bind 127.0.0.1:7777 --location=file://${GITHUB_WORKSPACE}/objects &
         sleep 10
     - name: (ost-legacy) start rawstor_ost
       if: "${{ matrix.backend == 'ost-legacy' }}"
       run: |
         mkdir ${GITHUB_WORKSPACE}/objects
         truncate -s 2G ${GITHUB_WORKSPACE}/objects/01988675-e1e5-7788-9ed4-2f2d30910d23
-        ost 8080 ${GITHUB_WORKSPACE}/objects/ &
+        ost 7777 ${GITHUB_WORKSPACE}/objects/ &
         sleep 10
     - name: create object
       if: "${{ matrix.backend != 'ost-legacy' }}"

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -94,23 +94,23 @@ jobs:
     - name: start rawstor-ost
       run: |
         mkdir /tmp/ost_objects
-        rawstor-ost --bind 127.0.0.1:8080 --location=file:///tmp/ost_objects/ &
+        rawstor-ost --bind 127.0.0.1:7777 --location=file:///tmp/ost_objects/ &
         sleep 10
     - name: create object file,ost
       run: |
         mkdir /tmp/file_objects
-        target=$(rawstor-cli create --location=file:///tmp/file_objects,ost://127.0.0.1:8080 --size=1G)
+        target=$(rawstor-cli create --location=file:///tmp/file_objects,ost://127.0.0.1:7777 --size=1G)
         echo "TARGET=${target}" >> $GITHUB_ENV
-        rawstor-cli list --location=file:///tmp/file_objects,ost://127.0.0.1:8080
+        rawstor-cli list --location=file:///tmp/file_objects,ost://127.0.0.1:7777
     - name: testio file,ost
       run: |
         rawstor-cli testio --target=${TARGET} --block-size=4K --io-depth=1 --count=10
         rawstor-cli testio --target=${TARGET} --block-size=4K --io-depth=1 --count=10 --vector-mode
     - name: create object ost,file
       run: |
-        target=$(rawstor-cli create --location=ost://127.0.0.1:8080,file:///tmp/file_objects --size=1G)
+        target=$(rawstor-cli create --location=ost://127.0.0.1:7777,file:///tmp/file_objects --size=1G)
         echo "TARGET=${target}" >> $GITHUB_ENV
-        rawstor-cli list --location=ost://127.0.0.1:8080,file:///tmp/file_objects
+        rawstor-cli list --location=ost://127.0.0.1:7777,file:///tmp/file_objects
     - name: testio ost,file
       run: |
         rawstor-cli testio --target=${TARGET} --block-size=4K --io-depth=1 --count=10

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ PREFIX=${HOME}/local
 make -j$(nproc)
 make install
 
-OST_ADDR=192.168.0.1:8080
+OST_ADDR=192.168.0.1:7777
 
 ##
 # OST Server
@@ -82,28 +82,28 @@ Default values are shown below.
 |--------|-------------|
 | `-h, --help` | Show help message and exit. |
 | `-l, --location LOCATION` | Comma‑separated list of backend locations (e.g., `file:///path`, `ost://host:port`). |
-| `-b, --bind ADDR` | Bind address in `<ip>:<port>` format (e.g., `127.0.0.1:8080`). |
+| `-b, --bind ADDR` | Bind address in `<ip>:<port>` format (e.g., `127.0.0.1:7777`). |
 
 ### Examples
 
 Serve local directory:
 ```bash
-rawstor-ost -l file:///var/rawstor/data -b 0.0.0.0:8080
+rawstor-ost -l file:///var/rawstor/data -b 0.0.0.0:7777
 ```
 
 Proxy to remote OST:
 ```bash
-rawstor-ost -l ost://192.168.1.100:8080 -b 0.0.0.0:8080
+rawstor-ost -l ost://192.168.1.100:7777 -b 0.0.0.0:7777
 ```
 
 Data locality (local cache + proxy):
 ```bash
-rawstor-ost -l file:///var/rawstor/data,ost://remote:8080 -b 0.0.0.0:8080
+rawstor-ost -l file:///var/rawstor/data,ost://remote:7777 -b 0.0.0.0:7777
 ```
 
 Mirroring between two OST backends:
 ```bash
-rawstor-ost -l ost://left:8080,ost://right:8080 -b 0.0.0.0:8080
+rawstor-ost -l ost://left:7777,ost://right:7777 -b 0.0.0.0:7777
 ```
 
 ## rawstor-vhost
@@ -112,7 +112,7 @@ rawstor-vhost is a userspace VirtIO block device backend that implements the vho
 
 ```
 PREFIX=${HOME}/local
-OST_ADDR=192.168.0.1:8080
+OST_ADDR=192.168.0.1:7777
 OBJECT_ID=...
 VHOST_RUNDIR=${PREFIX}/var/run/rawstor
 

--- a/librawstd/tests/test_uri.cpp
+++ b/librawstd/tests/test_uri.cpp
@@ -56,17 +56,17 @@ TEST(URITest, file) {
 }
 
 TEST(URITest, empty_path) {
-    rawstd::URI uri("ost://127.0.0.1:8080");
+    rawstd::URI uri("ost://127.0.0.1:7777");
 
-    EXPECT_EQ(uri.str(), "ost://127.0.0.1:8080");
+    EXPECT_EQ(uri.str(), "ost://127.0.0.1:7777");
     EXPECT_EQ(uri.scheme(), "ost");
     EXPECT_EQ(uri.userinfo(), "");
     EXPECT_EQ(uri.username(), "");
     EXPECT_EQ(uri.password(), "");
-    EXPECT_EQ(uri.authority(), "127.0.0.1:8080");
-    EXPECT_EQ(uri.host(), "127.0.0.1:8080");
+    EXPECT_EQ(uri.authority(), "127.0.0.1:7777");
+    EXPECT_EQ(uri.host(), "127.0.0.1:7777");
     EXPECT_EQ(uri.hostname(), "127.0.0.1");
-    EXPECT_EQ(uri.port(), 8080u);
+    EXPECT_EQ(uri.port(), 7777u);
     EXPECT_EQ(uri.path().str(), "");
     EXPECT_EQ(uri.path().dirname(), "/");
     EXPECT_EQ(uri.path().filename(), "");

--- a/ost/main.cpp
+++ b/ost/main.cpp
@@ -37,7 +37,7 @@ void usage() {
               << "required arguments:" << std::endl
               << "  -b, --bind ADDR       Bind address in the format "
               << "<ip>:<port> " << std::endl
-              << "                        (e.g., 127.0.0.1:8080)." << std::endl
+              << "                        (e.g., 127.0.0.1:7777)." << std::endl
               << "  -l, --location LOCATION" << std::endl
               << "                        Comma separated list of rawstor "
                  "backend locations"


### PR DESCRIPTION
This pull request standardizes the default port used by the rawstor application to 7777. This change ensures consistency across documentation, examples, and internal test cases, making it clearer for users and developers to understand and configure the application's network binding.

### Highlights

* **Default Port Update**: The default port for the rawstor application has been changed from 8080 to 7777 across various configurations and examples.
* **Documentation Alignment**: The README.md file has been updated to reflect the new default port in all relevant command examples and setup instructions.
* **Test Case Adjustment**: A URI parsing test in librawstd/tests/test_uri.cpp was modified to validate the new 7777 port.
* **Usage Message Consistency**: The usage message for the ost executable in ost/main.cpp now correctly displays 7777 as the example bind address.

(cherry picked from commit 4c0dc2a51e2f67fe6eead7bff10544809254b1b4)