### PR TITLE
fix: forward server error to the client (#472)

### DIFF
--- a/src/ost_session.cpp
+++ b/src/ost_session.cpp
@@ -70,7 +70,7 @@ int validate_response(
         rawstd_error(
             "fd %d: Server error: %s\n", fd, strerror(-response->body.res)
         );
-        return EPROTO;
+        return -response->body.res;
     }
 
     return 0;


### PR DESCRIPTION
This pull request updates the error handling mechanism to ensure that specific server-side errors are accurately forwarded to the client. By returning the actual error code rather than a static protocol error, the system provides more granular feedback for debugging and operational monitoring.

### Highlights

* **Error Propagation**: Modified the validate_response function to return the actual server error code instead of a generic EPROTO error, improving error visibility for the client.

(cherry picked from commit 2b62003bc25042dcfd5b3434ce3efa41f59d391d)