### PR TITLE
add: add systemd service (#466)

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -107,7 +107,10 @@ jobs:
         cp deb/rawstor-ost/compat debian
         cp deb/rawstor-ost/changelog debian
         cp deb/rawstor-ost/format debian/source
+        cp deb/rawstor-ost/rawstor-ost.postinst debian
+        cp deb/rawstor-ost/rawstor-ost.prerm debian
         cp deb/rawstor-ost/rules debian
+        cp etc/systemd/system/rawstor-ost.service debian
         cp COPYING debian/copyright
         dpkg-buildpackage -us -uc
     - uses: actions/upload-artifact@v7
@@ -175,18 +178,19 @@ jobs:
     - name: install-librawstor
       run: sudo apt install -y ./librawstor.deb/librawstor_*.deb
     - name: test-librawstor
-      run: |
-        rawstor-cli --version
+      run: rawstor-cli --version
     - name: install-rawstor-ost
-      run: sudo apt install -y ./rawstor-ost.deb/rawstor-ost_*.deb
+      run: |
+        sudo apt install -y ./rawstor-ost.deb/rawstor-ost_*.deb
+        sudo systemctl start rawstor-ost.service
     - name: test-rawstor-ost
-      run: rawstor-ost --version
+      run: |
+        rawstor-ost --version
+        rawstor-cli list --location=ost://127.0.0.1:7777
     - name: install-python3-rawstor
-      run: |
-        sudo apt install -y ./python3-rawstor.deb/python3-rawstor_*.deb
+      run: sudo apt install -y ./python3-rawstor.deb/python3-rawstor_*.deb
     - name: test-python3-rawstor
-      run: |
-        python -c "import rawstor; print('OK')"
+      run: python -c "import rawstor; print(list(rawstor.Location('ost://127.0.0.1:7777/'))); print('OK')"
 
   rpm-librawstor:
     needs: sources

--- a/Makefile.am
+++ b/Makefile.am
@@ -28,9 +28,7 @@ ChangeLog: $(srcdir)/ChangeLog.md
 	cp $(srcdir)/ChangeLog.md ChangeLog
 
 
-EXTRA_DIST = ChangeLog.md \
-             README.md \
-             deb/librawstor/compat \
+EXTRA_DIST = deb/librawstor/compat \
              deb/librawstor/format \
              deb/librawstor/rules \
              deb/python3-rawstor/compat \
@@ -38,7 +36,12 @@ EXTRA_DIST = ChangeLog.md \
              deb/python3-rawstor/rules \
              deb/rawstor-ost/compat \
              deb/rawstor-ost/format \
-             deb/rawstor-ost/rules
+             deb/rawstor-ost/rawstor-ost.postinst \
+             deb/rawstor-ost/rawstor-ost.prerm \
+             deb/rawstor-ost/rules \
+             etc/systemd/system/rawstor-ost.service \
+             ChangeLog.md \
+             README.md
 
 
 CLEANFILES = ChangeLog \

--- a/deb/rawstor-ost/control.in
+++ b/deb/rawstor-ost/control.in
@@ -9,6 +9,7 @@ Package: rawstor-ost
 Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
+         adduser,
          librawstor (>= @PACKAGE_VERSION_MAJOR@.@PACKAGE_VERSION_MINOR@.0),
          librawstor (<< @PACKAGE_VERSION_MAJOR@.@PACKAGE_VERSION_MINOR_NEXT@.0)
 Description: Rawstor OST backend

--- a/deb/rawstor-ost/rawstor-ost.postinst
+++ b/deb/rawstor-ost/rawstor-ost.postinst
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+    configure)
+        if ! getent group rawstor >/dev/null; then
+            addgroup --system rawstor
+        fi
+        mkdir -p /var/lib/rawstor
+        chmod 0755 /var/lib/rawstor
+        if ! getent passwd rawstor >/dev/null; then
+            adduser --system --no-create-home --ingroup rawstor --home /var/lib/rawstor --shell /usr/sbin/nologin rawstor
+        fi
+        chown rawstor:rawstor /var/lib/rawstor
+        ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/deb/rawstor-ost/rawstor-ost.prerm
+++ b/deb/rawstor-ost/rawstor-ost.prerm
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+#DEBHELPER#
+
+exit 0

--- a/etc/systemd/system/rawstor-ost.service
+++ b/etc/systemd/system/rawstor-ost.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Rawstor OST backend
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=rawstor
+Group=rawstor
+WorkingDirectory=/var/lib/rawstor
+StateDirectory=rawstor
+Environment=BIND_ADDR=0.0.0.0:7777
+Environment=LOCATION=file:///var/lib/rawstor
+EnvironmentFile=-/etc/rawstor-ost.conf
+ExecStart=/usr/bin/rawstor-ost --bind=${BIND_ADDR} --location=${LOCATION}
+Restart=always
+RestartSec=10
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+NoNewPrivileges=true
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/rpm/librawstor.spec.in
+++ b/rpm/librawstor.spec.in
@@ -14,7 +14,7 @@ Rawstor client library
 %autosetup -n %{name}-@PACKAGE_VERSION@
 
 %build
-./configure --prefix=%{_prefix} --without-python3 --disable-ost-backend
+./configure --prefix=%{_prefix} --libdir=%{_libdir} --without-python3 --disable-ost-backend
 make %{?_smp_mflags}
 
 %install

--- a/rpm/python3-rawstor.spec.in
+++ b/rpm/python3-rawstor.spec.in
@@ -18,7 +18,7 @@ Rawstor python bindings
 %autosetup -n librawstor-@PACKAGE_VERSION@
 
 %build
-./configure --prefix=%{_prefix} --disable-ost-backend
+./configure --prefix=%{_prefix} --libdir=%{_libdir} --disable-ost-backend
 make %{?_smp_mflags}
 
 %install

--- a/rpm/rawstor-ost.spec.in
+++ b/rpm/rawstor-ost.spec.in
@@ -6,21 +6,51 @@ License: LGPL
 URL: https://github.com/rawstor/librawstor
 Source0: librawstor-@PACKAGE_VERSION@.tar.gz
 
+Requires(pre): shadow-utils
 Requires: librawstor >= @PACKAGE_VERSION_MAJOR@.@PACKAGE_VERSION_MINOR@.0, librawstor < @PACKAGE_VERSION_MAJOR@.@PACKAGE_VERSION_MINOR_NEXT@.0
+
+%{!?_unitdir: %global _unitdir /usr/lib/systemd/system}
 
 %description
 Rawstor OST backend
+
+%pre
+getent group rawstor >/dev/null || groupadd -r rawstor
+getent passwd rawstor >/dev/null || useradd -r -g rawstor -d /var/lib/rawstor -s /sbin/nologin -c "Rawstor OST daemon" rawstor
 
 %prep
 %autosetup -n librawstor-@PACKAGE_VERSION@
 
 %build
-./configure --prefix=%{_prefix} --without-python3
+./configure --prefix=%{_prefix} --libdir=%{_libdir} --without-python3
 make %{?_smp_mflags}
 
 %install
 rm -rf %{buildroot}
 make -C ost install DESTDIR=%{buildroot}
+mkdir -p %{buildroot}%{_unitdir}
+install -m 644 etc/systemd/system/rawstor-ost.service %{buildroot}%{_unitdir}/rawstor-ost.service
+mkdir -p %{buildroot}/var/lib/rawstor
+
+%post
+chown rawstor:rawstor /var/lib/rawstor
+if [ $1 -eq 1 ]; then
+    systemctl enable rawstor-ost.service >/dev/null 2>&1 || :
+    systemctl start rawstor-ost.service >/dev/null 2>&1 || :
+fi
+
+%preun
+if [ $1 -eq 0 ]; then
+    systemctl stop rawstor-ost.service >/dev/null 2>&1 || :
+    systemctl disable rawstor-ost.service >/dev/null 2>&1 || :
+fi
+
+%postun
+if [ $1 -ge 1 ]; then
+    systemctl try-restart rawstor-ost.service >/dev/null 2>&1 || :
+fi
 
 %files
 %{_bindir}/*
+%{_unitdir}/rawstor-ost.service
+%dir %attr(0755, rawstor, rawstor) /var/lib/rawstor

--- a/src/rawstor.pc.in
+++ b/src/rawstor.pc.in
@@ -6,6 +6,6 @@ includedir=@includedir@
 Name: rawstor
 Description: Rawstor client library
 Requires: @maybe_liburing@ @maybe_libxxhash@
-Version: @PACKAGE_VERSION@
+Version: @PACKAGE_VERSION_SHORT@
 Libs: -L${libdir} -lrawstor -lstdc++ @maybe_asan@
 Cflags: -I${includedir}


### PR DESCRIPTION
This pull request introduces support for running the rawstor-ost backend as a systemd service. It includes the necessary service definition, Debian maintainer scripts for automated user and directory management, and updates to the RPM packaging process to ensure proper service lifecycle handling and directory permissions.

### Highlights

* **Systemd Service Integration**: Added a new systemd service unit file for the rawstor-ost backend to enable service management.
* **Package Maintainer Scripts**: Introduced Debian post-installation and pre-removal scripts to handle user/group creation and service lifecycle management.
* **Build System Updates**: Updated Makefile.am to include new maintainer scripts and the systemd service file in the distribution tarball.
* **RPM Packaging Improvements**: Enhanced the RPM spec file to automate user creation and integrate systemd service lifecycle hooks.

(cherry picked from commit 8469d12265a86f15815d6e94c90385d249d947ee)